### PR TITLE
Add BrowserStack integration as alternative to URL-based Selenium connection

### DIFF
--- a/LookseeCore/looksee-browser/src/main/java/com/looksee/browsing/BrowserFactory.java
+++ b/LookseeCore/looksee-browser/src/main/java/com/looksee/browsing/BrowserFactory.java
@@ -1,5 +1,6 @@
 package com.looksee.browsing;
 
+import com.looksee.config.BrowserStackProperties;
 import com.looksee.models.Browser;
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -7,6 +8,7 @@ import org.openqa.selenium.ImmutableCapabilities;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebDriverException;
 import org.openqa.selenium.chrome.ChromeOptions;
+import org.openqa.selenium.remote.DesiredCapabilities;
 import org.openqa.selenium.remote.RemoteWebDriver;
 import org.openqa.selenium.remote.UnreachableBrowserException;
 import org.slf4j.Logger;
@@ -116,5 +118,89 @@ public final class BrowserFactory {
 		driver.manage().window().maximize();
 
 		return driver;
+	}
+
+	/**
+	 * Creates a fully configured Browser instance using BrowserStack.
+	 *
+	 * @param browserType the browser type ("chrome", "firefox")
+	 * @param hubUrl the BrowserStack hub URL
+	 * @param properties the BrowserStack configuration properties
+	 * @return the created Browser
+	 * @throws MalformedURLException if the URL is malformed
+	 *
+	 * precondition: browserType != null
+	 * precondition: hubUrl != null
+	 * precondition: properties != null
+	 */
+	public static Browser createBrowserStackBrowser(String browserType, URL hubUrl,
+			BrowserStackProperties properties) throws MalformedURLException {
+		assert browserType != null;
+		assert hubUrl != null;
+		assert properties != null;
+
+		WebDriver driver = createBrowserStackDriver(browserType, hubUrl, properties);
+		return new Browser(driver, browserType);
+	}
+
+	/**
+	 * Creates a RemoteWebDriver configured for BrowserStack.
+	 * Credentials are passed via capabilities rather than embedded in the URL.
+	 * Headless mode is omitted since BrowserStack manages the display environment.
+	 */
+	private static WebDriver createBrowserStackDriver(String browserType, URL hubUrl,
+			BrowserStackProperties properties) {
+		DesiredCapabilities caps = new DesiredCapabilities();
+
+		// BrowserStack credentials
+		caps.setCapability("browserstack.user", properties.getUsername());
+		caps.setCapability("browserstack.key", properties.getAccessKey());
+
+		// BrowserStack settings
+		caps.setCapability("browserstack.debug", String.valueOf(properties.isDebug()));
+		caps.setCapability("browserstack.local", String.valueOf(properties.isLocal()));
+
+		// Optional capabilities
+		if (properties.getOs() != null) {
+			caps.setCapability("os", properties.getOs());
+		}
+		if (properties.getOsVersion() != null) {
+			caps.setCapability("os_version", properties.getOsVersion());
+		}
+		if (properties.getBrowserVersion() != null) {
+			caps.setCapability("browser_version", properties.getBrowserVersion());
+		}
+		if (properties.getProject() != null) {
+			caps.setCapability("project", properties.getProject());
+		}
+		if (properties.getBuild() != null) {
+			caps.setCapability("build", properties.getBuild());
+		}
+		if (properties.getName() != null) {
+			caps.setCapability("name", properties.getName());
+		}
+
+		// Browser-specific configuration
+		String browser = properties.getBrowser() != null ? properties.getBrowser() : browserType;
+		caps.setCapability("browser", capitalize(browser));
+
+		if ("chrome".equalsIgnoreCase(browserType)) {
+			ChromeOptions chromeOptions = new ChromeOptions();
+			chromeOptions.addArguments("user-agent=LookseeBot");
+			chromeOptions.addArguments("window-size=1920,1080");
+			chromeOptions.addArguments("--remote-allow-origins=*");
+			// Headless mode is omitted — BrowserStack manages the display environment
+			caps.setCapability(ChromeOptions.CAPABILITY, chromeOptions);
+		}
+
+		log.debug("Creating BrowserStack RemoteWebDriver for browser: {}", browser);
+		return new RemoteWebDriver(hubUrl, caps);
+	}
+
+	private static String capitalize(String str) {
+		if (str == null || str.isEmpty()) {
+			return str;
+		}
+		return str.substring(0, 1).toUpperCase() + str.substring(1).toLowerCase();
 	}
 }

--- a/LookseeCore/looksee-browser/src/main/java/com/looksee/browsing/MobileFactory.java
+++ b/LookseeCore/looksee-browser/src/main/java/com/looksee/browsing/MobileFactory.java
@@ -1,5 +1,6 @@
 package com.looksee.browsing;
 
+import com.looksee.config.BrowserStackProperties;
 import com.looksee.models.MobileDevice;
 import io.appium.java_client.android.AndroidDriver;
 import io.appium.java_client.ios.IOSDriver;
@@ -7,6 +8,7 @@ import java.net.URL;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebDriverException;
 import org.openqa.selenium.remote.DesiredCapabilities;
+import org.openqa.selenium.remote.RemoteWebDriver;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -112,5 +114,84 @@ public final class MobileFactory {
 
 		log.debug("Requesting iOS driver from Appium server");
 		return new IOSDriver(appiumUrl, caps);
+	}
+
+	/**
+	 * Creates a fully configured MobileDevice instance using BrowserStack.
+	 * BrowserStack runs Appium tests on real devices in the cloud.
+	 *
+	 * @param platformType the mobile platform type ("android", "ios")
+	 * @param hubUrl the BrowserStack hub URL
+	 * @param properties the BrowserStack configuration properties
+	 * @return the created MobileDevice
+	 *
+	 * precondition: platformType != null
+	 * precondition: hubUrl != null
+	 * precondition: properties != null
+	 */
+	public static MobileDevice createBrowserStackMobileDevice(String platformType, URL hubUrl,
+			BrowserStackProperties properties) {
+		assert platformType != null;
+		assert hubUrl != null;
+		assert properties != null;
+
+		WebDriver driver = createBrowserStackMobileDriver(platformType, hubUrl, properties);
+		return new MobileDevice(driver, platformType);
+	}
+
+	/**
+	 * Creates a RemoteWebDriver configured for BrowserStack mobile testing.
+	 * Uses RemoteWebDriver (not AndroidDriver/IOSDriver) since BrowserStack
+	 * handles the Appium server-side; the client just needs to send capabilities.
+	 */
+	private static WebDriver createBrowserStackMobileDriver(String platformType, URL hubUrl,
+			BrowserStackProperties properties) {
+		DesiredCapabilities caps = new DesiredCapabilities();
+
+		// BrowserStack credentials
+		caps.setCapability("browserstack.user", properties.getUsername());
+		caps.setCapability("browserstack.key", properties.getAccessKey());
+
+		// BrowserStack settings
+		caps.setCapability("browserstack.debug", String.valueOf(properties.isDebug()));
+		caps.setCapability("browserstack.local", String.valueOf(properties.isLocal()));
+		caps.setCapability("realMobile", String.valueOf(properties.isRealMobile()));
+
+		// Platform-specific capabilities
+		switch (platformType.toLowerCase()) {
+			case "android":
+				caps.setCapability("platformName", "Android");
+				caps.setCapability("browserName", "Chrome");
+				caps.setCapability("device", properties.getDeviceName() != null
+						? properties.getDeviceName() : "Samsung Galaxy S23");
+				break;
+			case "ios":
+				caps.setCapability("platformName", "iOS");
+				caps.setCapability("browserName", "Safari");
+				caps.setCapability("device", properties.getDeviceName() != null
+						? properties.getDeviceName() : "iPhone 15");
+				break;
+			default:
+				throw new WebDriverException("Unsupported mobile platform type: " + platformType);
+		}
+
+		// OS version if specified
+		if (properties.getOsVersion() != null) {
+			caps.setCapability("os_version", properties.getOsVersion());
+		}
+
+		// Optional capabilities
+		if (properties.getProject() != null) {
+			caps.setCapability("project", properties.getProject());
+		}
+		if (properties.getBuild() != null) {
+			caps.setCapability("build", properties.getBuild());
+		}
+		if (properties.getName() != null) {
+			caps.setCapability("name", properties.getName());
+		}
+
+		log.debug("Creating BrowserStack mobile RemoteWebDriver for platform: {}", platformType);
+		return new RemoteWebDriver(hubUrl, caps);
 	}
 }

--- a/LookseeCore/looksee-browser/src/main/java/com/looksee/browsing/helpers/BrowserConnectionHelper.java
+++ b/LookseeCore/looksee-browser/src/main/java/com/looksee/browsing/helpers/BrowserConnectionHelper.java
@@ -2,6 +2,7 @@ package com.looksee.browsing.helpers;
 
 import com.looksee.browsing.BrowserFactory;
 import com.looksee.browsing.MobileFactory;
+import com.looksee.config.BrowserStackProperties;
 import com.looksee.models.Browser;
 import com.looksee.models.MobileDevice;
 import com.looksee.browsing.enums.BrowserEnvironment;
@@ -38,7 +39,22 @@ public class BrowserConnectionHelper {
 	private static int APPIUM_SERVER_IDX = 0;
 
 	private static String[] APPIUM_URLS;
-	
+
+	/**
+	 * Whether BrowserStack is enabled as the connection provider
+	 */
+	private static boolean browserStackEnabled = false;
+
+	/**
+	 * The BrowserStack hub URL
+	 */
+	private static String browserStackHubUrl = null;
+
+	/**
+	 * The BrowserStack configuration properties
+	 */
+	private static BrowserStackProperties browserStackProperties = null;
+
 	/**
 	 * Gets the selenium hub URLs, either from environment variable SELENIUM_URLS or fallback to hardcoded list
 	 * @param urls the selenium hub URLs
@@ -62,6 +78,36 @@ public class BrowserConnectionHelper {
 	}
 
 	/**
+	 * Configures BrowserStack as the connection provider.
+	 * When set, {@link #getConnection} will use BrowserStack instead of the
+	 * default Selenium URL-based round-robin.
+	 *
+	 * @param hubUrl the BrowserStack hub URL
+	 * @param properties the BrowserStack configuration properties
+	 *
+	 * precondition: hubUrl != null
+	 * precondition: properties != null
+	 */
+	public static void setBrowserStackConfig(String hubUrl, BrowserStackProperties properties) {
+		assert hubUrl != null;
+		assert properties != null;
+
+		browserStackHubUrl = hubUrl;
+		browserStackProperties = properties;
+		browserStackEnabled = true;
+	}
+
+	/**
+	 * Clears the BrowserStack configuration, reverting to the default
+	 * Selenium URL-based connection.
+	 */
+	public static void clearBrowserStackConfig() {
+		browserStackEnabled = false;
+		browserStackHubUrl = null;
+		browserStackProperties = null;
+	}
+
+	/**
 	 * Creates a {@link Browser} connection
 	 *
 	 * @param browser the browser to connect to
@@ -80,6 +126,11 @@ public class BrowserConnectionHelper {
     {
 		assert browser != null;
 		assert environment != null;
+
+		if (browserStackEnabled) {
+			URL server_url = new URL(browserStackHubUrl);
+			return BrowserFactory.createBrowserStackBrowser(browser.toString(), server_url, browserStackProperties);
+		}
 
 		URL server_url = null;
 

--- a/LookseeCore/looksee-browser/src/main/java/com/looksee/browsing/helpers/BrowserConnectionHelper.java
+++ b/LookseeCore/looksee-browser/src/main/java/com/looksee/browsing/helpers/BrowserConnectionHelper.java
@@ -167,6 +167,11 @@ public class BrowserConnectionHelper {
 		assert browser.isMobile();
 		assert environment != null;
 
+		if (browserStackEnabled) {
+			URL server_url = new URL(browserStackHubUrl);
+			return MobileFactory.createBrowserStackMobileDevice(browser.toString(), server_url, browserStackProperties);
+		}
+
 		if (APPIUM_URLS == null || APPIUM_URLS.length == 0) {
 			throw new IllegalStateException(
 				"Appium URLs not configured. Set appium.urls property.");

--- a/LookseeCore/looksee-browser/src/main/java/com/looksee/config/BrowserStackConfiguration.java
+++ b/LookseeCore/looksee-browser/src/main/java/com/looksee/config/BrowserStackConfiguration.java
@@ -18,7 +18,7 @@ import com.looksee.browsing.helpers.BrowserConnectionHelper;
  * Configuration class for BrowserStack integration.
  * Only created when browserstack.access-key property is configured.
  *
- * When active, BrowserStack is used instead of the default Selenium URL-based connection.
+ * When active, BrowserStack is used instead of the default Selenium and Appium URL-based connections.
  *
  * This configuration uses BrowserStackProperties to load values from either:
  * - application.properties: browserstack.access-key, browserstack.username, etc.
@@ -66,6 +66,8 @@ public class BrowserStackConfiguration {
         log.info("   Project: {}", browserStackProperties.getProject());
         log.info("   Build: {}", browserStackProperties.getBuild());
         log.info("   OS: {} {}", browserStackProperties.getOs(), browserStackProperties.getOsVersion());
+        log.info("   Device: {}", browserStackProperties.getDeviceName());
+        log.info("   Real Mobile: {}", browserStackProperties.isRealMobile());
         log.info("   Local: {}", browserStackProperties.isLocal());
         log.info("   Debug: {}", browserStackProperties.isDebug());
         log.info("   Connection timeout: {}ms", browserStackProperties.getConnectionTimeout());
@@ -90,13 +92,15 @@ public class BrowserStackConfiguration {
             log.info("browserstack.os-version: {}", environment.getProperty("browserstack.os-version", "<DEFAULT>"));
             log.info("browserstack.project: {}", environment.getProperty("browserstack.project", "<DEFAULT>"));
             log.info("browserstack.build: {}", environment.getProperty("browserstack.build", "<DEFAULT>"));
+            log.info("browserstack.device-name: {}", environment.getProperty("browserstack.device-name", "<DEFAULT>"));
+            log.info("browserstack.real-mobile: {}", environment.getProperty("browserstack.real-mobile", "true"));
             log.info("browserstack.local: {}", environment.getProperty("browserstack.local", "false"));
             log.info("browserstack.debug: {}", environment.getProperty("browserstack.debug", "true"));
 
             if (accessKey != null && !accessKey.trim().isEmpty()
                     && username != null && !username.trim().isEmpty()) {
                 log.info("BrowserStack configuration ENABLED");
-                log.info("   BrowserConnectionHelper will use BrowserStack instead of Selenium hubs");
+                log.info("   BrowserConnectionHelper will use BrowserStack instead of Selenium/Appium hubs");
             } else {
                 log.warn("BrowserStack partially configured - both username and access-key are required");
             }

--- a/LookseeCore/looksee-browser/src/main/java/com/looksee/config/BrowserStackConfiguration.java
+++ b/LookseeCore/looksee-browser/src/main/java/com/looksee/config/BrowserStackConfiguration.java
@@ -1,0 +1,107 @@
+package com.looksee.config;
+
+import javax.annotation.PostConstruct;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.ApplicationListener;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
+
+import com.looksee.browsing.helpers.BrowserConnectionHelper;
+
+/**
+ * Configuration class for BrowserStack integration.
+ * Only created when browserstack.access-key property is configured.
+ *
+ * When active, BrowserStack is used instead of the default Selenium URL-based connection.
+ *
+ * This configuration uses BrowserStackProperties to load values from either:
+ * - application.properties: browserstack.access-key, browserstack.username, etc.
+ * - Environment variables: BROWSERSTACK_ACCESS_KEY, BROWSERSTACK_USERNAME, etc.
+ */
+@Configuration
+@EnableConfigurationProperties({BrowserStackProperties.class})
+@ConditionalOnProperty(name = "browserstack.access-key")
+public class BrowserStackConfiguration {
+
+    private static final Logger log = LoggerFactory.getLogger(BrowserStackConfiguration.class);
+
+    private static final String BROWSERSTACK_HUB_URL = "https://hub-cloud.browserstack.com/wd/hub";
+
+    private final BrowserStackProperties browserStackProperties;
+
+    public BrowserStackConfiguration(BrowserStackProperties browserStackProperties) {
+        this.browserStackProperties = browserStackProperties;
+        log.info("BrowserStackConfiguration loaded for user: {}", browserStackProperties.getUsername());
+    }
+
+    @PostConstruct
+    public void initializeBrowserStack() {
+        String username = browserStackProperties.getUsername();
+        String accessKey = browserStackProperties.getAccessKey();
+
+        if (accessKey == null || accessKey.trim().isEmpty()) {
+            log.warn("BrowserStack access key is empty after parsing");
+            return;
+        }
+
+        if (username == null || username.trim().isEmpty()) {
+            log.warn("BrowserStack username is not configured. Set browserstack.username property.");
+            return;
+        }
+
+        log.info("Configuring BrowserConnectionHelper with BrowserStack");
+        log.info("  Hub URL: {}", BROWSERSTACK_HUB_URL);
+        log.info("  Username: {}", username);
+        log.info("  Access Key: {}...", accessKey.substring(0, Math.min(4, accessKey.length())));
+
+        BrowserConnectionHelper.setBrowserStackConfig(BROWSERSTACK_HUB_URL, browserStackProperties);
+
+        log.info("BrowserStack configuration completed successfully");
+        log.info("   Project: {}", browserStackProperties.getProject());
+        log.info("   Build: {}", browserStackProperties.getBuild());
+        log.info("   OS: {} {}", browserStackProperties.getOs(), browserStackProperties.getOsVersion());
+        log.info("   Local: {}", browserStackProperties.isLocal());
+        log.info("   Debug: {}", browserStackProperties.isDebug());
+        log.info("   Connection timeout: {}ms", browserStackProperties.getConnectionTimeout());
+        log.info("   Max retries: {}", browserStackProperties.getMaxRetries());
+    }
+
+    public BrowserStackProperties getBrowserStackProperties() {
+        return browserStackProperties;
+    }
+
+    @Bean
+    public ApplicationListener<ApplicationReadyEvent> browserStackDiagnosticListener(Environment environment) {
+        return event -> {
+            log.info("=== BrowserStack Configuration Diagnostic ===");
+
+            String accessKey = environment.getProperty("browserstack.access-key");
+            String username = environment.getProperty("browserstack.username");
+
+            log.info("browserstack.username: {}", username != null ? username : "<NULL>");
+            log.info("browserstack.access-key: {}", accessKey != null ? "****" : "<NULL>");
+            log.info("browserstack.os: {}", environment.getProperty("browserstack.os", "<DEFAULT>"));
+            log.info("browserstack.os-version: {}", environment.getProperty("browserstack.os-version", "<DEFAULT>"));
+            log.info("browserstack.project: {}", environment.getProperty("browserstack.project", "<DEFAULT>"));
+            log.info("browserstack.build: {}", environment.getProperty("browserstack.build", "<DEFAULT>"));
+            log.info("browserstack.local: {}", environment.getProperty("browserstack.local", "false"));
+            log.info("browserstack.debug: {}", environment.getProperty("browserstack.debug", "true"));
+
+            if (accessKey != null && !accessKey.trim().isEmpty()
+                    && username != null && !username.trim().isEmpty()) {
+                log.info("BrowserStack configuration ENABLED");
+                log.info("   BrowserConnectionHelper will use BrowserStack instead of Selenium hubs");
+            } else {
+                log.warn("BrowserStack partially configured - both username and access-key are required");
+            }
+
+            log.info("=== End BrowserStack Configuration Diagnostic ===");
+        };
+    }
+}

--- a/LookseeCore/looksee-browser/src/main/java/com/looksee/config/BrowserStackProperties.java
+++ b/LookseeCore/looksee-browser/src/main/java/com/looksee/config/BrowserStackProperties.java
@@ -1,0 +1,160 @@
+package com.looksee.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.ConstructorBinding;
+
+/**
+ * Configuration properties for BrowserStack integration.
+ *
+ * This allows applications to configure BrowserStack using either:
+ * - browserstack.* properties (e.g., browserstack.access-key)
+ * - Environment variables (e.g., BROWSERSTACK_ACCESS_KEY)
+ *
+ * When browserstack.access-key is configured, BrowserStack will be used
+ * instead of the default Selenium URL-based connection.
+ */
+@ConfigurationProperties(prefix = "browserstack")
+@ConstructorBinding
+public class BrowserStackProperties {
+
+    /**
+     * BrowserStack username.
+     */
+    private final String username;
+
+    /**
+     * BrowserStack access key. This is the activation trigger for BrowserStack integration.
+     */
+    private final String accessKey;
+
+    /**
+     * Target operating system (e.g., "Windows", "OS X").
+     */
+    private final String os;
+
+    /**
+     * Target OS version (e.g., "11", "Ventura").
+     */
+    private final String osVersion;
+
+    /**
+     * Browser name override (e.g., "Chrome", "Firefox").
+     * When null, the BrowserType from getConnection is used.
+     */
+    private final String browser;
+
+    /**
+     * Browser version (e.g., "latest", "120.0").
+     */
+    private final String browserVersion;
+
+    /**
+     * BrowserStack project name for organizing tests.
+     */
+    private final String project;
+
+    /**
+     * BrowserStack build name for grouping test runs.
+     */
+    private final String build;
+
+    /**
+     * BrowserStack session name.
+     */
+    private final String name;
+
+    /**
+     * Whether to enable BrowserStack Local for testing internal/staging sites.
+     * Default is false.
+     */
+    private final boolean local;
+
+    /**
+     * Whether to enable BrowserStack debug mode for visual logs.
+     * Default is true.
+     */
+    private final boolean debug;
+
+    /**
+     * Connection timeout in milliseconds.
+     * Default is 30000 (30 seconds).
+     */
+    private final int connectionTimeout;
+
+    /**
+     * Maximum number of retry attempts.
+     * Default is 3.
+     */
+    private final int maxRetries;
+
+    public BrowserStackProperties(String username, String accessKey, String os, String osVersion,
+                                  String browser, String browserVersion, String project,
+                                  String build, String name, Boolean local, Boolean debug,
+                                  Integer connectionTimeout, Integer maxRetries) {
+        this.username = username;
+        this.accessKey = accessKey;
+        this.os = os;
+        this.osVersion = osVersion;
+        this.browser = browser;
+        this.browserVersion = browserVersion;
+        this.project = project;
+        this.build = build;
+        this.name = name;
+        this.local = local != null ? local : false;
+        this.debug = debug != null ? debug : true;
+        this.connectionTimeout = connectionTimeout != null ? connectionTimeout : 30000;
+        this.maxRetries = maxRetries != null ? maxRetries : 3;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public String getAccessKey() {
+        return accessKey;
+    }
+
+    public String getOs() {
+        return os;
+    }
+
+    public String getOsVersion() {
+        return osVersion;
+    }
+
+    public String getBrowser() {
+        return browser;
+    }
+
+    public String getBrowserVersion() {
+        return browserVersion;
+    }
+
+    public String getProject() {
+        return project;
+    }
+
+    public String getBuild() {
+        return build;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public boolean isLocal() {
+        return local;
+    }
+
+    public boolean isDebug() {
+        return debug;
+    }
+
+    public int getConnectionTimeout() {
+        return connectionTimeout;
+    }
+
+    public int getMaxRetries() {
+        return maxRetries;
+    }
+}

--- a/LookseeCore/looksee-browser/src/main/java/com/looksee/config/BrowserStackProperties.java
+++ b/LookseeCore/looksee-browser/src/main/java/com/looksee/config/BrowserStackProperties.java
@@ -11,7 +11,12 @@ import org.springframework.boot.context.properties.ConstructorBinding;
  * - Environment variables (e.g., BROWSERSTACK_ACCESS_KEY)
  *
  * When browserstack.access-key is configured, BrowserStack will be used
- * instead of the default Selenium URL-based connection.
+ * instead of the default Selenium and Appium URL-based connections.
+ *
+ * For desktop browsers: os, osVersion, browser, browserVersion apply.
+ * For mobile (Appium): deviceName, realMobile, and os/osVersion apply.
+ * BrowserStack determines the platform (Android/iOS) from the BrowserType
+ * passed to getMobileConnection.
  */
 @ConfigurationProperties(prefix = "browserstack")
 @ConstructorBinding
@@ -64,6 +69,18 @@ public class BrowserStackProperties {
     private final String name;
 
     /**
+     * BrowserStack device name for mobile testing (e.g., "Samsung Galaxy S23", "iPhone 15").
+     * Used with Appium connections on BrowserStack.
+     */
+    private final String deviceName;
+
+    /**
+     * Whether to use a real mobile device on BrowserStack (as opposed to an emulator/simulator).
+     * Default is true, since BrowserStack's primary value is real device testing.
+     */
+    private final boolean realMobile;
+
+    /**
      * Whether to enable BrowserStack Local for testing internal/staging sites.
      * Default is false.
      */
@@ -89,7 +106,8 @@ public class BrowserStackProperties {
 
     public BrowserStackProperties(String username, String accessKey, String os, String osVersion,
                                   String browser, String browserVersion, String project,
-                                  String build, String name, Boolean local, Boolean debug,
+                                  String build, String name, String deviceName, Boolean realMobile,
+                                  Boolean local, Boolean debug,
                                   Integer connectionTimeout, Integer maxRetries) {
         this.username = username;
         this.accessKey = accessKey;
@@ -100,6 +118,8 @@ public class BrowserStackProperties {
         this.project = project;
         this.build = build;
         this.name = name;
+        this.deviceName = deviceName;
+        this.realMobile = realMobile != null ? realMobile : true;
         this.local = local != null ? local : false;
         this.debug = debug != null ? debug : true;
         this.connectionTimeout = connectionTimeout != null ? connectionTimeout : 30000;
@@ -140,6 +160,14 @@ public class BrowserStackProperties {
 
     public String getName() {
         return name;
+    }
+
+    public String getDeviceName() {
+        return deviceName;
+    }
+
+    public boolean isRealMobile() {
+        return realMobile;
     }
 
     public boolean isLocal() {

--- a/LookseeCore/looksee-browser/src/test/java/com/looksee/browsing/helpers/BrowserConnectionHelperTest.java
+++ b/LookseeCore/looksee-browser/src/test/java/com/looksee/browsing/helpers/BrowserConnectionHelperTest.java
@@ -14,7 +14,8 @@ public class BrowserConnectionHelperTest {
 
     @BeforeEach
     public void setUp() {
-        // Reset state before each test
+        // Reset BrowserStack state before each test to avoid cross-test interference
+        BrowserConnectionHelper.clearBrowserStackConfig();
     }
 
     @Test
@@ -51,7 +52,7 @@ public class BrowserConnectionHelperTest {
         BrowserStackProperties props = new BrowserStackProperties(
                 "testuser", "testaccesskey", null, null,
                 null, null, null, null,
-                null, null, null, null, null);
+                null, null, null, null, null, null, null);
 
         assertDoesNotThrow(() -> BrowserConnectionHelper.setBrowserStackConfig(
                 "https://hub-cloud.browserstack.com/wd/hub", props));
@@ -62,11 +63,28 @@ public class BrowserConnectionHelperTest {
         BrowserStackProperties props = new BrowserStackProperties(
                 "testuser", "testaccesskey", null, null,
                 null, null, null, null,
-                null, null, null, null, null);
+                null, null, null, null, null, null, null);
 
         BrowserConnectionHelper.setBrowserStackConfig(
                 "https://hub-cloud.browserstack.com/wd/hub", props);
 
         assertDoesNotThrow(() -> BrowserConnectionHelper.clearBrowserStackConfig());
+    }
+
+    @Test
+    public void testGetMobileConnectionWithoutUrlsWhenBrowserStackCleared() {
+        // Ensure that after clearing BrowserStack, mobile connections still require Appium URLs
+        BrowserStackProperties props = new BrowserStackProperties(
+                "testuser", "testaccesskey", null, null,
+                null, null, null, null,
+                null, "Samsung Galaxy S23", null, null, null, null, null);
+
+        BrowserConnectionHelper.setBrowserStackConfig(
+                "https://hub-cloud.browserstack.com/wd/hub", props);
+        BrowserConnectionHelper.clearBrowserStackConfig();
+        BrowserConnectionHelper.setConfiguredAppiumUrls(new String[]{});
+
+        assertThrows(IllegalStateException.class,
+                () -> BrowserConnectionHelper.getMobileConnection(BrowserType.ANDROID, BrowserEnvironment.DISCOVERY));
     }
 }

--- a/LookseeCore/looksee-browser/src/test/java/com/looksee/browsing/helpers/BrowserConnectionHelperTest.java
+++ b/LookseeCore/looksee-browser/src/test/java/com/looksee/browsing/helpers/BrowserConnectionHelperTest.java
@@ -6,6 +6,7 @@ import java.net.MalformedURLException;
 
 import com.looksee.browsing.enums.BrowserEnvironment;
 import com.looksee.browsing.enums.BrowserType;
+import com.looksee.config.BrowserStackProperties;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -43,5 +44,29 @@ public class BrowserConnectionHelperTest {
 
         assertThrows(IllegalStateException.class,
                 () -> BrowserConnectionHelper.getMobileConnection(BrowserType.IOS, BrowserEnvironment.DISCOVERY));
+    }
+
+    @Test
+    public void testSetBrowserStackConfig() {
+        BrowserStackProperties props = new BrowserStackProperties(
+                "testuser", "testaccesskey", null, null,
+                null, null, null, null,
+                null, null, null, null, null);
+
+        assertDoesNotThrow(() -> BrowserConnectionHelper.setBrowserStackConfig(
+                "https://hub-cloud.browserstack.com/wd/hub", props));
+    }
+
+    @Test
+    public void testClearBrowserStackConfig() {
+        BrowserStackProperties props = new BrowserStackProperties(
+                "testuser", "testaccesskey", null, null,
+                null, null, null, null,
+                null, null, null, null, null);
+
+        BrowserConnectionHelper.setBrowserStackConfig(
+                "https://hub-cloud.browserstack.com/wd/hub", props);
+
+        assertDoesNotThrow(() -> BrowserConnectionHelper.clearBrowserStackConfig());
     }
 }

--- a/LookseeCore/looksee-browser/src/test/java/com/looksee/config/BrowserStackPropertiesTest.java
+++ b/LookseeCore/looksee-browser/src/test/java/com/looksee/config/BrowserStackPropertiesTest.java
@@ -11,7 +11,8 @@ public class BrowserStackPropertiesTest {
         BrowserStackProperties props = new BrowserStackProperties(
                 "myuser", "mykey123", "Windows", "11",
                 "Chrome", "latest", "MyProject", "build-1",
-                "test-session", true, false, 60000, 5);
+                "test-session", "Samsung Galaxy S23", false,
+                true, false, 60000, 5);
 
         assertEquals("myuser", props.getUsername());
         assertEquals("mykey123", props.getAccessKey());
@@ -22,6 +23,8 @@ public class BrowserStackPropertiesTest {
         assertEquals("MyProject", props.getProject());
         assertEquals("build-1", props.getBuild());
         assertEquals("test-session", props.getName());
+        assertEquals("Samsung Galaxy S23", props.getDeviceName());
+        assertFalse(props.isRealMobile());
         assertTrue(props.isLocal());
         assertFalse(props.isDebug());
         assertEquals(60000, props.getConnectionTimeout());
@@ -33,7 +36,7 @@ public class BrowserStackPropertiesTest {
         BrowserStackProperties props = new BrowserStackProperties(
                 "myuser", "mykey123", null, null,
                 null, null, null, null,
-                null, null, null, null, null);
+                null, null, null, null, null, null, null);
 
         assertEquals("myuser", props.getUsername());
         assertEquals("mykey123", props.getAccessKey());
@@ -44,6 +47,8 @@ public class BrowserStackPropertiesTest {
         assertNull(props.getProject());
         assertNull(props.getBuild());
         assertNull(props.getName());
+        assertNull(props.getDeviceName());
+        assertTrue(props.isRealMobile());
         assertFalse(props.isLocal());
         assertTrue(props.isDebug());
         assertEquals(30000, props.getConnectionTimeout());

--- a/LookseeCore/looksee-browser/src/test/java/com/looksee/config/BrowserStackPropertiesTest.java
+++ b/LookseeCore/looksee-browser/src/test/java/com/looksee/config/BrowserStackPropertiesTest.java
@@ -1,0 +1,52 @@
+package com.looksee.config;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+public class BrowserStackPropertiesTest {
+
+    @Test
+    public void testConstructorWithAllValues() {
+        BrowserStackProperties props = new BrowserStackProperties(
+                "myuser", "mykey123", "Windows", "11",
+                "Chrome", "latest", "MyProject", "build-1",
+                "test-session", true, false, 60000, 5);
+
+        assertEquals("myuser", props.getUsername());
+        assertEquals("mykey123", props.getAccessKey());
+        assertEquals("Windows", props.getOs());
+        assertEquals("11", props.getOsVersion());
+        assertEquals("Chrome", props.getBrowser());
+        assertEquals("latest", props.getBrowserVersion());
+        assertEquals("MyProject", props.getProject());
+        assertEquals("build-1", props.getBuild());
+        assertEquals("test-session", props.getName());
+        assertTrue(props.isLocal());
+        assertFalse(props.isDebug());
+        assertEquals(60000, props.getConnectionTimeout());
+        assertEquals(5, props.getMaxRetries());
+    }
+
+    @Test
+    public void testConstructorWithDefaults() {
+        BrowserStackProperties props = new BrowserStackProperties(
+                "myuser", "mykey123", null, null,
+                null, null, null, null,
+                null, null, null, null, null);
+
+        assertEquals("myuser", props.getUsername());
+        assertEquals("mykey123", props.getAccessKey());
+        assertNull(props.getOs());
+        assertNull(props.getOsVersion());
+        assertNull(props.getBrowser());
+        assertNull(props.getBrowserVersion());
+        assertNull(props.getProject());
+        assertNull(props.getBuild());
+        assertNull(props.getName());
+        assertFalse(props.isLocal());
+        assertTrue(props.isDebug());
+        assertEquals(30000, props.getConnectionTimeout());
+        assertEquals(3, props.getMaxRetries());
+    }
+}

--- a/LookseeCore/looksee-core/src/main/java/com/looksee/config/LookseeCoreAutoConfiguration.java
+++ b/LookseeCore/looksee-core/src/main/java/com/looksee/config/LookseeCoreAutoConfiguration.java
@@ -17,13 +17,14 @@ import com.looksee.gcp.GoogleCloudStorageProperties;
  * library is included as a dependency in other Spring Boot applications.
  */
 @Configuration
-@EnableConfigurationProperties({LookseeCoreProperties.class, GoogleCloudStorageProperties.class, PusherProperties.class, SeleniumProperties.class})
+@EnableConfigurationProperties({LookseeCoreProperties.class, GoogleCloudStorageProperties.class, PusherProperties.class, SeleniumProperties.class, BrowserStackProperties.class})
 @ConditionalOnProperty(prefix = "looksee.core", name = "enabled", havingValue = "true", matchIfMissing = true)
 @Import({
     LookseeCoreComponentConfiguration.class,
     LookseeCoreRepositoryConfiguration.class,
     PusherConfiguration.class,
-    SeleniumConfiguration.class
+    SeleniumConfiguration.class,
+    BrowserStackConfiguration.class
 })
 public class LookseeCoreAutoConfiguration {
     


### PR DESCRIPTION
When browserstack.access-key is configured, BrowserConnectionHelper uses
BrowserStack's cloud hub instead of the default Selenium URL round-robin.
Credentials are passed via capabilities (not embedded in URLs) to avoid
accidental logging. Headless mode is omitted for BrowserStack since it
manages the display environment. The existing URL-based connection remains
the default when BrowserStack is not configured.

https://claude.ai/code/session_01AdoaGPUcCM4HHtYhFsngoK