### PR TITLE
Add Auth0, GCP API key, and optional SMTP configuration to Terraform

### DIFF
--- a/LookseeIaC/GCP/modules.tf
+++ b/LookseeIaC/GCP/modules.tf
@@ -69,6 +69,10 @@ module "secrets" {
   auth0_domain        = var.auth0_domain
   auth0_audience      = var.auth0_audience
 
+  gcp_api_key                 = var.gcp_api_key
+  integrations_encryption_key = var.integrations_encryption_key
+  smtp_host                   = var.smtp_host
+
   depends_on = [module.neo4j_db]
 }
 
@@ -136,6 +140,29 @@ module "api" {
     "pubsub.discarded_journey_topic" : module.pubsub_topics.journey_discarded_topic_name,
     "pubsub.error_topic" : module.pubsub_topics.audit_error_topic_name
   }
+  environment_variables = merge(
+    {
+      "spring.data.neo4j.database" : [module.secrets.neo4j_db_name_secret_name, "latest"],
+      "spring.data.neo4j.username" : [module.secrets.neo4j_username_secret_name, "latest"],
+      "spring.data.neo4j.password" : [module.secrets.neo4j_password_secret_name, "latest"],
+      "spring.data.neo4j.uri" : [module.neo4j_db.neo4j_bolt_uri_secret_name, "latest"],
+      "auth0.clientId" : [module.secrets.auth0_client_id_secret_name, "latest"],
+      "auth0.clientSecret" : [module.secrets.auth0_client_secret_secret_name, "latest"],
+      "auth0.domain" : [module.secrets.auth0_domain_secret_name, "latest"],
+      "auth0.audience" : [module.secrets.auth0_audience_secret_name, "latest"],
+      "smtp.username" : [module.secrets.smtp_username_secret_name, "latest"],
+      "smtp.password" : [module.secrets.smtp_password_secret_name, "latest"],
+    },
+    var.gcp_api_key != "" ? {
+      "gcp.api.key" : [module.secrets.gcp_api_key_secret_name, "latest"],
+    } : {},
+    var.integrations_encryption_key != "" ? {
+      "integrations.encryption.key" : [module.secrets.integrations_encryption_key_secret_name, "latest"],
+    } : {},
+    var.smtp_host != "" ? {
+      "spring.mail.host" : [module.secrets.smtp_host_secret_name, "latest"],
+    } : {},
+  )
   memory_allocation = "1Gi"
   depends_on        = [module.neo4j_db, module.secrets]
 }
@@ -163,12 +190,17 @@ module "page_builder_cloud_run" {
     "spring.cloud.gcp.project-id" : var.project_id,
     "spring.cloud.gcp.region" : var.region
   }
-  environment_variables = {
-    "spring.data.neo4j.database" : [module.secrets.neo4j_db_name_secret_name, "latest"],
-    "spring.data.neo4j.username" : [module.secrets.neo4j_username_secret_name, "latest"],
-    "spring.data.neo4j.password" : [module.secrets.neo4j_password_secret_name, "latest"],
-    "spring.data.neo4j.uri" : [module.neo4j_db.neo4j_bolt_uri_secret_name, "latest"],
-  }
+  environment_variables = merge(
+    {
+      "spring.data.neo4j.database" : [module.secrets.neo4j_db_name_secret_name, "latest"],
+      "spring.data.neo4j.username" : [module.secrets.neo4j_username_secret_name, "latest"],
+      "spring.data.neo4j.password" : [module.secrets.neo4j_password_secret_name, "latest"],
+      "spring.data.neo4j.uri" : [module.neo4j_db.neo4j_bolt_uri_secret_name, "latest"],
+    },
+    var.gcp_api_key != "" ? {
+      "gcp.api.key" : [module.secrets.gcp_api_key_secret_name, "latest"],
+    } : {},
+  )
 
   vpc_connector_name = module.vpc.vpc_connector_name
   vpc_egress         = "private-ranges-only"

--- a/LookseeIaC/GCP/modules/api/main.tf
+++ b/LookseeIaC/GCP/modules/api/main.tf
@@ -13,52 +13,25 @@ resource "google_cloud_run_service" "api" {
           container_port = var.port
         }
 
-        # Add environment variables from secrets
-        env {
-          name = "NEO4J_PASSWORD"
-          value_from {
-            secret_key_ref {
-              name = "neo4j-password"
-              key  = "latest"
-            }
-          }
-        }
-
-        env {
-          name = "NEO4J_USERNAME"
-          value_from {
-            secret_key_ref {
-              name = "neo4j-username"
-              key  = "latest"
-            }
-          }
-        }
-
-        env {
-          name = "NEO4J_BOLT_URI"
-          value_from {
-            secret_key_ref {
-              name = "neo4j-bolt-uri"
-              key  = "latest"
-            }
-          }
-        }
-
-        env {
-          name = "NEO4J_DB_NAME"
-          value_from {
-            secret_key_ref {
-              name = "neo4j-db-name"
-              key  = "latest"
-            }
-          }
-        }
-        
         dynamic "env" {
           for_each = var.pubsub_topics
           content {
             name  = env.key
             value = env.value
+          }
+        }
+
+        # Add environment variables from secrets
+        dynamic "env" {
+          for_each = var.environment_variables
+          content {
+            name = env.key
+            value_from {
+              secret_key_ref {
+                name = env.value[0]
+                key  = env.value[1]
+              }
+            }
           }
         }
 

--- a/LookseeIaC/GCP/modules/api/variables.tf
+++ b/LookseeIaC/GCP/modules/api/variables.tf
@@ -49,30 +49,6 @@ variable "url_topic_name" {
   type        = string
 }
 
-################################
-# SECRETS
-################################
-
-variable "neo4j_password_secret" {
-  description = "Name of the Neo4j password secret"
-  default     = "neo4j-password"
-}
-
-variable "neo4j_username_secret" {
-  description = "Name of the Neo4j username secret"
-  default     = "neo4j-username"
-}
-
-variable "neo4j_bolt_uri_secret" {
-  description = "Name of the Neo4j bolt URI secret"
-  default     = "neo4j-bolt-uri"
-}
-
-variable "neo4j_db_name_secret" {
-  description = "Name of the Neo4j database name secret"
-  default     = "neo4j-db-name"
-}
-
 variable "pubsub_topics" {
   description = "Pubsub topics"
   type        = map(string)
@@ -81,4 +57,10 @@ variable "pubsub_topics" {
 variable "memory_allocation" {
   description = "Memory allocated for cloud run instance"
   type        = string
+}
+
+variable "environment_variables" {
+  description = "Map of environment variables backed by Secret Manager references"
+  type        = map(list(string))
+  default     = {}
 }

--- a/LookseeIaC/GCP/modules/secrets/iam.tf
+++ b/LookseeIaC/GCP/modules/secrets/iam.tf
@@ -53,6 +53,51 @@ resource "google_secret_manager_secret_iam_member" "smtp_username_secret_accesso
   member    = "serviceAccount:${var.service_account_email}"
 }
 
+resource "google_secret_manager_secret_iam_member" "auth0_client_id_secret_accessor" {
+  secret_id = google_secret_manager_secret.auth0_client_id.name
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${var.service_account_email}"
+}
+
+resource "google_secret_manager_secret_iam_member" "auth0_client_secret_secret_accessor" {
+  secret_id = google_secret_manager_secret.auth0_client_secret.name
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${var.service_account_email}"
+}
+
+resource "google_secret_manager_secret_iam_member" "auth0_domain_secret_accessor" {
+  secret_id = google_secret_manager_secret.auth0_domain.name
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${var.service_account_email}"
+}
+
+resource "google_secret_manager_secret_iam_member" "auth0_audience_secret_accessor" {
+  secret_id = google_secret_manager_secret.auth0_audience.name
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${var.service_account_email}"
+}
+
+resource "google_secret_manager_secret_iam_member" "gcp_api_key_secret_accessor" {
+  count     = var.gcp_api_key != "" ? 1 : 0
+  secret_id = google_secret_manager_secret.gcp_api_key[0].name
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${var.service_account_email}"
+}
+
+resource "google_secret_manager_secret_iam_member" "integrations_encryption_key_secret_accessor" {
+  count     = var.integrations_encryption_key != "" ? 1 : 0
+  secret_id = google_secret_manager_secret.integrations_encryption_key[0].name
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${var.service_account_email}"
+}
+
+resource "google_secret_manager_secret_iam_member" "smtp_host_secret_accessor" {
+  count     = var.smtp_host != "" ? 1 : 0
+  secret_id = google_secret_manager_secret.smtp_host[0].name
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${var.service_account_email}"
+}
+
 
 
 

--- a/LookseeIaC/GCP/modules/secrets/main.tf
+++ b/LookseeIaC/GCP/modules/secrets/main.tf
@@ -168,3 +168,142 @@ resource "google_secret_manager_secret_version" "smtp_username_version" {
   secret         = google_secret_manager_secret.smtp_username.id
   secret_data_wo = var.smtp_username
 }
+
+# Auth0 Client ID Secret
+resource "google_secret_manager_secret" "auth0_client_id" {
+  secret_id = "auth0-client-id"
+  project   = var.project_id
+
+  labels = {
+    environment = var.environment
+  }
+
+  replication {
+    auto {}
+  }
+}
+
+resource "google_secret_manager_secret_version" "auth0_client_id_version" {
+  secret         = google_secret_manager_secret.auth0_client_id.id
+  secret_data_wo = var.auth0_client_id
+}
+
+# Auth0 Client Secret
+resource "google_secret_manager_secret" "auth0_client_secret" {
+  secret_id = "auth0-client-secret"
+  project   = var.project_id
+
+  labels = {
+    environment = var.environment
+  }
+
+  replication {
+    auto {}
+  }
+}
+
+resource "google_secret_manager_secret_version" "auth0_client_secret_version" {
+  secret         = google_secret_manager_secret.auth0_client_secret.id
+  secret_data_wo = var.auth0_client_secret
+}
+
+# Auth0 Domain Secret
+resource "google_secret_manager_secret" "auth0_domain" {
+  secret_id = "auth0-domain"
+  project   = var.project_id
+
+  labels = {
+    environment = var.environment
+  }
+
+  replication {
+    auto {}
+  }
+}
+
+resource "google_secret_manager_secret_version" "auth0_domain_version" {
+  secret         = google_secret_manager_secret.auth0_domain.id
+  secret_data_wo = var.auth0_domain
+}
+
+# Auth0 Audience Secret
+resource "google_secret_manager_secret" "auth0_audience" {
+  secret_id = "auth0-audience"
+  project   = var.project_id
+
+  labels = {
+    environment = var.environment
+  }
+
+  replication {
+    auto {}
+  }
+}
+
+resource "google_secret_manager_secret_version" "auth0_audience_version" {
+  secret         = google_secret_manager_secret.auth0_audience.id
+  secret_data_wo = var.auth0_audience
+}
+
+# GCP API Key Secret
+resource "google_secret_manager_secret" "gcp_api_key" {
+  count     = var.gcp_api_key != "" ? 1 : 0
+  secret_id = "gcp-api-key"
+  project   = var.project_id
+
+  labels = {
+    environment = var.environment
+  }
+
+  replication {
+    auto {}
+  }
+}
+
+resource "google_secret_manager_secret_version" "gcp_api_key_version" {
+  count          = var.gcp_api_key != "" ? 1 : 0
+  secret         = google_secret_manager_secret.gcp_api_key[0].id
+  secret_data_wo = var.gcp_api_key
+}
+
+# Integrations Encryption Key Secret
+resource "google_secret_manager_secret" "integrations_encryption_key" {
+  count     = var.integrations_encryption_key != "" ? 1 : 0
+  secret_id = "integrations-encryption-key"
+  project   = var.project_id
+
+  labels = {
+    environment = var.environment
+  }
+
+  replication {
+    auto {}
+  }
+}
+
+resource "google_secret_manager_secret_version" "integrations_encryption_key_version" {
+  count          = var.integrations_encryption_key != "" ? 1 : 0
+  secret         = google_secret_manager_secret.integrations_encryption_key[0].id
+  secret_data_wo = var.integrations_encryption_key
+}
+
+# SMTP Host Secret
+resource "google_secret_manager_secret" "smtp_host" {
+  count     = var.smtp_host != "" ? 1 : 0
+  secret_id = "smtp-host"
+  project   = var.project_id
+
+  labels = {
+    environment = var.environment
+  }
+
+  replication {
+    auto {}
+  }
+}
+
+resource "google_secret_manager_secret_version" "smtp_host_version" {
+  count          = var.smtp_host != "" ? 1 : 0
+  secret         = google_secret_manager_secret.smtp_host[0].id
+  secret_data_wo = var.smtp_host
+}

--- a/LookseeIaC/GCP/modules/secrets/outputs.tf
+++ b/LookseeIaC/GCP/modules/secrets/outputs.tf
@@ -94,3 +94,58 @@ output "smtp_username_secret_name" {
   description = "The name of the SMTP username secret"
   value       = google_secret_manager_secret.smtp_username.name
 }
+
+output "auth0_client_id_secret_id" {
+  description = "The ID of the Auth0 client ID secret"
+  value       = google_secret_manager_secret.auth0_client_id.id
+}
+
+output "auth0_client_id_secret_name" {
+  description = "The name of the Auth0 client ID secret"
+  value       = google_secret_manager_secret.auth0_client_id.secret_id
+}
+
+output "auth0_client_secret_secret_id" {
+  description = "The ID of the Auth0 client secret"
+  value       = google_secret_manager_secret.auth0_client_secret.id
+}
+
+output "auth0_client_secret_secret_name" {
+  description = "The name of the Auth0 client secret"
+  value       = google_secret_manager_secret.auth0_client_secret.secret_id
+}
+
+output "auth0_domain_secret_id" {
+  description = "The ID of the Auth0 domain secret"
+  value       = google_secret_manager_secret.auth0_domain.id
+}
+
+output "auth0_domain_secret_name" {
+  description = "The name of the Auth0 domain secret"
+  value       = google_secret_manager_secret.auth0_domain.secret_id
+}
+
+output "auth0_audience_secret_id" {
+  description = "The ID of the Auth0 audience secret"
+  value       = google_secret_manager_secret.auth0_audience.id
+}
+
+output "auth0_audience_secret_name" {
+  description = "The name of the Auth0 audience secret"
+  value       = google_secret_manager_secret.auth0_audience.secret_id
+}
+
+output "gcp_api_key_secret_name" {
+  description = "The name of the GCP API key secret (empty if not configured)"
+  value       = var.gcp_api_key != "" ? google_secret_manager_secret.gcp_api_key[0].secret_id : ""
+}
+
+output "integrations_encryption_key_secret_name" {
+  description = "The name of the integrations encryption key secret (empty if not configured)"
+  value       = var.integrations_encryption_key != "" ? google_secret_manager_secret.integrations_encryption_key[0].secret_id : ""
+}
+
+output "smtp_host_secret_name" {
+  description = "The name of the SMTP host secret (empty if not configured)"
+  value       = var.smtp_host != "" ? google_secret_manager_secret.smtp_host[0].secret_id : ""
+}

--- a/LookseeIaC/GCP/modules/secrets/variables.tf
+++ b/LookseeIaC/GCP/modules/secrets/variables.tf
@@ -91,3 +91,23 @@ variable "auth0_audience" {
   type        = string
   sensitive   = true
 }
+
+variable "gcp_api_key" {
+  description = "Google Cloud API key (PageSpeed Insights / Vision API)"
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
+variable "integrations_encryption_key" {
+  description = "AES-GCM encryption key for integration configurations"
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
+variable "smtp_host" {
+  description = "SMTP host for outbound email"
+  type        = string
+  default     = ""
+}

--- a/LookseeIaC/GCP/variables.tf
+++ b/LookseeIaC/GCP/variables.tf
@@ -152,6 +152,34 @@ variable "auth0_audience" {
 
 
 #########################
+# GCP API Keys
+#########################
+
+variable "gcp_api_key" {
+  description = "Google Cloud API key (used by PageSpeed Insights / Vision API)"
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
+variable "integrations_encryption_key" {
+  description = "AES-GCM encryption key for integration configurations"
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
+#########################
+# SMTP Additional
+#########################
+
+variable "smtp_host" {
+  description = "SMTP host for outbound email"
+  type        = string
+  default     = ""
+}
+
+#########################
 # GCP Service Account
 #########################
 

--- a/LookseeIaC/GCP/versions.tf
+++ b/LookseeIaC/GCP/versions.tf
@@ -1,0 +1,24 @@
+terraform {
+  required_version = ">= 1.6"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 5.0"
+    }
+  }
+
+  backend "gcs" {
+    # All values must be provided at init time via -backend-config flags or
+    # a backend config file so that no bucket names are committed to the repo.
+    #
+    # Example:
+    #   terraform init \
+    #     -backend-config="bucket=my-tf-state-bucket" \
+    #     -backend-config="prefix=looksee/dev"
+    #
+    # In GitHub Actions, pass these via environment or step inputs:
+    #   env:
+    #     TF_CLI_ARGS_init: "-backend-config=bucket=${{ secrets.TF_STATE_BUCKET }} -backend-config=prefix=looksee/${{ github.ref_name }}"
+  }
+}

--- a/README.md
+++ b/README.md
@@ -355,10 +355,29 @@ jobs:
 
 ---
 
-### Known Gaps
+### Terraform Backend (Remote State)
 
-1. **No remote backend configured.** The Terraform code has no `terraform {}` block with a backend. Without a remote backend (e.g. GCS bucket), state is lost between GitHub Actions runs. A GCS backend must be added to `LookseeIaC/GCP/`.
+The GCS backend is configured in `LookseeIaC/GCP/versions.tf` but requires backend config values at init time (no bucket names are committed to the repo). Provide them via `-backend-config` flags or a backend config file:
 
-2. **Auth0 secrets are accepted but never created.** The secrets module accepts `auth0_client_id`, `auth0_client_secret`, `auth0_domain`, and `auth0_audience` as input variables but does not create corresponding `google_secret_manager_secret` resources or outputs. Auth0 configuration is not wired to any Cloud Run service.
+```bash
+terraform init \
+  -backend-config="bucket=my-tf-state-bucket" \
+  -backend-config="prefix=looksee/dev"
+```
 
-3. **Stripe, Segment, and integration keys are not in Terraform.** These are only set in Spring Boot application property files and would need to be added to the secrets module if they should be managed as infrastructure.
+In GitHub Actions, set the `TF_STATE_BUCKET` secret and pass it during init:
+
+```yaml
+env:
+  TF_CLI_ARGS_init: "-backend-config=bucket=${{ secrets.TF_STATE_BUCKET }} -backend-config=prefix=looksee/${{ github.ref_name }}"
+```
+
+### Optional Secrets (Gap 3 Variables)
+
+The following variables are optional (default to empty string). When provided, Terraform creates the corresponding Secret Manager entries and wires them into the API and/or Page Builder Cloud Run services:
+
+| GitHub Secret Name | Terraform Variable | Wired To |
+|---|---|---|
+| `TF_VAR_GCP_API_KEY` | `gcp_api_key` | API, Page Builder (`gcp.api.key`) |
+| `TF_VAR_INTEGRATIONS_ENCRYPTION_KEY` | `integrations_encryption_key` | API (`integrations.encryption.key`) |
+| `TF_VAR_SMTP_HOST` | `smtp_host` | API (`spring.mail.host`) |

--- a/README.md
+++ b/README.md
@@ -43,3 +43,322 @@ git push -u origin main
 ```
 
 Individual project remotes in `LEGACY_REMOTES.txt` can be archived or left as read-only once this monorepo is canonical.
+
+---
+
+## LookseeIaC GCP Deployment Configuration
+
+This section documents every variable, secret, and property required to deploy the platform using the `LookseeIaC/GCP` Terraform package. All values are designed to be provided via `TF_VAR_` environment variables (e.g. GitHub Actions Secrets) so that no credentials file is ever committed to the repository.
+
+### Table of Contents (Deployment)
+
+1. [Required Terraform Variables](#required-terraform-variables)
+2. [Optional Terraform Variables](#optional-terraform-variables)
+3. [Container Images](#container-images)
+4. [GCP APIs to Enable](#gcp-apis-to-enable)
+5. [GCP Authentication](#gcp-authentication)
+6. [GCP Secret Manager (auto-created)](#gcp-secret-manager-auto-created)
+7. [PubSub Topics (auto-created)](#pubsub-topics-auto-created)
+8. [Application-Level Properties (Spring Boot)](#application-level-properties-spring-boot)
+9. [GitHub Actions Secrets Reference](#github-actions-secrets-reference)
+
+---
+
+### Required Terraform Variables
+
+These have no defaults and **must** be provided. In GitHub Actions, set each as a repository secret named `TF_VAR_<variable>`.
+
+#### GCP Project
+
+| Variable | Type | Description |
+|---|---|---|
+| `project_id` | string | Your GCP project ID |
+| `vpc_name` | string | Name for the VPC network |
+| `subnet_cidr` | string | Subnet CIDR range (e.g. `10.0.0.0/24`) |
+| `labels` | map(string) | Resource labels as JSON (e.g. `{"team":"eng","app":"looksee"}`) |
+
+#### Neo4j Database
+
+| Variable | Type | Description |
+|---|---|---|
+| `neo4j_password` | string (sensitive) | Neo4j admin password |
+| `neo4j_username` | string | Neo4j username (e.g. `neo4j`) |
+| `neo4j_db_name` | string | Neo4j database name (e.g. `neo4j`) |
+| `neo4j_bolt_uri` | string | Neo4j bolt connection URI (e.g. `bolt://host:7687`) |
+
+#### Auth0
+
+| Variable | Type | Description |
+|---|---|---|
+| `auth0_client_id` | string (sensitive) | Auth0 application client ID |
+| `auth0_client_secret` | string (sensitive) | Auth0 application client secret |
+| `auth0_domain` | string (sensitive) | Auth0 tenant domain (e.g. `look-see.us.auth0.com`) |
+| `auth0_audience` | string (sensitive) | Auth0 API audience identifier |
+
+#### Pusher (real-time WebSocket messaging)
+
+| Variable | Type | Description |
+|---|---|---|
+| `pusher_key` | string (sensitive) | Pusher API key |
+| `pusher_app_id` | string | Pusher application ID |
+| `pusher_cluster` | string | Pusher cluster region (e.g. `us2`) |
+| `pusher_secret` | string (sensitive) | Pusher secret key |
+
+#### SMTP (email)
+
+| Variable | Type | Description |
+|---|---|---|
+| `smtp_username` | string (sensitive) | SMTP username |
+| `smtp_password` | string (sensitive) | SMTP password |
+
+---
+
+### Optional Terraform Variables
+
+These have sensible defaults. Override only if needed.
+
+| Variable | Default | Description |
+|---|---|---|
+| `region` | `us-central1` | GCP region for all resources |
+| `environment` | `dev` | Environment name (dev, prod, etc.) |
+| `credentials_file` | `null` | Path to GCP SA JSON key file. Leave null to use ADC or Workload Identity Federation |
+| `selenium_instance_count` | `1` | Number of Selenium Chrome browser instances to deploy |
+
+---
+
+### Container Images
+
+All container image variables have defaults pointing to Docker Hub. Override to use a private registry or pin specific versions.
+
+| Variable | Default Image |
+|---|---|
+| `page_builder_image` | `docker.io/deepthought42/page-builder:latest` |
+| `api_image` | `docker.io/deepthought42/crawler-api:latest` |
+| `audit_manager_image` | `docker.io/deepthought42/audit-manager:latest` |
+| `audit_service_image` | `docker.io/deepthought42/audit-update-service:latest` |
+| `journey_executor_image` | `docker.io/deepthought42/journey-executor:latest` |
+| `journey_expander_image` | `docker.io/deepthought42/journey-expander:latest` |
+| `content_audit_image` | `docker.io/deepthought42/content-audit:latest` |
+| `visual_design_audit_image` | `docker.io/deepthought42/visual-design-audit:latest` |
+| `information_architecture_audit_image` | `docker.io/deepthought42/information-architecture-audit:latest` |
+| `selenium_image` | `docker.io/selenium/standalone-chrome:3.141.59` |
+
+---
+
+### GCP APIs to Enable
+
+These APIs must be enabled on your GCP project before running `terraform apply`:
+
+```bash
+gcloud services enable \
+  run.googleapis.com \
+  pubsub.googleapis.com \
+  secretmanager.googleapis.com \
+  compute.googleapis.com \
+  vpcaccess.googleapis.com \
+  iam.googleapis.com \
+  --project=${PROJECT_ID}
+```
+
+| API | Purpose |
+|---|---|
+| `run.googleapis.com` | Cloud Run services |
+| `pubsub.googleapis.com` | Pub/Sub topics and subscriptions |
+| `secretmanager.googleapis.com` | Secret Manager for credentials |
+| `compute.googleapis.com` | VPC network and Neo4j VM |
+| `vpcaccess.googleapis.com` | Serverless VPC Access connector |
+| `iam.googleapis.com` | Service account creation and IAM bindings |
+
+---
+
+### GCP Authentication
+
+Two options for authenticating Terraform with GCP:
+
+1. **Workload Identity Federation (recommended for CI/CD)** -- Configure OIDC federation between GitHub Actions and GCP. No key files needed. Use the `google-github-actions/auth` action in your workflow.
+2. **Service account key file** -- Set `TF_VAR_credentials_file` to the path of a JSON key file. Store the key contents as a GitHub Actions secret and write it to a file during the workflow.
+
+The authenticated identity requires at minimum: **Project Editor**, **Secret Manager Admin**, **Pub/Sub Admin**, and **Service Account Admin** roles.
+
+---
+
+### GCP Secret Manager (auto-created)
+
+Terraform automatically creates these secrets in GCP Secret Manager and wires them as environment variables into the Cloud Run services:
+
+| Secret ID | Source Variable | Used By |
+|---|---|---|
+| `neo4j-password` | `neo4j_password` | All Cloud Run services |
+| `neo4j-username` | `neo4j_username` | All Cloud Run services |
+| `neo4j-db-name` | `neo4j_db_name` | All Cloud Run services |
+| `neo4j-bolt-uri` | (output from neo4j-db module) | All Cloud Run services |
+| `pusher-key` | `pusher_key` | audit-service |
+| `pusher-app-id` | `pusher_app_id` | audit-service |
+| `pusher-cluster` | `pusher_cluster` | audit-service |
+| `pusher-secret` | `pusher_secret` | audit-service |
+| `smtp-username` | `smtp_username` | (secrets module) |
+| `smtp-password` | `smtp_password` | (secrets module) |
+
+---
+
+### PubSub Topics (auto-created)
+
+Terraform creates these Pub/Sub topics and wires them to Cloud Run services via push subscriptions:
+
+| Topic Name | Spring Property | Services |
+|---|---|---|
+| `url` | `pubsub.url_topic` | API (publisher), Page Builder (subscriber) |
+| `page_created` | `pubsub.page_built` | Page Builder (publisher), Audit Manager (subscriber) |
+| `page_audit` | `pubsub.page_audit_topic` | Audit Manager (publisher), Audit Service / Content Audit / Visual Design Audit / Info Architecture Audit (subscribers) |
+| `journey_verified` | `pubsub.journey_verified` | Page Builder (publisher), Journey Expander (subscriber) |
+| `journey_discarded` | `pubsub.discarded_journey_topic` | API, Journey Executor |
+| `audit_error` | `pubsub.error_topic` | All services (publisher) |
+| `audit_update` | `pubsub.audit_update` | Audit Manager, Audit Service, Content Audit, Visual Design Audit, Info Architecture Audit |
+| `journey_candidate` | `pubsub.journey_candidate` | Journey Expander (publisher), Journey Executor (subscriber) |
+| `journey_completion_cleanup` | — | (topic created, not yet wired) |
+
+---
+
+### Application-Level Properties (Spring Boot)
+
+These properties are set in each service's `application.properties` / `application.yml` files. Most are wired automatically by Terraform, but the following are **not currently managed by Terraform** and may need manual configuration or additional secrets if used in production:
+
+| Property | Service(s) | Notes |
+|---|---|---|
+| `stripe.secretKey` | CrawlerAPI | Stripe payment API key |
+| `stripe.agency_basic_price_id` | CrawlerAPI | Stripe price ID |
+| `stripe.agency_pro_price_id` | CrawlerAPI | Stripe price ID |
+| `stripe.company_basic_price_id` | CrawlerAPI | Stripe price ID |
+| `stripe.company_pro_price_id` | CrawlerAPI | Stripe price ID |
+| `stripe.checkout_success_url` | CrawlerAPI | Checkout redirect URL |
+| `stripe.checkout_cancel_url` | CrawlerAPI | Checkout redirect URL |
+| `segment.analytics.writeKey` | CrawlerAPI | Segment analytics write key |
+| `gcp.api.key` | PageBuilder | Google Cloud Vision API key |
+| `integrations.encryption.key` | CrawlerAPI | AES-GCM encryption key for integration configs |
+| `spring.mail.host` | CrawlerAPI | SMTP host (only user/pass are in Terraform) |
+| `spring.sendgrid.api-key` | CrawlerAPI | SendGrid API key (if used instead of SMTP) |
+
+#### Properties Wired Automatically by Terraform
+
+These are injected into Cloud Run containers as environment variables or Secret Manager references:
+
+| Property | How It's Set |
+|---|---|
+| `spring.data.neo4j.uri` | Secret Manager reference |
+| `spring.data.neo4j.username` | Secret Manager reference |
+| `spring.data.neo4j.password` | Secret Manager reference |
+| `spring.data.neo4j.database` | Secret Manager reference |
+| `spring.cloud.gcp.project-id` | Environment variable from `project_id` |
+| `spring.cloud.gcp.region` | Environment variable from `region` |
+| `pusher.key` | Secret Manager reference (audit-service only) |
+| `pusher.appId` | Secret Manager reference (audit-service only) |
+| `pusher.cluster` | Secret Manager reference (audit-service only) |
+| `pusher.secret` | Secret Manager reference (audit-service only) |
+| `pubsub.*` topics | Environment variables from Pub/Sub module outputs |
+| `SELENIUM_URLS` | Environment variable from Selenium module outputs |
+
+---
+
+### GitHub Actions Secrets Reference
+
+Below is the complete list of GitHub Actions secrets to configure. Each secret maps to a `TF_VAR_` environment variable in your Terraform workflow.
+
+#### Required Secrets
+
+| GitHub Secret Name | Maps To | Example Value |
+|---|---|---|
+| `TF_VAR_PROJECT_ID` | `TF_VAR_project_id` | `my-gcp-project-123` |
+| `TF_VAR_VPC_NAME` | `TF_VAR_vpc_name` | `looksee-vpc` |
+| `TF_VAR_SUBNET_CIDR` | `TF_VAR_subnet_cidr` | `10.0.0.0/24` |
+| `TF_VAR_LABELS` | `TF_VAR_labels` | `{"team":"platform","app":"looksee"}` |
+| `TF_VAR_NEO4J_PASSWORD` | `TF_VAR_neo4j_password` | (sensitive) |
+| `TF_VAR_NEO4J_USERNAME` | `TF_VAR_neo4j_username` | `neo4j` |
+| `TF_VAR_NEO4J_DB_NAME` | `TF_VAR_neo4j_db_name` | `neo4j` |
+| `TF_VAR_NEO4J_BOLT_URI` | `TF_VAR_neo4j_bolt_uri` | `bolt://10.0.0.5:7687` |
+| `TF_VAR_AUTH0_CLIENT_ID` | `TF_VAR_auth0_client_id` | (sensitive) |
+| `TF_VAR_AUTH0_CLIENT_SECRET` | `TF_VAR_auth0_client_secret` | (sensitive) |
+| `TF_VAR_AUTH0_DOMAIN` | `TF_VAR_auth0_domain` | `look-see.us.auth0.com` |
+| `TF_VAR_AUTH0_AUDIENCE` | `TF_VAR_auth0_audience` | `https://api.look-see.com` |
+| `TF_VAR_PUSHER_KEY` | `TF_VAR_pusher_key` | (sensitive) |
+| `TF_VAR_PUSHER_APP_ID` | `TF_VAR_pusher_app_id` | `1149968` |
+| `TF_VAR_PUSHER_CLUSTER` | `TF_VAR_pusher_cluster` | `us2` |
+| `TF_VAR_PUSHER_SECRET` | `TF_VAR_pusher_secret` | (sensitive) |
+| `TF_VAR_SMTP_USERNAME` | `TF_VAR_smtp_username` | (sensitive) |
+| `TF_VAR_SMTP_PASSWORD` | `TF_VAR_smtp_password` | (sensitive) |
+
+#### GCP Authentication Secrets (pick one approach)
+
+| GitHub Secret Name | Purpose |
+|---|---|
+| `GCP_WORKLOAD_IDENTITY_PROVIDER` | Workload Identity Federation provider (recommended) |
+| `GCP_SERVICE_ACCOUNT_EMAIL` | Service account email for WIF |
+| *or* `GCP_SA_KEY` | Base64-encoded service account JSON key (alternative) |
+
+#### Docker Hub Secrets (for CI image push)
+
+| GitHub Secret Name | Purpose |
+|---|---|
+| `DOCKER_USERNAME` | Docker Hub username (already configured in existing workflows) |
+| `DOCKER_PASSWORD` | Docker Hub password/token (already configured in existing workflows) |
+
+#### Example GitHub Actions Workflow Snippet
+
+```yaml
+jobs:
+  terraform:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: LookseeIaC/GCP
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Authenticate to GCP
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT_EMAIL }}
+
+      - uses: hashicorp/setup-terraform@v3
+
+      - name: Terraform Init
+        run: terraform init
+
+      - name: Terraform Plan
+        run: terraform plan -out=tf.plan
+        env:
+          TF_VAR_project_id: ${{ secrets.TF_VAR_PROJECT_ID }}
+          TF_VAR_region: "us-central1"
+          TF_VAR_environment: "dev"
+          TF_VAR_vpc_name: ${{ secrets.TF_VAR_VPC_NAME }}
+          TF_VAR_subnet_cidr: ${{ secrets.TF_VAR_SUBNET_CIDR }}
+          TF_VAR_labels: ${{ secrets.TF_VAR_LABELS }}
+          TF_VAR_neo4j_password: ${{ secrets.TF_VAR_NEO4J_PASSWORD }}
+          TF_VAR_neo4j_username: ${{ secrets.TF_VAR_NEO4J_USERNAME }}
+          TF_VAR_neo4j_db_name: ${{ secrets.TF_VAR_NEO4J_DB_NAME }}
+          TF_VAR_neo4j_bolt_uri: ${{ secrets.TF_VAR_NEO4J_BOLT_URI }}
+          TF_VAR_auth0_client_id: ${{ secrets.TF_VAR_AUTH0_CLIENT_ID }}
+          TF_VAR_auth0_client_secret: ${{ secrets.TF_VAR_AUTH0_CLIENT_SECRET }}
+          TF_VAR_auth0_domain: ${{ secrets.TF_VAR_AUTH0_DOMAIN }}
+          TF_VAR_auth0_audience: ${{ secrets.TF_VAR_AUTH0_AUDIENCE }}
+          TF_VAR_pusher_key: ${{ secrets.TF_VAR_PUSHER_KEY }}
+          TF_VAR_pusher_app_id: ${{ secrets.TF_VAR_PUSHER_APP_ID }}
+          TF_VAR_pusher_cluster: ${{ secrets.TF_VAR_PUSHER_CLUSTER }}
+          TF_VAR_pusher_secret: ${{ secrets.TF_VAR_PUSHER_SECRET }}
+          TF_VAR_smtp_username: ${{ secrets.TF_VAR_SMTP_USERNAME }}
+          TF_VAR_smtp_password: ${{ secrets.TF_VAR_SMTP_PASSWORD }}
+
+      - name: Terraform Apply
+        if: github.ref == 'refs/heads/main'
+        run: terraform apply tf.plan
+```
+
+---
+
+### Known Gaps
+
+1. **No remote backend configured.** The Terraform code has no `terraform {}` block with a backend. Without a remote backend (e.g. GCS bucket), state is lost between GitHub Actions runs. A GCS backend must be added to `LookseeIaC/GCP/`.
+
+2. **Auth0 secrets are accepted but never created.** The secrets module accepts `auth0_client_id`, `auth0_client_secret`, `auth0_domain`, and `auth0_audience` as input variables but does not create corresponding `google_secret_manager_secret` resources or outputs. Auth0 configuration is not wired to any Cloud Run service.
+
+3. **Stripe, Segment, and integration keys are not in Terraform.** These are only set in Spring Boot application property files and would need to be added to the secrets module if they should be managed as infrastructure.


### PR DESCRIPTION
## Summary
This PR extends the LookseeIaC GCP Terraform deployment configuration to support Auth0 authentication, optional GCP API keys, and additional SMTP settings. It also refactors the Cloud Run service environment variable handling to use a dynamic, centralized approach backed by Secret Manager.

## Key Changes

- **Auth0 Integration**: Added four new required Terraform variables (`auth0_client_id`, `auth0_client_secret`, `auth0_domain`, `auth0_audience`) with corresponding GCP Secret Manager resources and IAM bindings. These secrets are automatically wired into the API Cloud Run service.

- **Optional Configuration Variables**: Introduced three new optional variables with empty string defaults:
  - `gcp_api_key` – Google Cloud Vision/PageSpeed Insights API key
  - `integrations_encryption_key` – AES-GCM encryption key for integration configs
  - `smtp_host` – SMTP server hostname (complements existing `smtp_username`/`smtp_password`)

- **Refactored Environment Variable Handling**: Replaced hardcoded Neo4j secret references in the API module with a dynamic `environment_variables` map that accepts Secret Manager references. This centralizes secret wiring in `modules.tf` and makes it easier to add new secrets without modifying service modules.

- **Terraform Backend Configuration**: Added `versions.tf` with GCS backend configuration that requires bucket and prefix values to be provided at init time via `-backend-config` flags, preventing credentials from being committed to the repository.

- **Comprehensive Documentation**: Expanded README with detailed deployment guide covering:
  - Required and optional Terraform variables with descriptions and examples
  - Container image registry configuration
  - GCP APIs to enable
  - GCP Secret Manager and Pub/Sub topic mappings
  - Spring Boot application properties (both auto-wired and manual)
  - GitHub Actions secrets reference with example workflow snippet
  - Terraform backend setup instructions

## Implementation Details

- Conditional secret creation using `count` for optional variables (only created if non-empty)
- Consistent use of `secret_data_wo` attribute for sensitive values
- IAM bindings automatically grant the service account `secretmanager.secretAccessor` role for all secrets
- Environment variables passed as `[secret_name, key_version]` tuples to support dynamic Secret Manager references
- Merge operations in `modules.tf` allow optional secrets to be conditionally included in service configurations

https://claude.ai/code/session_01UWBQXr94P51Dro4PHXuStM