### PR TITLE
Add accessibility audit UI flow with landing page and visual issue map

### DIFF
--- a/Look-see-UI-v3/src/app/app-routing.module.ts
+++ b/Look-see-UI-v3/src/app/app-routing.module.ts
@@ -5,37 +5,21 @@ import { AuditDashboardComponent } from './components/audit-dashboard/audit-dash
 import { AuditListComponent } from './components/audit-list/audit-list.component';
 import { DomainsComponent } from './components/domains/domains.component';
 import { HowItWorksComponent } from './components/how-it-works/how-it-works.component';
+import { LandingComponent } from './components/landing/landing.component';
 import { PageAuditReviewComponent } from './components/page-audit-review/page-audit-review.component';
 
 import { IntegrationsPanelComponent } from './integrations-panel/integrations-panel.component';
 import { UserProfileComponent } from './user-profile/user-profile.component';
 
-/*
 const routes: Routes = [
-  //{ path: '', component:QuickAuditComponent }, 
-  { path: 'dashboard', component: AuditRecordsComponent },
-  //{ path: 'how-it-works', component: HowItWorksComponent},
-  //{ path: 'domains', component: DomainsComponent},
-  //{ path: 'domains/:domain_id', component: DomainDetailsComponent, canActivate: [AuthGuard]},
-  { path: 'account', component: UserProfileComponent, canActivate: [AuthGuard]},
-  //{ path: 'settings', component: SettingsComponent, canActivate: [AuthGuard]},
-  //{ path: 'domains/:domain_id/settings', component: DomainSettingsComponent, canActivate: [AuthGuard]},
-  //{ path: 'domains/:domain_id/policies', component: DomainSettingsComponent, canActivate: [AuthGuard]},
-  //{ path: 'plans/agency', component: SubscriptionAgencyComponent},
-  //{ path: 'plans/saas', component: SubscriptionCompanyComponent},
-  { path: 'plans', component: UpgradeSubscriptionComponent},
-  //{ path: 'portal', component: FeaturePortalComponent}
-];
-*/
-
-const routes: Routes = [
-  { path: '', redirectTo:'audit', pathMatch: 'full' },
+  { path: '', component: LandingComponent },
   { path: 'dashboard', component: AuditDashboardComponent },
   { path: 'account', component: UserProfileComponent, canActivate: [AuthGuard]},
 
   { path: 'domains', component: DomainsComponent, canActivate: [AuthGuard]},
   { path: 'audit', component: AuditListComponent, canActivate: [AuthGuard]},
   { path: 'audit/:id/page', component: PageAuditReviewComponent, canActivate: [AuthGuard]},
+  { path: 'audit/:id/review', component: PageAuditReviewComponent },
   { path: 'audit/:id/domain', component: AuditDashboardComponent, canActivate: [AuthGuard]},
   { path: 'how-it-works', component: HowItWorksComponent},
   { path: 'integration', component: IntegrationsPanelComponent}

--- a/Look-see-UI-v3/src/app/app.component.html
+++ b/Look-see-UI-v3/src/app/app.component.html
@@ -1,6 +1,7 @@
 <div class="relative flex top-0 left-0 w-full h-screen">
-    <app-nav-bar id="nav-bar" class="hidden sm:block"></app-nav-bar>
-    <main class="flex-1 h-full overflow-y-auto bg-gray-50 sm:ml-64">
+    <app-nav-bar id="nav-bar" class="hidden sm:block" *ngIf="!isLandingPage && !isReviewPage"></app-nav-bar>
+    <main class="flex-1 h-full overflow-y-auto bg-gray-50"
+          [ngClass]="{'sm:ml-64': !isLandingPage && !isReviewPage}">
         <router-outlet></router-outlet>
     </main>
 </div>
@@ -31,7 +32,7 @@
 
 <!-- Beta acknowledgment modal -->
 <div class="modal modal-active fixed w-full h-full top-0 left-0 flex items-center justify-center z-30"
-     *ngIf="(this.auth.isAuthenticated$ | async) && !isBetaAcknowledged">
+     *ngIf="(this.auth.isAuthenticated$ | async) && !isBetaAcknowledged && !isLandingPage">
     <div class="modal-overlay absolute w-full h-full bg-gray-900/60 backdrop-blur-sm z-50"></div>
     <section class="modal-container bg-white w-[90vw] max-w-lg rounded-2xl shadow-elevated overflow-hidden z-50 animate-fade-in">
         <header class="px-6 pt-6 pb-2">

--- a/Look-see-UI-v3/src/app/app.component.ts
+++ b/Look-see-UI-v3/src/app/app.component.ts
@@ -1,7 +1,8 @@
 import { Component, OnInit, inject } from '@angular/core';
-import { Router } from '@angular/router';
+import { NavigationEnd, Router } from '@angular/router';
 import { AuthService } from '@auth0/auth0-angular';
 import { initFlowbite } from 'flowbite';
+import { filter } from 'rxjs/operators';
 import { environment as env } from '../environments/environment';
 import { SegmentIOService } from './services/segmentio.service';
 
@@ -13,9 +14,10 @@ import { SegmentIOService } from './services/segmentio.service';
 })
 export class AppComponent implements OnInit{
   isBetaAcknowledged = false;
-
   isMobileDevice = false;
-  env = env
+  isLandingPage = false;
+  isReviewPage = false;
+  env = env;
 
   router = inject(Router);
   auth = inject(AuthService);
@@ -29,7 +31,13 @@ export class AppComponent implements OnInit{
       this.isBetaAcknowledged = JSON.parse(sessionStorage.getItem("isBetaAcknowledged") || "false")
     }
 
-
+    this.router.events.pipe(
+      filter(event => event instanceof NavigationEnd)
+    ).subscribe((event) => {
+      const navEvent = event as NavigationEnd;
+      this.isLandingPage = navEvent.urlAfterRedirects === '/' || navEvent.urlAfterRedirects === '';
+      this.isReviewPage = navEvent.urlAfterRedirects.includes('/review');
+    });
   }
 
   ngOnInit(): void {

--- a/Look-see-UI-v3/src/app/app.module.ts
+++ b/Look-see-UI-v3/src/app/app.module.ts
@@ -35,10 +35,12 @@ import { AppComponent } from './app.component';
 import { AuditDashboardComponent } from './components/audit-dashboard/audit-dashboard.component';
 import { AuditFormComponent } from './components/audit-form/audit-form.component';
 import { AuditListComponent } from './components/audit-list/audit-list.component';
+import { AuditOnboardingComponent } from './components/audit-onboarding/audit-onboarding.component';
 import { AuthButtonComponent } from './components/auth-button/auth-button.component';
 import { DomainsComponent } from './components/domains/domains.component';
 import { FooterComponent } from './components/footer/footer.component';
 import { HowItWorksComponent } from './components/how-it-works/how-it-works.component';
+import { LandingComponent } from './components/landing/landing.component';
 import { LoadingComponent } from './components/loading/loading.component';
 import { NavBarComponent } from './components/nav-bar/nav-bar.component';
 import { PageAuditReviewComponent } from './components/page-audit-review/page-audit-review.component';
@@ -76,6 +78,8 @@ import { UserProfileComponent } from './user-profile/user-profile.component';
     FooterComponent,
     MatchesCategoryPipe,
 
+    LandingComponent,
+    AuditOnboardingComponent,
 
     AuditFormComponent,
     PageAuditReviewComponent,
@@ -121,13 +125,13 @@ import { UserProfileComponent } from './user-profile/user-profile.component';
   bootstrap: [AppComponent]
 })
 
-export class AppModule { 
+export class AppModule {
   constructor(library: FaIconLibrary, public auth_service: AuthService) {
     library.addIconPacks(fas);
     library.addIcons(
-      faSquare, 
-      faCheckSquare, 
-      farSquare, 
+      faSquare,
+      faCheckSquare,
+      farSquare,
       farCheckSquare,
       faInfoCircle,
       faCircleCheck,
@@ -151,6 +155,3 @@ export class AppModule {
     });
   }
 }
-
-
-

--- a/Look-see-UI-v3/src/app/components/audit-onboarding/audit-onboarding.component.html
+++ b/Look-see-UI-v3/src/app/components/audit-onboarding/audit-onboarding.component.html
@@ -104,14 +104,15 @@
 
                 <!-- Carousel dots -->
                 <div class="flex items-center gap-1.5 mt-4">
-                    <div *ngFor="let preview of featurePreviews; let i = index"
-                         class="h-1 rounded-full transition-all duration-300 cursor-pointer"
-                         [ngClass]="{
-                             'w-6 bg-brand-400': i === currentFeatureIndex,
-                             'w-1.5 bg-white/20': i !== currentFeatureIndex
-                         }"
-                         (click)="currentFeatureIndex = i">
-                    </div>
+                    <button *ngFor="let preview of featurePreviews; let i = index"
+                            class="h-1 rounded-full transition-all duration-300 cursor-pointer border-0 p-0"
+                            [ngClass]="{
+                                'w-6 bg-brand-400': i === currentFeatureIndex,
+                                'w-1.5 bg-white/20': i !== currentFeatureIndex
+                            }"
+                            (click)="currentFeatureIndex = i"
+                            [attr.aria-label]="'Show feature ' + (i + 1)">
+                    </button>
                 </div>
             </div>
 

--- a/Look-see-UI-v3/src/app/components/audit-onboarding/audit-onboarding.component.html
+++ b/Look-see-UI-v3/src/app/components/audit-onboarding/audit-onboarding.component.html
@@ -1,0 +1,136 @@
+<div class="h-full flex flex-col bg-gray-50">
+
+    <!-- Header -->
+    <div class="px-6 py-5 bg-white border-b border-gray-200">
+        <div class="flex items-center gap-3">
+            <div class="w-8 h-8 rounded-lg bg-brand-50 flex items-center justify-center">
+                <svg class="w-4 h-4 text-brand-500 animate-spin" fill="none" viewBox="0 0 24 24">
+                    <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+                    <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+                </svg>
+            </div>
+            <div>
+                <h2 class="text-lg font-semibold text-gray-900">Analyzing your website</h2>
+                <p class="text-sm text-gray-500 truncate max-w-md">{{ url }}</p>
+            </div>
+        </div>
+    </div>
+
+    <div class="flex-1 overflow-y-auto">
+        <div class="max-w-3xl mx-auto px-6 py-8">
+
+            <!-- Progress Steps -->
+            <div class="space-y-1 mb-10">
+                <div *ngFor="let step of steps; let i = index; let last = last"
+                     class="flex items-start gap-4">
+
+                    <!-- Step indicator -->
+                    <div class="flex flex-col items-center">
+                        <div class="w-8 h-8 rounded-full flex items-center justify-center flex-shrink-0 transition-all duration-500"
+                             [ngClass]="{
+                                 'bg-emerald-500 text-white': step.status === 'complete',
+                                 'bg-brand-500 text-white ring-4 ring-brand-100': step.status === 'active',
+                                 'bg-gray-200 text-gray-400': step.status === 'pending'
+                             }">
+                            <!-- Complete checkmark -->
+                            <svg *ngIf="step.status === 'complete'" class="w-4 h-4" fill="currentColor" viewBox="0 0 20 20">
+                                <path fill-rule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clip-rule="evenodd"/>
+                            </svg>
+                            <!-- Active spinner -->
+                            <svg *ngIf="step.status === 'active'" class="w-4 h-4 animate-spin" fill="none" viewBox="0 0 24 24">
+                                <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+                                <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"></path>
+                            </svg>
+                            <!-- Pending number -->
+                            <span *ngIf="step.status === 'pending'" class="text-xs font-semibold">{{ i + 1 }}</span>
+                        </div>
+                        <!-- Connector line -->
+                        <div *ngIf="!last" class="w-0.5 h-8 mt-1 transition-colors duration-500"
+                             [ngClass]="{
+                                 'bg-emerald-300': step.status === 'complete',
+                                 'bg-gray-200': step.status !== 'complete'
+                             }">
+                        </div>
+                    </div>
+
+                    <!-- Step content -->
+                    <div class="pb-6 pt-1">
+                        <h4 class="text-sm font-semibold transition-colors duration-300"
+                            [ngClass]="{
+                                'text-emerald-700': step.status === 'complete',
+                                'text-gray-900': step.status === 'active',
+                                'text-gray-400': step.status === 'pending'
+                            }">
+                            {{ step.title }}
+                        </h4>
+                        <p class="text-xs mt-0.5 transition-colors duration-300"
+                           [ngClass]="{
+                               'text-emerald-600': step.status === 'complete',
+                               'text-gray-500': step.status === 'active',
+                               'text-gray-400': step.status === 'pending'
+                           }">
+                            {{ step.description }}
+                        </p>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Feature Preview Carousel -->
+            <div class="card p-6 bg-gradient-to-br from-charcoal-950 to-charcoal-900 border-0">
+                <div class="flex items-center gap-2 mb-4">
+                    <svg class="w-4 h-4 text-brand-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 10V3L4 14h7v7l9-11h-7z"/>
+                    </svg>
+                    <span class="text-xs font-semibold text-white/60 uppercase tracking-wider">What you'll see</span>
+                </div>
+
+                <div class="min-h-[80px]">
+                    <div *ngFor="let preview of featurePreviews; let i = index">
+                        <div *ngIf="i === currentFeatureIndex" class="animate-fade-in">
+                            <div class="flex items-start gap-4">
+                                <div class="w-10 h-10 rounded-xl bg-white/10 flex items-center justify-center flex-shrink-0 mt-0.5">
+                                    <svg class="w-5 h-5 text-brand-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" [attr.d]="getFeatureIcon(preview)"/>
+                                    </svg>
+                                </div>
+                                <div>
+                                    <h4 class="text-sm font-semibold text-white">{{ preview.title }}</h4>
+                                    <p class="text-xs text-white/60 mt-1 leading-relaxed">{{ preview.description }}</p>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Carousel dots -->
+                <div class="flex items-center gap-1.5 mt-4">
+                    <div *ngFor="let preview of featurePreviews; let i = index"
+                         class="h-1 rounded-full transition-all duration-300 cursor-pointer"
+                         [ngClass]="{
+                             'w-6 bg-brand-400': i === currentFeatureIndex,
+                             'w-1.5 bg-white/20': i !== currentFeatureIndex
+                         }"
+                         (click)="currentFeatureIndex = i">
+                    </div>
+                </div>
+            </div>
+
+            <!-- Audit Complete CTA -->
+            <div *ngIf="auditComplete" class="mt-8 text-center animate-fade-in">
+                <div class="card p-8 border-emerald-200 bg-emerald-50">
+                    <div class="w-14 h-14 rounded-full bg-emerald-100 flex items-center justify-center mx-auto mb-4">
+                        <svg class="w-7 h-7 text-emerald-600" fill="currentColor" viewBox="0 0 20 20">
+                            <path fill-rule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clip-rule="evenodd"/>
+                        </svg>
+                    </div>
+                    <h3 class="text-lg font-semibold text-emerald-900 mb-1">Audit Complete</h3>
+                    <p class="text-sm text-emerald-700 mb-5">Your accessibility report is ready to review.</p>
+                    <button class="btn-accent px-8 py-3 text-sm font-semibold" (click)="onViewResults()">
+                        View Results
+                    </button>
+                </div>
+            </div>
+
+        </div>
+    </div>
+</div>

--- a/Look-see-UI-v3/src/app/components/audit-onboarding/audit-onboarding.component.scss
+++ b/Look-see-UI-v3/src/app/components/audit-onboarding/audit-onboarding.component.scss
@@ -1,0 +1,8 @@
+@keyframes fade-in {
+    from { opacity: 0; transform: translateY(8px); }
+    to { opacity: 1; transform: translateY(0); }
+}
+
+.animate-fade-in {
+    animation: fade-in 0.4s ease-out;
+}

--- a/Look-see-UI-v3/src/app/components/audit-onboarding/audit-onboarding.component.ts
+++ b/Look-see-UI-v3/src/app/components/audit-onboarding/audit-onboarding.component.ts
@@ -1,0 +1,172 @@
+import { Component, EventEmitter, Input, OnChanges, OnDestroy, OnInit, Output, SimpleChanges } from '@angular/core';
+
+interface OnboardingStep {
+  id: string;
+  title: string;
+  description: string;
+  icon: string;
+  status: 'pending' | 'active' | 'complete';
+}
+
+interface FeaturePreview {
+  title: string;
+  description: string;
+  icon: string;
+}
+
+@Component({
+  selector: 'app-audit-onboarding',
+  templateUrl: './audit-onboarding.component.html',
+  styleUrls: ['./audit-onboarding.component.scss']
+})
+export class AuditOnboardingComponent implements OnInit, OnDestroy, OnChanges {
+  @Input() url = '';
+  @Input() auditStarted = false;
+  @Input() auditComplete = false;
+  @Output() viewResults = new EventEmitter<void>();
+
+  steps: OnboardingStep[] = [
+    {
+      id: 'capture',
+      title: 'Capturing Page',
+      description: 'Taking a screenshot and extracting DOM elements from your page',
+      icon: 'camera',
+      status: 'pending'
+    },
+    {
+      id: 'content',
+      title: 'Content Analysis',
+      description: 'Evaluating readability, alt text, and written content quality',
+      icon: 'document',
+      status: 'pending'
+    },
+    {
+      id: 'accessibility',
+      title: 'Accessibility Check',
+      description: 'Testing WCAG compliance, color contrast, ARIA labels, and semantic HTML',
+      icon: 'accessibility',
+      status: 'pending'
+    },
+    {
+      id: 'visual',
+      title: 'Visual Design Review',
+      description: 'Analyzing typography, whitespace, branding, and color palette',
+      icon: 'palette',
+      status: 'pending'
+    },
+    {
+      id: 'architecture',
+      title: 'Information Architecture',
+      description: 'Checking SEO, metadata, link structure, and navigation',
+      icon: 'sitemap',
+      status: 'pending'
+    }
+  ];
+
+  featurePreviews: FeaturePreview[] = [
+    {
+      title: 'Visual Issue Map',
+      description: 'See accessibility issues pinpointed directly on a screenshot of your page. Each issue is marked exactly where it occurs.',
+      icon: 'map'
+    },
+    {
+      title: 'Non-Visual Issue Report',
+      description: 'Metadata problems, SEO issues, and other non-rendered HTML problems are grouped in a dedicated panel.',
+      icon: 'code'
+    },
+    {
+      title: 'AI-Powered Fix Suggestions',
+      description: 'For each issue, get intelligent recommendations and code snippets to resolve it quickly.',
+      icon: 'sparkle'
+    },
+    {
+      title: 'Exportable PDF Report',
+      description: 'Download a comprehensive PDF report with all findings, scores, and recommendations to share with your team.',
+      icon: 'download'
+    }
+  ];
+
+  currentFeatureIndex = 0;
+  stepTimerIds: ReturnType<typeof setTimeout>[] = [];
+  featureRotationId: ReturnType<typeof setInterval> | undefined;
+
+  ngOnInit(): void {
+    if (this.auditStarted) {
+      this.startProgressSimulation();
+      this.startFeatureRotation();
+    }
+  }
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes['auditStarted'] && this.auditStarted) {
+      this.startProgressSimulation();
+      this.startFeatureRotation();
+    }
+    if (changes['auditComplete'] && this.auditComplete) {
+      this.completeAllSteps();
+    }
+  }
+
+  ngOnDestroy(): void {
+    this.stepTimerIds.forEach(id => clearTimeout(id));
+    if (this.featureRotationId) {
+      clearInterval(this.featureRotationId);
+    }
+  }
+
+  startProgressSimulation(): void {
+    // Simulate step progression with realistic timing
+    const delays = [0, 3000, 7000, 12000, 18000];
+
+    this.steps.forEach((step, index) => {
+      // Mark as active
+      const activeTimer = setTimeout(() => {
+        step.status = 'active';
+      }, delays[index]);
+      this.stepTimerIds.push(activeTimer);
+
+      // Mark as complete (except last step - that completes when audit finishes)
+      if (index < this.steps.length - 1) {
+        const completeTimer = setTimeout(() => {
+          step.status = 'complete';
+        }, delays[index + 1]);
+        this.stepTimerIds.push(completeTimer);
+      }
+    });
+  }
+
+  startFeatureRotation(): void {
+    this.featureRotationId = setInterval(() => {
+      this.currentFeatureIndex = (this.currentFeatureIndex + 1) % this.featurePreviews.length;
+    }, 5000);
+  }
+
+  completeAllSteps(): void {
+    this.steps.forEach(step => step.status = 'complete');
+  }
+
+  onViewResults(): void {
+    this.viewResults.emit();
+  }
+
+  getStepIcon(step: OnboardingStep): string {
+    switch (step.icon) {
+      case 'camera': return 'M3 9a2 2 0 012-2h.93a2 2 0 001.664-.89l.812-1.22A2 2 0 0110.07 4h3.86a2 2 0 011.664.89l.812 1.22A2 2 0 0018.07 7H19a2 2 0 012 2v9a2 2 0 01-2 2H5a2 2 0 01-2-2V9z M15 13a3 3 0 11-6 0 3 3 0 016 0z';
+      case 'document': return 'M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z';
+      case 'accessibility': return 'M12 4.354a4 4 0 110 5.292M15 21H3v-1a6 6 0 0112 0v1zm0 0h6v-1a6 6 0 00-9-5.197M13 7a4 4 0 11-8 0 4 4 0 018 0z';
+      case 'palette': return 'M7 21a4 4 0 01-4-4V5a2 2 0 012-2h4a2 2 0 012 2v12a4 4 0 01-4 4zm0 0h12a2 2 0 002-2v-4a2 2 0 00-2-2h-2.343M11 7.343l1.657-1.657a2 2 0 012.828 0l2.829 2.829a2 2 0 010 2.828l-8.486 8.485M7 17h.01';
+      case 'sitemap': return 'M4 5a1 1 0 011-1h14a1 1 0 011 1v2a1 1 0 01-1 1H5a1 1 0 01-1-1V5zM4 13a1 1 0 011-1h6a1 1 0 011 1v6a1 1 0 01-1 1H5a1 1 0 01-1-1v-6zM16 13a1 1 0 011-1h2a1 1 0 011 1v6a1 1 0 01-1 1h-2a1 1 0 01-1-1v-6z';
+      default: return '';
+    }
+  }
+
+  getFeatureIcon(preview: FeaturePreview): string {
+    switch (preview.icon) {
+      case 'map': return 'M9 20l-5.447-2.724A1 1 0 013 16.382V5.618a1 1 0 011.447-.894L9 7m0 13l6-3m-6 3V7m6 10l4.553 2.276A1 1 0 0021 18.382V7.618a1 1 0 00-.553-.894L15 4m0 13V4m0 0L9 7';
+      case 'code': return 'M10 20l4-16m4 4l4 4-4 4M6 16l-4-4 4-4';
+      case 'sparkle': return 'M5 3v4M3 5h4M6 17v4m-2-2h4m5-16l2.286 6.857L21 12l-5.714 2.143L13 21l-2.286-6.857L5 12l5.714-2.143L13 3z';
+      case 'download': return 'M12 10v6m0 0l-3-3m3 3l3-3m2 8H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z';
+      default: return '';
+    }
+  }
+}

--- a/Look-see-UI-v3/src/app/components/landing/landing.component.html
+++ b/Look-see-UI-v3/src/app/components/landing/landing.component.html
@@ -1,0 +1,112 @@
+<div class="min-h-screen bg-gradient-to-br from-charcoal-950 via-charcoal-900 to-charcoal-950 flex flex-col">
+
+    <!-- Top bar -->
+    <header class="flex items-center justify-between px-8 py-5">
+        <div class="flex items-center gap-3">
+            <div class="w-9 h-9 rounded-lg bg-brand-500 flex items-center justify-center">
+                <svg class="w-5 h-5 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"/>
+                </svg>
+            </div>
+            <span class="text-xl font-semibold text-white tracking-tight">Look-see</span>
+        </div>
+        <div>
+            <app-auth-button></app-auth-button>
+        </div>
+    </header>
+
+    <!-- Hero section -->
+    <main class="flex-1 flex flex-col items-center justify-center px-6 -mt-16">
+        <!-- Badge -->
+        <div class="inline-flex items-center gap-2 px-3 py-1.5 rounded-full bg-white/10 border border-white/10 mb-8">
+            <span class="w-2 h-2 rounded-full bg-brand-500 animate-pulse"></span>
+            <span class="text-xs font-medium text-white/80">AI-Powered Accessibility Audits</span>
+        </div>
+
+        <!-- Headline -->
+        <h1 class="text-5xl md:text-6xl font-semibold text-white text-center max-w-3xl leading-tight tracking-tight">
+            Find and fix accessibility issues
+            <span class="text-brand-400">in seconds</span>
+        </h1>
+
+        <p class="mt-5 text-lg text-white/60 text-center max-w-xl leading-relaxed">
+            Enter any URL and get a comprehensive audit of accessibility, content quality, and visual design — with AI-powered fix suggestions.
+        </p>
+
+        <!-- URL Input Form -->
+        <form [formGroup]="form" (ngSubmit)="startAudit()" class="w-full max-w-2xl mt-10">
+            <div class="bg-white rounded-2xl p-2 shadow-elevated flex items-center gap-2">
+                <div class="flex-1 relative">
+                    <div class="absolute inset-y-0 left-0 flex items-center pl-4 pointer-events-none">
+                        <svg class="w-5 h-5 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 12a9 9 0 01-9 9m9-9a9 9 0 00-9-9m9 9H3m9 9a9 9 0 01-9-9m9 9c1.657 0 3-4.03 3-9s-1.343-9-3-9m0 18c-1.657 0-3-4.03-3-9s1.343-9 3-9m-9 9a9 9 0 019-9"/>
+                        </svg>
+                    </div>
+                    <input formControlName="url"
+                           type="text"
+                           placeholder="Enter a website URL (e.g. https://www.example.com)"
+                           class="w-full pl-12 pr-4 py-4 text-base bg-transparent border-0 focus:ring-0 focus:outline-none placeholder-gray-400 text-gray-900"
+                           (keydown.enter)="startAudit()" />
+                </div>
+                <button type="submit"
+                        class="btn-accent px-8 py-4 text-base font-semibold rounded-xl flex items-center gap-2 whitespace-nowrap"
+                        [disabled]="isLoading"
+                        [class.opacity-75]="isLoading">
+                    <span *ngIf="!isLoading">Start Audit</span>
+                    <span *ngIf="isLoading" class="flex items-center gap-2">
+                        <svg class="animate-spin h-5 w-5 text-white" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+                            <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+                            <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+                        </svg>
+                        Starting...
+                    </span>
+                </button>
+            </div>
+
+            <!-- Error message -->
+            <div *ngIf="error" class="mt-3 flex items-center gap-2 text-sm text-red-400">
+                <svg class="w-4 h-4 flex-shrink-0" fill="currentColor" viewBox="0 0 20 20">
+                    <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z" clip-rule="evenodd"/>
+                </svg>
+                {{ error }}
+            </div>
+        </form>
+
+        <!-- Feature highlights -->
+        <div class="grid grid-cols-3 gap-8 mt-16 max-w-2xl w-full">
+            <div class="text-center">
+                <div class="w-10 h-10 rounded-xl bg-white/10 flex items-center justify-center mx-auto mb-3">
+                    <svg class="w-5 h-5 text-brand-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"/>
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"/>
+                    </svg>
+                </div>
+                <h3 class="text-sm font-semibold text-white mb-1">Visual Issues</h3>
+                <p class="text-xs text-white/50 leading-relaxed">See issues pinpointed directly on your page screenshot</p>
+            </div>
+            <div class="text-center">
+                <div class="w-10 h-10 rounded-xl bg-white/10 flex items-center justify-center mx-auto mb-3">
+                    <svg class="w-5 h-5 text-brand-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z"/>
+                    </svg>
+                </div>
+                <h3 class="text-sm font-semibold text-white mb-1">AI Fix Suggestions</h3>
+                <p class="text-xs text-white/50 leading-relaxed">Get intelligent recommendations to resolve each issue</p>
+            </div>
+            <div class="text-center">
+                <div class="w-10 h-10 rounded-xl bg-white/10 flex items-center justify-center mx-auto mb-3">
+                    <svg class="w-5 h-5 text-brand-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 10v6m0 0l-3-3m3 3l3-3m2 8H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"/>
+                    </svg>
+                </div>
+                <h3 class="text-sm font-semibold text-white mb-1">PDF Reports</h3>
+                <p class="text-xs text-white/50 leading-relaxed">Export detailed reports with issues and recommendations</p>
+            </div>
+        </div>
+    </main>
+
+    <!-- Footer -->
+    <footer class="px-8 py-5 text-center">
+        <p class="text-xs text-white/30">WCAG 2.1 compliant auditing for content, accessibility, and visual design</p>
+    </footer>
+</div>

--- a/Look-see-UI-v3/src/app/components/landing/landing.component.scss
+++ b/Look-see-UI-v3/src/app/components/landing/landing.component.scss
@@ -1,0 +1,4 @@
+:host {
+    display: block;
+    height: 100vh;
+}

--- a/Look-see-UI-v3/src/app/components/landing/landing.component.ts
+++ b/Look-see-UI-v3/src/app/components/landing/landing.component.ts
@@ -38,7 +38,7 @@ export class LandingComponent {
 
     this.error = '';
     this.isLoading = true;
-    this.segmentio.sendDomainUxAuditStartedMessage(url);
+    this.segmentio.sendUxAuditStartedMessage(url);
 
     this.auditorService.startAudit(url, 'PAGE').subscribe(
       (data) => {

--- a/Look-see-UI-v3/src/app/components/landing/landing.component.ts
+++ b/Look-see-UI-v3/src/app/components/landing/landing.component.ts
@@ -1,0 +1,64 @@
+import { Component, inject } from '@angular/core';
+import { FormControl, FormGroup } from '@angular/forms';
+import { Router } from '@angular/router';
+import { AuthService } from '@auth0/auth0-angular';
+import { AuditorService } from '../../services/auditor.service';
+import { SegmentIOService } from '../../services/segmentio.service';
+
+@Component({
+  selector: 'app-landing',
+  templateUrl: './landing.component.html',
+  styleUrls: ['./landing.component.scss']
+})
+export class LandingComponent {
+  isLoading = false;
+  error = '';
+
+  form = new FormGroup({
+    url: new FormControl(''),
+  });
+
+  router = inject(Router);
+  auth = inject(AuthService);
+  auditorService = inject(AuditorService);
+  segmentio = inject(SegmentIOService);
+
+  startAudit(): void {
+    const url = this.form.value.url?.trim() || '';
+
+    if (!url.length) {
+      this.error = 'Please enter a URL to audit.';
+      return;
+    }
+
+    if (!this.isValidURL(url)) {
+      this.error = 'Please enter a valid URL (e.g. https://www.example.com)';
+      return;
+    }
+
+    this.error = '';
+    this.isLoading = true;
+    this.segmentio.sendDomainUxAuditStartedMessage(url);
+
+    this.auditorService.startAudit(url, 'PAGE').subscribe(
+      (data) => {
+        this.isLoading = false;
+        if (data && data.id) {
+          sessionStorage.setItem('audit_record_id', data.id.toString());
+          sessionStorage.setItem('is_audit_started', 'true');
+          sessionStorage.setItem('url', url.replace('https://', '').replace('http://', ''));
+          this.router.navigate(['/audit', data.id, 'review']);
+        }
+      },
+      () => {
+        this.error = 'Something went wrong starting the audit. Please try again.';
+        this.isLoading = false;
+      }
+    );
+  }
+
+  isValidURL(domain_url: string): boolean {
+    const urlregex = /^((https?|ftp):\/\/)?([a-zA-Z0-9.-]+(:[a-zA-Z0-9.&%$-]+)*@)*((25[0-5]|2[0-4][0-9]|1[0-9]{2}|[1-9][0-9]?)(\.(25[0-5]|2[0-4][0-9]|1[0-9]{2}|[1-9]?[0-9])){3}|([a-zA-Z0-9-]+\.)*[a-zA-Z0-9-]+\.(com|app|edu|gov|int|mil|net|org|biz|arpa|info|name|pro|aero|coop|museum|website|space|[a-zA-Z]{2}))(:[0-9]+)*(\/($|[a-zA-Z0-9.,?'\\+&%$#=~_-]+))*$/;
+    return urlregex.test(domain_url);
+  }
+}

--- a/Look-see-UI-v3/src/app/components/page-audit-review/page-audit-review.component.html
+++ b/Look-see-UI-v3/src/app/components/page-audit-review/page-audit-review.component.html
@@ -1,7 +1,7 @@
 <!-- Error banner -->
-<div *ngIf="errors.length" class="mx-6 mt-4">
+<div *ngIf="errors.length" class="fixed top-4 right-4 z-50 max-w-md">
     <div *ngFor="let error of errors"
-         class="flex items-center gap-3 px-4 py-3 rounded-lg bg-red-50 border border-red-200 text-red-700 text-sm mb-2">
+         class="flex items-center gap-3 px-4 py-3 rounded-lg bg-red-50 border border-red-200 text-red-700 text-sm mb-2 shadow-elevated">
         <svg class="w-5 h-5 flex-shrink-0" fill="currentColor" viewBox="0 0 20 20">
             <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z" clip-rule="evenodd"/>
         </svg>
@@ -9,431 +9,210 @@
     </div>
 </div>
 
-<!-- Loading state -->
-<div class="flex flex-col items-center justify-center h-[80vh]" *ngIf="!issue_element_map">
-    <mat-progress-spinner
-        class="mb-6"
-        [color]="color"
-        [mode]="mode"
-        [value]="value"
-        [diameter]="diameter">
-    </mat-progress-spinner>
-    <p class="text-sm text-gray-500 max-w-md text-center">
-        Evaluating your website. Results will appear here once the analysis is complete.
-    </p>
+<!-- ==================== ONBOARDING / LOADING STATE ==================== -->
+<div *ngIf="is_audit_started && !resultsReady" class="h-full">
+    <app-audit-onboarding
+        [url]="page.url"
+        [auditStarted]="is_audit_started"
+        [auditComplete]="resultsReady"
+        (viewResults)="showResults()">
+    </app-audit-onboarding>
 </div>
 
-<!-- Main audit results panel -->
-<div *ngIf="issue_element_map && audit_record_id"
-     class="grid grid-cols-12 h-[calc(100vh-2rem)]">
+<!-- ==================== RESULTS VIEW ==================== -->
+<div *ngIf="resultsReady && issue_element_map"
+     class="h-[100vh] flex flex-col">
 
-    <!-- LEFT PANEL: Issues & Scores -->
-    <div class="col-span-5 bg-gray-50 h-full flex flex-col border-r border-gray-200"
-         id="issue_details_panel">
+    <!-- Top toolbar -->
+    <div class="flex items-center gap-3 px-4 py-2.5 bg-white border-b border-gray-200 flex-shrink-0">
+        <!-- Back button -->
+        <button class="btn-ghost flex items-center gap-1.5 text-xs py-1.5 px-2" (click)="goBack()">
+            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7"/>
+            </svg>
+            Back
+        </button>
 
-        <!-- Top bar: Export + URL -->
-        <div class="flex items-center gap-3 px-4 py-3 border-b border-gray-200 bg-white">
-            <div *ngIf="!isLoading" class="flex-shrink-0">
-                <button class="btn-primary flex items-center gap-2 text-xs py-2 px-3"
-                        aria-label="You must login to export UX audit report"
-                        (click)="showLoginRequiredDialog()"
-                        *ngIf="(auth.isAuthenticated$ | async) === false && isLoading === false">
-                    <fa-icon [icon]="faDownload" size="sm"></fa-icon>
-                    Report
-                </button>
-                <button class="btn-primary flex items-center gap-2 text-xs py-2 px-3"
-                        aria-label="Click to export UX audit report for the current page"
-                        (click)="showReportDownloadDialog()"
-                        *ngIf="(auth.isAuthenticated$ | async) === true && isLoading === false">
-                    <fa-icon [icon]="faDownload" size="sm"></fa-icon>
-                    Report
-                </button>
-            </div>
-            <div class="flex-1 min-w-0">
-                <a [href]="formatPageUrlAsLink(page.url)"
-                   target="_blank"
-                   class="text-sm text-gray-600 hover:text-brand-500 truncate block transition-colors">
-                    {{ page.url | slice:0:50 }}
-                </a>
-            </div>
+        <!-- URL display -->
+        <div class="flex-1 min-w-0">
+            <a [href]="formatPageUrlAsLink(page.url)"
+               target="_blank"
+               class="text-sm text-gray-600 hover:text-brand-500 truncate block transition-colors">
+                {{ page.url }}
+            </a>
         </div>
 
-        <!-- Error display -->
-        <div *ngIf="error.length" class="mx-4 mt-3">
-            <div class="px-4 py-3 rounded-lg bg-red-50 border border-red-200 text-red-700 text-sm">
-                {{ error }}
-            </div>
+        <!-- Overall score -->
+        <div class="flex items-center gap-2 mr-2" *ngIf="category_scores.overallScore">
+            <app-score-gauge [score]="category_scores.overallScore" [size]="36" [strokeWidth]="4"></app-score-gauge>
+            <span class="text-xs font-medium text-gray-500">Overall</span>
         </div>
 
-        <!-- Empty state: No audit started -->
-        <div *ngIf="isLoading === false && page.htmlSource === null" class="flex-1 flex items-center justify-center p-8">
-            <div class="text-center">
-                <div class="w-12 h-12 rounded-xl bg-gray-100 flex items-center justify-center mx-auto mb-4">
-                    <fa-icon [icon]="faSearch" class="text-gray-400 text-lg"></fa-icon>
-                </div>
-                <h3 class="text-gray-900 mb-1">Start an audit</h3>
-                <p class="text-sm text-gray-500">Enter a URL to get UX scores and recommendations.</p>
-            </div>
-        </div>
+        <!-- Export PDF button -->
+        <button class="btn-accent flex items-center gap-2 text-xs py-2 px-4"
+                (click)="exportPDFReport()"
+                *ngIf="(auth.isAuthenticated$ | async) === true">
+            <fa-icon [icon]="faFilePdf" size="sm"></fa-icon>
+            Export PDF
+        </button>
+        <button class="btn-accent flex items-center gap-2 text-xs py-2 px-4"
+                (click)="showLoginRequiredDialog()"
+                *ngIf="(auth.isAuthenticated$ | async) === false">
+            <fa-icon [icon]="faFilePdf" size="sm"></fa-icon>
+            Export PDF
+        </button>
+    </div>
 
-        <!-- In-progress state -->
-        <div *ngIf="isLoading === true && is_audit_started === true" class="flex-1 overflow-y-auto">
-            <div class="p-8">
-                <div class="text-center mb-8">
-                    <h3 class="text-gray-900 mb-2">Analyzing your website</h3>
-                    <p class="text-sm text-gray-500">Results will be available in a few minutes.</p>
+    <!-- Main content grid -->
+    <div class="flex-1 grid grid-cols-12 overflow-hidden">
 
-                    <div class="mt-4" *ngIf="(auth.isAuthenticated$ | async) === true">
-                        <p class="text-sm text-gray-400">
-                            We'll email you when the audit is complete.
-                        </p>
-                    </div>
-                </div>
+        <!-- ===== LEFT PANEL: Issues & Details ===== -->
+        <div class="col-span-5 h-full flex flex-col border-r border-gray-200 bg-gray-50"
+             id="issue_details_panel">
 
-                <!-- Email form for non-authenticated users -->
-                <form [formGroup]="auditReportForm" (ngSubmit)="requestReport()" *ngIf="(auth.isAuthenticated$ | async) === false">
-                    <div class="card p-6 text-center" *ngIf="!email_submitted">
-                        <p class="text-sm text-gray-600 mb-4">
-                            Get results delivered to your inbox.
-                        </p>
-                        <div class="flex gap-2">
-                            <input id="user_email" type="email" placeholder="your@email.com"
-                                   class="flex-1 text-sm" formControlName="email">
-                            <button type="submit" [disabled]="!auditReportForm.valid"
-                                    class="btn-primary text-sm whitespace-nowrap">
-                                Notify me
-                            </button>
-                        </div>
-                    </div>
-                    <div *ngIf="email_submitted" class="card p-6 text-center">
-                        <svg class="w-8 h-8 text-emerald-500 mx-auto mb-2" fill="currentColor" viewBox="0 0 20 20">
-                            <path fill-rule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clip-rule="evenodd"/>
+            <!-- View toggle: Visual Issues / Non-Visual Issues -->
+            <div class="flex bg-white border-b border-gray-200">
+                <button class="flex-1 py-3 text-xs font-semibold text-center border-b-2 transition-colors"
+                        [ngClass]="{
+                            'border-brand-500 text-brand-600 bg-brand-50/30': activeTab === 'visual',
+                            'border-transparent text-gray-500 hover:text-gray-700 hover:bg-gray-50': activeTab !== 'visual'
+                        }"
+                        (click)="activeTab = 'visual'">
+                    <span class="flex items-center justify-center gap-1.5">
+                        <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"/>
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"/>
                         </svg>
-                        <p class="text-sm font-medium text-gray-900">
-                            We'll email you when results are ready.
-                        </p>
-                    </div>
-                </form>
-
-                <!-- Progress indicators -->
-                <div *ngIf="audit_stat && is_audit_started === true" class="space-y-3 mt-6">
-                    <div class="flex items-center gap-3 px-4 py-3 rounded-lg bg-white border border-gray-100">
-                        <fa-icon [icon]="faSpinner" class="text-brand-500" size="sm" [spin]="true"></fa-icon>
-                        <span class="text-sm text-gray-600">Data Extraction</span>
-                    </div>
-                    <div class="flex items-center gap-3 px-4 py-3 rounded-lg bg-white border border-gray-100">
-                        <fa-icon [icon]="faSpinner" class="text-brand-500" size="sm" [spin]="true"></fa-icon>
-                        <span class="text-sm text-gray-600">Content Analysis</span>
-                    </div>
-                    <div class="flex items-center gap-3 px-4 py-3 rounded-lg bg-white border border-gray-100">
-                        <fa-icon [icon]="faSpinner" class="text-brand-500" size="sm" [spin]="true"></fa-icon>
-                        <span class="text-sm text-gray-600">Information Architecture</span>
-                    </div>
-                    <div class="flex items-center gap-3 px-4 py-3 rounded-lg bg-white border border-gray-100">
-                        <fa-icon [icon]="faSpinner" class="text-brand-500" size="sm" [spin]="true"></fa-icon>
-                        <span class="text-sm text-gray-600">Visual Design</span>
-                    </div>
-                </div>
-            </div>
-        </div>
-
-        <!-- Category navigation tabs -->
-        <div id="issue_nav" class="grid grid-cols-4 bg-white border-y border-gray-200"
-             *ngIf="isLoading === false && is_audit_started === false">
-            <button *ngFor="let cat of [
-                {key: 'OVERALL', label: 'Overall', score: category_scores.overallScore},
-                {key: 'CONTENT', label: 'Content', score: category_scores.contentScore},
-                {key: 'INFORMATION_ARCHITECTURE', label: 'Info Arch', score: category_scores.informationArchitectureScore},
-                {key: 'AESTHETICS', label: 'Aesthetics', score: category_scores.aestheticsScore}
-            ]"
-                    class="flex flex-col items-center py-3 px-2 border-b-2 transition-colors duration-200 cursor-pointer"
-                    [ngClass]="{
-                        'border-brand-500 bg-brand-50/50': selected_category === cat.key,
-                        'border-transparent hover:bg-gray-50': selected_category !== cat.key
-                    }"
-                    (click)="selectCategory(cat.key)"
-                    (keydown.enter)="selectCategory(cat.key)"
-                    (keydown.space)="selectCategory(cat.key)"
-                    tabindex="0"
-                    role="tab"
-                    [attr.aria-label]="'Select ' + cat.label + ' category'"
-                    [attr.aria-selected]="selected_category === cat.key">
-                <app-score-badge *ngIf="cat.score" [score]="cat.score" size="sm" [showValue]="true"></app-score-badge>
-                <span *ngIf="!cat.score && !isLoading" class="text-xs text-gray-400">--</span>
-                <span class="text-xs font-medium mt-1"
-                      [ngClass]="{'text-brand-600': selected_category === cat.key, 'text-gray-500': selected_category !== cat.key}">
-                    {{ cat.label }}
-                </span>
-            </button>
-        </div>
-
-        <!-- Perfect score celebration states -->
-        <ng-container *ngIf="!isLoading && !is_audit_started">
-            <div *ngIf="(selected_category === 'CONTENT' && category_scores.contentScore >= 100) ||
-                        (selected_category === 'AESTHETICS' && category_scores.aestheticsScore >= 100) ||
-                        (selected_category === 'INFORMATION_ARCHITECTURE' && category_scores.informationArchitectureScore >= 100) ||
-                        (selected_category === 'OVERALL' && category_scores.interactivityScore >= 100)"
-                 class="flex-1 flex flex-col items-center justify-center p-8 text-center">
-                <div class="w-12 h-12 rounded-full bg-emerald-50 flex items-center justify-center mb-3">
-                    <svg class="w-6 h-6 text-emerald-500" fill="currentColor" viewBox="0 0 20 20">
-                        <path fill-rule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clip-rule="evenodd"/>
-                    </svg>
-                </div>
-                <h3 class="text-gray-900 mb-1">Excellent work</h3>
-                <p class="text-sm text-gray-500">
-                    Your {{ selected_category.toLowerCase().replace('_', ' ') }} scores are outstanding.
-                </p>
-            </div>
-        </ng-container>
-
-        <!-- Overall score detail view -->
-        <div *ngIf="selected_category==='OVERALL' && !isLoading" class="flex-1 overflow-y-auto"
-             style="max-height:70vh">
-
-            <!-- Score summary card -->
-            <div class="p-4" *ngIf="!isLoading && page.htmlSource">
-                <div class="card p-5">
-                    <div class="flex items-center gap-6">
-                        <div class="flex-shrink-0">
-                            <app-score-gauge [score]="category_score" [size]="100" [strokeWidth]="8"></app-score-gauge>
-                        </div>
-                        <div class="flex-1">
-                            <p class="text-sm text-gray-900 font-medium">
-                                Your overall experience {{ getExperienceScoreNeeds(category_score) }}.
-                            </p>
-                            <p class="text-xs text-gray-500 mt-1">
-                                There {{ getNumberOfNonDelightfulCategoryScores() }} that need improvement.
-                            </p>
-                        </div>
-                    </div>
-                </div>
+                        Visual Issues
+                        <span class="bg-gray-100 text-gray-600 px-1.5 py-0.5 rounded-full text-2xs font-bold" *ngIf="visualIssues.length">{{ visualIssues.length }}</span>
+                    </span>
+                </button>
+                <button class="flex-1 py-3 text-xs font-semibold text-center border-b-2 transition-colors"
+                        [ngClass]="{
+                            'border-brand-500 text-brand-600 bg-brand-50/30': activeTab === 'nonvisual',
+                            'border-transparent text-gray-500 hover:text-gray-700 hover:bg-gray-50': activeTab !== 'nonvisual'
+                        }"
+                        (click)="activeTab = 'nonvisual'">
+                    <span class="flex items-center justify-center gap-1.5">
+                        <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 20l4-16m4 4l4 4-4 4M6 16l-4-4 4-4"/>
+                        </svg>
+                        Non-Visual Issues
+                        <span class="bg-gray-100 text-gray-600 px-1.5 py-0.5 rounded-full text-2xs font-bold" *ngIf="nonVisualIssues.length">{{ nonVisualIssues.length }}</span>
+                    </span>
+                </button>
             </div>
 
-            <!-- Category breakdown cards -->
-            <div class="px-4 pb-4 space-y-2" style="max-height:50vh; overflow-y:auto">
-                <!-- Content -->
-                <div class="card p-4">
-                    <div class="flex items-center gap-4">
-                        <img alt="content icon"
-                             src="https://storage.googleapis.com/look-see-inc-assets/icons/written-content-icon.png"
-                             class="w-8 h-8 object-contain" />
-                        <h4 class="text-sm font-semibold text-gray-900 flex-1">Content</h4>
-                    </div>
-                    <div class="grid grid-cols-2 gap-3 mt-3 pl-12">
-                        <div class="flex items-center justify-between text-sm">
-                            <span class="text-gray-500">Readability</span>
-                            <span class="font-medium">{{ category_scores.readability | number: '1.0-0' }}%</span>
-                        </div>
-                        <div class="flex items-center justify-between text-sm">
-                            <span class="text-gray-500">Alt-text</span>
-                            <span class="font-medium">{{ category_scores.altText | number: '1.0-0' }}%</span>
-                        </div>
-                    </div>
-                </div>
-
-                <!-- Aesthetics -->
-                <div class="card p-4">
-                    <div class="flex items-center gap-4">
-                        <div class="w-8 h-8 rounded bg-gray-100 flex items-center justify-center">
-                            <svg class="w-4 h-4 text-gray-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 21a4 4 0 01-4-4V5a2 2 0 012-2h4a2 2 0 012 2v12a4 4 0 01-4 4zm0 0h12a2 2 0 002-2v-4a2 2 0 00-2-2h-2.343M11 7.343l1.657-1.657a2 2 0 012.828 0l2.829 2.829a2 2 0 010 2.828l-8.486 8.485M7 17h.01"/>
-                            </svg>
-                        </div>
-                        <h4 class="text-sm font-semibold text-gray-900 flex-1">Aesthetics</h4>
-                    </div>
-                    <div class="grid grid-cols-2 gap-3 mt-3 pl-12">
-                        <div class="flex items-center justify-between text-sm">
-                            <span class="text-gray-500">Text contrast</span>
-                            <span class="font-medium">{{ category_scores.textContrastScore | number: '1.0-0' }}%</span>
-                        </div>
-                        <div class="flex items-center justify-between text-sm">
-                            <span class="text-gray-500">Non-text contrast</span>
-                            <span class="font-medium">{{ category_scores.nonTextContrastScore | number: '1.0-0' }}%</span>
-                        </div>
-                    </div>
-                </div>
-
-                <!-- Information Architecture -->
-                <div class="card p-4">
-                    <div class="flex items-center gap-4">
-                        <img alt="information architecture icon"
-                             src="https://storage.googleapis.com/look-see-inc-assets/icons/info-architecture-icon.png"
-                             class="w-8 h-8 object-contain" />
-                        <h4 class="text-sm font-semibold text-gray-900 flex-1">Information Architecture</h4>
-                    </div>
-                    <div class="grid grid-cols-2 gap-3 mt-3 pl-12">
-                        <div class="flex items-center justify-between text-sm">
-                            <span class="text-gray-500">Security</span>
-                            <span class="font-medium">{{ category_scores.security | number: '1.0-0' }}%</span>
-                        </div>
-                        <div class="flex items-center justify-between text-sm">
-                            <span class="text-gray-500">Links</span>
-                            <span class="font-medium">{{ category_scores.links | number: '1.0-0' }}%</span>
-                        </div>
-                        <div class="flex items-center justify-between text-sm">
-                            <span class="text-gray-500">SEO</span>
-                            <span class="font-medium">{{ category_scores.seo | number: '1.0-0' }}%</span>
-                        </div>
-                        <div class="flex items-center justify-between text-sm">
-                            <span class="text-gray-500">Metadata</span>
-                            <span class="font-medium">{{ category_scores.metadata | number: '1.0-0' }}%</span>
-                        </div>
-                    </div>
-                </div>
-
-                <!-- Accessibility -->
-                <div class="card p-4">
-                    <div class="flex items-center gap-4">
-                        <div class="w-8 h-8 rounded bg-gray-100 flex items-center justify-center">
-                            <svg class="w-4 h-4 text-gray-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"/>
-                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"/>
-                            </svg>
-                        </div>
-                        <h4 class="text-sm font-semibold text-gray-900 flex-1">Accessibility</h4>
-                    </div>
-                    <div class="grid grid-cols-2 gap-3 mt-3 pl-12">
-                        <div class="flex items-center justify-between text-sm">
-                            <span class="text-gray-500">Color contrast</span>
-                            <span class="font-medium">{{ category_scores.colorContrast | number: '1.0-0' }}%</span>
-                        </div>
-                        <div class="flex items-center justify-between text-sm">
-                            <span class="text-gray-500">Alt text</span>
-                            <span class="font-medium">{{ category_scores.altText | number: '1.0-0' }}%</span>
-                        </div>
-                        <div class="flex items-center justify-between text-sm">
-                            <span class="text-gray-500">Semantic HTML</span>
-                            <span class="badge bg-gray-100 text-gray-500 text-2xs">beta</span>
-                        </div>
-                        <div class="flex items-center justify-between text-sm">
-                            <span class="text-gray-500">ARIA labels</span>
-                            <span class="badge bg-gray-100 text-gray-500 text-2xs">beta</span>
-                        </div>
-                    </div>
-                </div>
-            </div>
-        </div>
-
-        <!-- Category-specific issue list view -->
-        <div class="flex-1 overflow-hidden flex flex-col"
-             *ngIf="issues.length && selected_category !== 'OVERALL' && !is_audit_started">
-
-            <!-- Score summary for selected category -->
-            <div class="p-4 bg-white" *ngIf="!isLoading && page.htmlSource">
-                <div class="flex items-center gap-4">
-                    <app-score-gauge [score]="category_score" [size]="72" [strokeWidth]="6"></app-score-gauge>
-                    <div class="flex-1">
-                        <!-- Content sub-scores -->
-                        <div *ngIf="selected_category==='CONTENT'" class="grid grid-cols-2 gap-2 text-sm">
-                            <div class="flex justify-between"><span class="text-gray-500">Readability</span><span class="font-medium">{{ category_scores.readability | number:'1.0-0' }}%</span></div>
-                            <div class="flex justify-between"><span class="text-gray-500">Alt-text</span><span class="font-medium">{{ category_scores.altText | number:'1.0-0' }}%</span></div>
-                        </div>
-                        <!-- Info Arch sub-scores -->
-                        <div *ngIf="selected_category==='INFORMATION_ARCHITECTURE'" class="grid grid-cols-2 gap-2 text-sm">
-                            <div class="flex justify-between"><span class="text-gray-500">Security</span><span class="font-medium">{{ category_scores.security | number:'1.0-0' }}%</span></div>
-                            <div class="flex justify-between"><span class="text-gray-500">Links</span><span class="font-medium">{{ category_scores.links | number:'1.0-0' }}%</span></div>
-                            <div class="flex justify-between"><span class="text-gray-500">SEO</span><span class="font-medium">{{ category_scores.seo | number:'1.0-0' }}%</span></div>
-                            <div class="flex justify-between"><span class="text-gray-500">Metadata</span><span class="font-medium">{{ category_scores.metadata | number:'1.0-0' }}%</span></div>
-                        </div>
-                        <!-- Aesthetics sub-scores -->
-                        <div *ngIf="selected_category==='AESTHETICS'" class="grid grid-cols-2 gap-2 text-sm">
-                            <div class="flex justify-between"><span class="text-gray-500">Text contrast</span><span class="font-medium">{{ category_scores.textContrastScore | number:'1.0-0' }}%</span></div>
-                            <div class="flex justify-between" *ngIf="category_scores.nonTextContrastScore >= 0"><span class="text-gray-500">Non-text contrast</span><span class="font-medium">{{ category_scores.nonTextContrastScore | number:'1.0-0' }}%</span></div>
-                        </div>
-                        <!-- Accessibility sub-scores -->
-                        <div *ngIf="selected_category==='ACCESSIBILITY'" class="grid grid-cols-2 gap-2 text-sm">
-                            <div class="flex justify-between"><span class="text-gray-500">Color contrast</span><span class="font-medium">--</span></div>
-                            <div class="flex justify-between"><span class="text-gray-500">Semantic HTML</span><span class="font-medium">--</span></div>
-                        </div>
-                    </div>
-                </div>
+            <!-- Category filter tabs -->
+            <div id="issue_nav" class="grid grid-cols-4 bg-white border-b border-gray-200">
+                <button *ngFor="let cat of [
+                    {key: 'OVERALL', label: 'All', score: category_scores.overallScore},
+                    {key: 'CONTENT', label: 'Content', score: category_scores.contentScore},
+                    {key: 'INFORMATION_ARCHITECTURE', label: 'Info Arch', score: category_scores.informationArchitectureScore},
+                    {key: 'AESTHETICS', label: 'Aesthetics', score: category_scores.aestheticsScore}
+                ]"
+                        class="flex flex-col items-center py-2.5 px-2 border-b-2 transition-colors duration-200 cursor-pointer"
+                        [ngClass]="{
+                            'border-brand-500 bg-brand-50/50': selected_category === cat.key,
+                            'border-transparent hover:bg-gray-50': selected_category !== cat.key
+                        }"
+                        (click)="selectCategory(cat.key)">
+                    <app-score-badge *ngIf="cat.score" [score]="cat.score" size="sm" [showValue]="true"></app-score-badge>
+                    <span *ngIf="!cat.score" class="text-xs text-gray-400">--</span>
+                    <span class="text-2xs font-medium mt-0.5"
+                          [ngClass]="{'text-brand-600': selected_category === cat.key, 'text-gray-500': selected_category !== cat.key}">
+                        {{ cat.label }}
+                    </span>
+                </button>
             </div>
 
             <!-- Issue list header -->
-            <div class="flex items-center px-4 py-2.5 bg-gray-100 border-y border-gray-200 text-xs font-semibold text-gray-500 uppercase tracking-wider">
-                <div class="w-20">Risk</div>
+            <div class="flex items-center px-4 py-2 bg-gray-100 border-b border-gray-200 text-2xs font-semibold text-gray-500 uppercase tracking-wider">
+                <div class="w-16">Risk</div>
                 <div class="flex-1">Issue</div>
                 <div class="w-8"></div>
             </div>
 
-            <!-- Scrollable issue list -->
-            <div class="flex-1 overflow-y-auto" style="max-height:50vh" #issues_container>
-                <div *ngFor="let ux_issue_row of issues | filterByCategory: selected_category"
+            <!-- ===== VISUAL ISSUES LIST ===== -->
+            <div class="flex-1 overflow-y-auto" *ngIf="activeTab === 'visual'" #issues_container>
+                <div *ngIf="!getFilteredIssues(visualIssues).length" class="flex flex-col items-center justify-center py-12 px-6 text-center">
+                    <div class="w-12 h-12 rounded-full bg-emerald-50 flex items-center justify-center mb-3">
+                        <svg class="w-6 h-6 text-emerald-500" fill="currentColor" viewBox="0 0 20 20">
+                            <path fill-rule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clip-rule="evenodd"/>
+                        </svg>
+                    </div>
+                    <h4 class="text-sm font-medium text-gray-900 mb-1">No visual issues found</h4>
+                    <p class="text-xs text-gray-500">Great work! No visual accessibility issues detected in this category.</p>
+                </div>
+
+                <div *ngFor="let ux_issue_row of getFilteredIssues(visualIssues)"
                      [id]="ux_issue_row.key"
                      class="border-b border-gray-100">
 
                     <!-- Issue row -->
                     <div class="flex items-center px-4 py-3 hover:bg-gray-50 cursor-pointer transition-colors"
                          (click)="openIssueDetails(ux_issue_row.key)"
-                         (keydown.enter)="openIssueDetails(ux_issue_row.key)"
-                         (keydown.space)="openIssueDetails(ux_issue_row.key)"
                          tabindex="0"
                          role="button"
                          [attr.aria-label]="'Open details for ' + ux_issue_row.title"
                          *ngIf="ux_issue_row.priority !== 'NONE'">
-
-                        <!-- Priority badge -->
-                        <div class="w-20 flex-shrink-0">
+                        <div class="w-16 flex-shrink-0">
                             <div class="flex flex-col items-center">
                                 <img [src]="getIconSrc(ux_issue_row.priority)"
-                                     class="h-8 relative"
+                                     class="h-7"
                                      [matTooltip]="getRiskTooltip(ux_issue_row.priority)"
                                      alt="Priority icon">
                                 <span class="text-2xs text-gray-400 mt-0.5">{{ ux_issue_row.priority }}</span>
                             </div>
                         </div>
-
-                        <!-- Issue title -->
                         <div class="flex-1 text-sm text-gray-700">
                             {{ ux_issue_row.title }}
                         </div>
-
-                        <!-- Expand indicator -->
                         <div class="w-8 flex justify-center text-gray-400">
                             <fa-icon [icon]="issue_selected !== ux_issue_row.key ? faAngleDown : faAngleUp" size="sm"></fa-icon>
                         </div>
                     </div>
 
                     <!-- Expanded issue details -->
-                    <div class="bg-white border-t border-gray-100 px-6 py-5"
+                    <div class="bg-white border-t border-gray-100 px-5 py-4"
                          *ngIf="issue_selected === ux_issue_row.key">
 
-                        <div *ngIf="isElementObservation(ux_issue_row)" class="mb-4">
-                            <h5 class="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-1">Observation</h5>
+                        <div *ngIf="isElementObservation(ux_issue_row)" class="mb-3">
+                            <h5 class="text-2xs font-semibold text-gray-500 uppercase tracking-wider mb-1">Observation</h5>
                             <p class="text-sm text-gray-700 leading-relaxed">{{ ux_issue_row.description }}</p>
                         </div>
 
-                        <div class="mb-4">
-                            <h5 class="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-1">Recommendation</h5>
+                        <div class="mb-3">
+                            <h5 class="text-2xs font-semibold text-gray-500 uppercase tracking-wider mb-1">Recommendation</h5>
                             <p class="text-sm text-gray-700 leading-relaxed">{{ ux_issue_row.recommendation }}</p>
                         </div>
 
                         <!-- Color contrast details -->
-                        <div *ngIf="isColorContrast(ux_issue_row)" class="mt-4">
-                            <div class="grid grid-cols-3 gap-4">
+                        <div *ngIf="isColorContrast(ux_issue_row)" class="mt-3">
+                            <div class="grid grid-cols-3 gap-3">
                                 <div class="flex items-center justify-center">
                                     <img src="{{ getElementScreenshot(ux_issue_row) }}"
                                          class="w-full rounded-lg border border-gray-200"
                                          alt="Element screenshot" />
                                 </div>
-                                <div class="col-span-2 space-y-3 text-sm">
+                                <div class="col-span-2 space-y-2 text-sm">
                                     <div class="grid grid-cols-2 gap-2">
                                         <div><span class="text-gray-500">Contrast:</span> <span class="font-medium">{{ ux_issue_row.contrast | number: '1.2-2' }}</span></div>
                                         <div><span class="text-gray-500">Font size:</span> <span class="font-medium">{{ ux_issue_row.fontSize | number: '1.1-1' }}pt</span></div>
                                     </div>
-                                    <div class="grid grid-cols-2 gap-4">
+                                    <div class="grid grid-cols-2 gap-3">
                                         <div>
                                             <div class="flex items-center gap-2 mb-1">
                                                 <div [style.background-color]="convertToHex(ux_issue_row.foregroundColor || '')"
-                                                     class="w-5 h-5 rounded border border-gray-200"></div>
-                                                <span class="text-xs font-medium text-gray-700">Text Color</span>
+                                                     class="w-4 h-4 rounded border border-gray-200"></div>
+                                                <span class="text-xs font-medium text-gray-700">Text</span>
                                             </div>
                                             <p class="text-xs text-gray-500">{{ convertToHex(ux_issue_row.foregroundColor || '') }}</p>
                                         </div>
                                         <div>
                                             <div class="flex items-center gap-2 mb-1">
                                                 <div [style.background-color]="convertToHex(ux_issue_row.backgroundColor || '')"
-                                                     class="w-5 h-5 rounded border border-gray-200"></div>
+                                                     class="w-4 h-4 rounded border border-gray-200"></div>
                                                 <span class="text-xs font-medium text-gray-700">Background</span>
                                             </div>
                                             <p class="text-xs text-gray-500">{{ convertToHex(ux_issue_row.backgroundColor || '') }}</p>
@@ -443,107 +222,238 @@
                             </div>
                         </div>
 
+                        <!-- WCAG compliance -->
+                        <div class="mt-3 pt-3 border-t border-gray-100" *ngIf="ux_issue_row.wcagCompliance">
+                            <h5 class="text-2xs font-semibold text-gray-500 uppercase tracking-wider mb-1">WCAG Compliance</h5>
+                            <p class="text-sm text-gray-700">{{ ux_issue_row.wcagCompliance }}</p>
+                        </div>
+
+                        <!-- AI Assist button -->
                         <div class="mt-4 pt-3 border-t border-gray-100">
-                            <h5 class="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-1">WCAG Compliance</h5>
-                            <p class="text-sm text-gray-700">
-                                {{ ux_issue_row.wcagCompliance || 'No WCAG compliance issues found' }}
-                            </p>
+                            <button class="w-full flex items-center justify-center gap-2 px-4 py-2.5 rounded-lg bg-gradient-to-r from-purple-600 to-brand-500 text-white text-sm font-medium hover:from-purple-700 hover:to-brand-600 transition-all duration-200 shadow-sm"
+                                    (click)="requestAIAssist(ux_issue_row)">
+                                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 10V3L4 14h7v7l9-11h-7z"/>
+                                </svg>
+                                AI Assist — Get Fix Suggestion
+                            </button>
+
+                            <!-- AI suggestion display -->
+                            <div *ngIf="aiSuggestions[ux_issue_row.key]" class="mt-3 rounded-lg bg-purple-50 border border-purple-200 p-4">
+                                <div class="flex items-center gap-2 mb-2">
+                                    <svg class="w-4 h-4 text-purple-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 10V3L4 14h7v7l9-11h-7z"/>
+                                    </svg>
+                                    <span class="text-xs font-semibold text-purple-700 uppercase tracking-wider">AI Suggestion</span>
+                                </div>
+                                <p class="text-sm text-purple-900 leading-relaxed whitespace-pre-line">{{ aiSuggestions[ux_issue_row.key] }}</p>
+                            </div>
+                            <div *ngIf="aiLoadingKeys[ux_issue_row.key]" class="mt-3 flex items-center gap-2 text-sm text-purple-600">
+                                <svg class="w-4 h-4 animate-spin" fill="none" viewBox="0 0 24 24">
+                                    <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+                                    <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"></path>
+                                </svg>
+                                Generating fix suggestion...
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <!-- ===== NON-VISUAL ISSUES LIST ===== -->
+            <div class="flex-1 overflow-y-auto" *ngIf="activeTab === 'nonvisual'">
+                <div *ngIf="!getFilteredIssues(nonVisualIssues).length" class="flex flex-col items-center justify-center py-12 px-6 text-center">
+                    <div class="w-12 h-12 rounded-full bg-emerald-50 flex items-center justify-center mb-3">
+                        <svg class="w-6 h-6 text-emerald-500" fill="currentColor" viewBox="0 0 20 20">
+                            <path fill-rule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clip-rule="evenodd"/>
+                        </svg>
+                    </div>
+                    <h4 class="text-sm font-medium text-gray-900 mb-1">No non-visual issues found</h4>
+                    <p class="text-xs text-gray-500">Metadata, SEO, and structural elements look good.</p>
+                </div>
+
+                <!-- Non-visual issue group headers -->
+                <div *ngFor="let group of nonVisualIssueGroups">
+                    <div class="px-4 py-2 bg-gray-100 border-b border-gray-200 flex items-center gap-2">
+                        <svg class="w-3.5 h-3.5 text-gray-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" [attr.d]="getNonVisualGroupIcon(group.type)"/>
+                        </svg>
+                        <span class="text-2xs font-semibold text-gray-600 uppercase tracking-wider">{{ group.label }}</span>
+                        <span class="text-2xs text-gray-400 ml-auto">{{ group.issues.length }}</span>
+                    </div>
+
+                    <div *ngFor="let ux_issue_row of group.issues"
+                         [id]="ux_issue_row.key"
+                         class="border-b border-gray-100">
+
+                        <div class="flex items-center px-4 py-3 hover:bg-gray-50 cursor-pointer transition-colors"
+                             (click)="openIssueDetails(ux_issue_row.key)"
+                             tabindex="0"
+                             role="button"
+                             *ngIf="ux_issue_row.priority !== 'NONE'">
+                            <div class="w-16 flex-shrink-0">
+                                <div class="flex flex-col items-center">
+                                    <img [src]="getIconSrc(ux_issue_row.priority)"
+                                         class="h-7"
+                                         alt="Priority icon">
+                                    <span class="text-2xs text-gray-400 mt-0.5">{{ ux_issue_row.priority }}</span>
+                                </div>
+                            </div>
+                            <div class="flex-1 text-sm text-gray-700">
+                                {{ ux_issue_row.title }}
+                            </div>
+                            <div class="w-8 flex justify-center text-gray-400">
+                                <fa-icon [icon]="issue_selected !== ux_issue_row.key ? faAngleDown : faAngleUp" size="sm"></fa-icon>
+                            </div>
+                        </div>
+
+                        <!-- Expanded non-visual issue details -->
+                        <div class="bg-white border-t border-gray-100 px-5 py-4"
+                             *ngIf="issue_selected === ux_issue_row.key">
+
+                            <div class="mb-3">
+                                <h5 class="text-2xs font-semibold text-gray-500 uppercase tracking-wider mb-1">Issue</h5>
+                                <p class="text-sm text-gray-700 leading-relaxed">{{ ux_issue_row.description }}</p>
+                            </div>
+
+                            <div class="mb-3">
+                                <h5 class="text-2xs font-semibold text-gray-500 uppercase tracking-wider mb-1">Recommendation</h5>
+                                <p class="text-sm text-gray-700 leading-relaxed">{{ ux_issue_row.recommendation }}</p>
+                            </div>
+
+                            <div class="mt-3 pt-3 border-t border-gray-100" *ngIf="ux_issue_row.wcagCompliance">
+                                <h5 class="text-2xs font-semibold text-gray-500 uppercase tracking-wider mb-1">WCAG Compliance</h5>
+                                <p class="text-sm text-gray-700">{{ ux_issue_row.wcagCompliance }}</p>
+                            </div>
+
+                            <!-- AI Assist for non-visual -->
+                            <div class="mt-4 pt-3 border-t border-gray-100">
+                                <button class="w-full flex items-center justify-center gap-2 px-4 py-2.5 rounded-lg bg-gradient-to-r from-purple-600 to-brand-500 text-white text-sm font-medium hover:from-purple-700 hover:to-brand-600 transition-all duration-200 shadow-sm"
+                                        (click)="requestAIAssist(ux_issue_row)">
+                                    <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 10V3L4 14h7v7l9-11h-7z"/>
+                                    </svg>
+                                    AI Assist — Get Fix Suggestion
+                                </button>
+                                <div *ngIf="aiSuggestions[ux_issue_row.key]" class="mt-3 rounded-lg bg-purple-50 border border-purple-200 p-4">
+                                    <div class="flex items-center gap-2 mb-2">
+                                        <svg class="w-4 h-4 text-purple-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 10V3L4 14h7v7l9-11h-7z"/>
+                                        </svg>
+                                        <span class="text-xs font-semibold text-purple-700 uppercase tracking-wider">AI Suggestion</span>
+                                    </div>
+                                    <p class="text-sm text-purple-900 leading-relaxed whitespace-pre-line">{{ aiSuggestions[ux_issue_row.key] }}</p>
+                                </div>
+                                <div *ngIf="aiLoadingKeys[ux_issue_row.key]" class="mt-3 flex items-center gap-2 text-sm text-purple-600">
+                                    <svg class="w-4 h-4 animate-spin" fill="none" viewBox="0 0 24 24">
+                                        <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+                                        <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"></path>
+                                    </svg>
+                                    Generating fix suggestion...
+                                </div>
+                            </div>
                         </div>
                     </div>
                 </div>
             </div>
         </div>
-    </div>
 
-    <!-- RIGHT PANEL: Screenshot -->
-    <div class="col-span-7 h-full bg-white">
-        <!-- Empty state -->
-        <div *ngIf="isLoading === false && page.fullPageScreenshotUrlComposite === null"
-             class="h-full flex items-center justify-center p-8">
-            <div class="text-center">
-                <div class="w-12 h-12 rounded-xl bg-gray-100 flex items-center justify-center mx-auto mb-4">
-                    <fa-icon [icon]="faSearch" class="text-gray-400 text-lg"></fa-icon>
+        <!-- ===== RIGHT PANEL: Screenshot with Issue Bubbles ===== -->
+        <div class="col-span-7 h-full bg-white flex flex-col">
+
+            <!-- Screenshot with element overlays -->
+            <div class="flex-1 w-full overflow-y-auto relative"
+                 #full_page_screenshot
+                 *ngIf="page.fullPageScreenshotUrlComposite">
+                <img src="{{ page.fullPageScreenshotUrlComposite }}"
+                     class="w-full"
+                     #image_screenshot
+                     alt="Full page screenshot of the webpage"/>
+
+                <!-- Element issue bubble overlays -->
+                <div *ngFor="let element of elements"
+                     [id]="element.key"
+                     class="element-container"
+                     style="position:absolute"
+                     [style.left]="element.xlocation ? getElementLeftCoordinate(element) : '0px'"
+                     [style.top]="element.ylocation ? getElementTopCoordinate(element) : '0px'"
+                     [style.width]="element.width ? getElementScaledWidth(element) : '0px'"
+                     [style.height]="element.height ? getElementScaledHeight(element) : '0px'"
+                     [class]="selected_element === element.key ? 'active_element' : ''">
+
+                    <!-- Issue bubble -->
+                    <div class="issue-bubble"
+                         *ngIf="getVisibleElementIssueCount(element.key) > 0"
+                         (click)="selectElementIssues(element.key)"
+                         [ngClass]="{
+                             'issue-bubble-high': getHighestPriority(element.key) === 'HIGH',
+                             'issue-bubble-medium': getHighestPriority(element.key) === 'MEDIUM',
+                             'issue-bubble-low': getHighestPriority(element.key) === 'LOW'
+                         }"
+                         matTooltip="{{getVisibleElementIssueCount(element.key)}} issue(s) — click to view">
+                        <span class="issue-bubble-count">{{ getVisibleElementIssueCount(element.key) }}</span>
+                    </div>
                 </div>
-                <p class="text-sm text-gray-500">
-                    Enter a URL and start an audit to see the page preview.
-                </p>
             </div>
-        </div>
 
-        <!-- Loading state -->
-        <app-loading *ngIf="page.fullPageScreenshotUrlComposite === null && isLoading === true"
-                     class="flex items-center justify-center h-full w-full">
-        </app-loading>
-
-        <!-- Screenshot with element overlays -->
-        <div class="w-full h-full overflow-y-auto relative"
-             #full_page_screenshot
-             *ngIf="page.fullPageScreenshotUrlComposite && isLoading === false">
-            <img src="{{ page.fullPageScreenshotUrlComposite }}"
-                 class="w-full"
-                 #image_screenshot
-                 alt="Full page screenshot of the webpage"/>
-
-            <!-- Element issue overlays -->
-            <div *ngFor="let element of elements"
-                 [id]="element.key"
-                 class="element-container"
-                 style="position:absolute"
-                 [style.left]="element.xlocation ? getElementLeftCoordinate(element) : '0px'"
-                 [style.top]="element.ylocation ? getElementTopCoordinate(element) : '0px'"
-                 [style.width]="element.width ? getElementScaledWidth(element) : '0px'"
-                 [style.height]="element.height ? getElementScaledHeight(element) : '0px'"
-                 [class]="selected_element === element.key ? 'active_element' : ''">
-
-                <div *ngFor="let issue of getElementIssues(element.key) | filterByCategory: selected_category | filterSeverity: 'NONE'"
-                     (click)="selectIssue(issue.key)"
-                     (keydown.enter)="selectIssue(issue.key)"
-                     (keydown.space)="selectIssue(issue.key)"
-                     tabindex="0"
-                     role="button"
-                     [attr.aria-label]="'Select issue ' + issue.key"
-                     class="cursor-pointer issue-icon-container">
-                    <img [src]="getIconSrc(issue.priority)" class="issue-icon" alt="Issue icon" />
+            <!-- Loading placeholder for screenshot -->
+            <div *ngIf="!page.fullPageScreenshotUrlComposite"
+                 class="flex-1 flex items-center justify-center">
+                <div class="text-center">
+                    <mat-progress-spinner
+                        class="mx-auto mb-4"
+                        [color]="color"
+                        [mode]="mode"
+                        [diameter]="40">
+                    </mat-progress-spinner>
+                    <p class="text-sm text-gray-500">Loading page screenshot...</p>
                 </div>
             </div>
         </div>
     </div>
 </div>
 
-<!-- Report download modal -->
+<!-- ==================== PDF REPORT DOWNLOAD MODAL ==================== -->
 <div class="modal modal-active fixed w-full h-full top-0 left-0 flex items-center justify-center z-30"
      *ngIf="isReportDownloadDialogDisplayed">
-    <div class="modal-overlay absolute w-full h-full bg-gray-900/60 backdrop-blur-sm z-50"></div>
+    <div class="modal-overlay absolute w-full h-full bg-gray-900/60 backdrop-blur-sm z-50"
+         (click)="isReportDownloadDialogDisplayed = false"></div>
     <div class="modal-container bg-white w-[90vw] max-w-md rounded-2xl shadow-elevated z-50 overflow-hidden animate-fade-in">
         <div class="p-6">
-            <h3 class="text-gray-900 mb-3">Generating Report</h3>
+            <div class="flex items-center gap-3 mb-4">
+                <div class="w-10 h-10 rounded-xl bg-brand-50 flex items-center justify-center">
+                    <fa-icon [icon]="faFilePdf" class="text-brand-500"></fa-icon>
+                </div>
+                <div>
+                    <h3 class="text-gray-900 text-base font-semibold">Generating PDF Report</h3>
+                    <p class="text-xs text-gray-500">This may take up to 90 seconds</p>
+                </div>
+            </div>
             <p class="text-sm text-gray-600 leading-relaxed">
-                It may take up to 90 seconds to generate your report. We're compiling your audit results into an Excel file.
+                We're compiling your accessibility audit results, scores, and recommendations into a comprehensive PDF report you can share with your team.
             </p>
         </div>
         <div class="flex justify-end gap-3 px-6 pb-6">
-            <button class="btn-primary" (click)="openReport()">
-                Download
-            </button>
+            <button class="btn-ghost" (click)="isReportDownloadDialogDisplayed = false">Cancel</button>
+            <button class="btn-primary" (click)="openReport()">Download</button>
         </div>
     </div>
 </div>
 
-<!-- Login required modal -->
+<!-- ==================== LOGIN REQUIRED MODAL ==================== -->
 <div class="modal modal-active fixed w-full h-full top-0 left-0 flex items-center justify-center z-30"
      *ngIf="showLoginRequiredMessage">
-    <div class="modal-overlay absolute w-full h-full bg-gray-900/60 backdrop-blur-sm z-30"></div>
+    <div class="modal-overlay absolute w-full h-full bg-gray-900/60 backdrop-blur-sm z-30"
+         (click)="showLoginRequiredMessage = false"></div>
     <div class="modal-container bg-white w-[90vw] max-w-md rounded-2xl shadow-elevated z-50 overflow-hidden animate-fade-in">
         <div class="p-6">
             <h3 class="text-gray-900 mb-3">Sign in required</h3>
             <p class="text-sm text-gray-600">
-                You need to be signed in to export reports. Please sign in or create an account to continue.
+                You need to be signed in to export PDF reports. Please sign in or create an account to continue.
             </p>
         </div>
         <div class="flex justify-end gap-3 px-6 pb-6">
-            <button class="btn-ghost" (click)="showLoginRequiredMessage=false">
-                Cancel
-            </button>
+            <button class="btn-ghost" (click)="showLoginRequiredMessage=false">Cancel</button>
             <app-auth-button (click)="showLoginRequiredMessage=false"></app-auth-button>
         </div>
     </div>

--- a/Look-see-UI-v3/src/app/components/page-audit-review/page-audit-review.component.html
+++ b/Look-see-UI-v3/src/app/components/page-audit-review/page-audit-review.component.html
@@ -382,17 +382,18 @@
                      [class]="selected_element === element.key ? 'active_element' : ''">
 
                     <!-- Issue bubble -->
-                    <div class="issue-bubble"
-                         *ngIf="getVisibleElementIssueCount(element.key) > 0"
-                         (click)="selectElementIssues(element.key)"
-                         [ngClass]="{
-                             'issue-bubble-high': getHighestPriority(element.key) === 'HIGH',
-                             'issue-bubble-medium': getHighestPriority(element.key) === 'MEDIUM',
-                             'issue-bubble-low': getHighestPriority(element.key) === 'LOW'
-                         }"
-                         matTooltip="{{getVisibleElementIssueCount(element.key)}} issue(s) — click to view">
+                    <button class="issue-bubble"
+                            *ngIf="getVisibleElementIssueCount(element.key) > 0"
+                            (click)="selectElementIssues(element.key)"
+                            [ngClass]="{
+                                'issue-bubble-high': getHighestPriority(element.key) === 'HIGH',
+                                'issue-bubble-medium': getHighestPriority(element.key) === 'MEDIUM',
+                                'issue-bubble-low': getHighestPriority(element.key) === 'LOW'
+                            }"
+                            [attr.aria-label]="getVisibleElementIssueCount(element.key) + ' issue(s) — click to view'"
+                            matTooltip="{{getVisibleElementIssueCount(element.key)}} issue(s) — click to view">
                         <span class="issue-bubble-count">{{ getVisibleElementIssueCount(element.key) }}</span>
-                    </div>
+                    </button>
                 </div>
             </div>
 
@@ -417,7 +418,12 @@
 <div class="modal modal-active fixed w-full h-full top-0 left-0 flex items-center justify-center z-30"
      *ngIf="isReportDownloadDialogDisplayed">
     <div class="modal-overlay absolute w-full h-full bg-gray-900/60 backdrop-blur-sm z-50"
-         (click)="isReportDownloadDialogDisplayed = false"></div>
+         role="button"
+         tabindex="0"
+         aria-label="Close report dialog"
+         (click)="isReportDownloadDialogDisplayed = false"
+         (keydown.enter)="isReportDownloadDialogDisplayed = false"
+         (keydown.escape)="isReportDownloadDialogDisplayed = false"></div>
     <div class="modal-container bg-white w-[90vw] max-w-md rounded-2xl shadow-elevated z-50 overflow-hidden animate-fade-in">
         <div class="p-6">
             <div class="flex items-center gap-3 mb-4">
@@ -444,7 +450,12 @@
 <div class="modal modal-active fixed w-full h-full top-0 left-0 flex items-center justify-center z-30"
      *ngIf="showLoginRequiredMessage">
     <div class="modal-overlay absolute w-full h-full bg-gray-900/60 backdrop-blur-sm z-30"
-         (click)="showLoginRequiredMessage = false"></div>
+         role="button"
+         tabindex="0"
+         aria-label="Close login dialog"
+         (click)="showLoginRequiredMessage = false"
+         (keydown.enter)="showLoginRequiredMessage = false"
+         (keydown.escape)="showLoginRequiredMessage = false"></div>
     <div class="modal-container bg-white w-[90vw] max-w-md rounded-2xl shadow-elevated z-50 overflow-hidden animate-fade-in">
         <div class="p-6">
             <h3 class="text-gray-900 mb-3">Sign in required</h3>

--- a/Look-see-UI-v3/src/app/components/page-audit-review/page-audit-review.component.scss
+++ b/Look-see-UI-v3/src/app/components/page-audit-review/page-audit-review.component.scss
@@ -6,6 +6,11 @@
 .cherise-red { color: #FF0050; }
 
 /* Element overlay styles */
+.element-container {
+    cursor: pointer;
+    z-index: 5;
+}
+
 .element-container:hover {
     background: rgba(255, 0, 80, 0.08);
     border-radius: 4px;
@@ -15,8 +20,65 @@
     border: 2px solid #FF0050;
     border-radius: 4px;
     background: rgba(255, 0, 80, 0.05);
+    z-index: 10;
 }
 
+/* ===== Issue Bubbles ===== */
+.issue-bubble {
+    position: absolute;
+    top: -14px;
+    left: -14px;
+    width: 28px;
+    height: 28px;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    z-index: 15;
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2), 0 0 0 3px rgba(255, 255, 255, 0.8);
+    transition: transform 0.15s ease, box-shadow 0.15s ease;
+    animation: bubble-appear 0.3s ease-out;
+}
+
+.issue-bubble:hover {
+    transform: scale(1.2);
+    box-shadow: 0 3px 10px rgba(0, 0, 0, 0.25), 0 0 0 3px rgba(255, 255, 255, 0.9);
+    z-index: 20;
+}
+
+.issue-bubble-high {
+    background: linear-gradient(135deg, #ef4444, #dc2626);
+}
+
+.issue-bubble-medium {
+    background: linear-gradient(135deg, #f59e0b, #d97706);
+}
+
+.issue-bubble-low {
+    background: linear-gradient(135deg, #3b82f6, #2563eb);
+}
+
+.issue-bubble-count {
+    color: white;
+    font-size: 11px;
+    font-weight: 700;
+    line-height: 1;
+    text-shadow: 0 1px 1px rgba(0, 0, 0, 0.2);
+}
+
+@keyframes bubble-appear {
+    from {
+        opacity: 0;
+        transform: scale(0.5);
+    }
+    to {
+        opacity: 1;
+        transform: scale(1);
+    }
+}
+
+/* Legacy issue icon styles (kept for compatibility) */
 .issue-icon-container {
     position: absolute;
     left: -12px;
@@ -72,4 +134,14 @@ iframe {
 
 h2 {
     margin: 0 !important;
+}
+
+/* Fade-in animation for panels */
+@keyframes fade-in {
+    from { opacity: 0; transform: translateY(8px); }
+    to { opacity: 1; transform: translateY(0); }
+}
+
+.animate-fade-in {
+    animation: fade-in 0.3s ease-out;
 }

--- a/Look-see-UI-v3/src/app/components/page-audit-review/page-audit-review.component.ts
+++ b/Look-see-UI-v3/src/app/components/page-audit-review/page-audit-review.component.ts
@@ -104,7 +104,7 @@ export class PageAuditReviewComponent implements OnInit, AfterViewInit, OnDestro
   interactivity_audit_score = 0
   category_scores: AuditScore = {} as AuditScore
 
-  selected_category = ""
+  selected_category = "OVERALL"
   issue_selected = ""
 
   //intervals
@@ -154,7 +154,16 @@ export class PageAuditReviewComponent implements OnInit, AfterViewInit, OnDestro
   //permissions
   is_audit_admin = false
 
-  selected_element = "" 
+  selected_element = ""
+
+  // New UI state
+  activeTab: string = 'visual'
+  resultsReady: boolean = false
+  visualIssues: UXIssueMessage[] = []
+  nonVisualIssues: UXIssueMessage[] = []
+  nonVisualIssueGroups: {type: string, label: string, issues: UXIssueMessage[]}[] = []
+  aiSuggestions: Record<string, string> = {}
+  aiLoadingKeys: Record<string, boolean> = {}
 
   //screenshot image element
   @ViewChild("full_page_screenshot")
@@ -183,8 +192,10 @@ export class PageAuditReviewComponent implements OnInit, AfterViewInit, OnDestro
   renderer = inject(Renderer2);
   auth_service = inject(AuthorizationService);
   report_service = inject(ReportService);
+  categoryPipe = inject(FilterByCategoryPipe);
+  severityPipe = inject(FilterSeverityPipe);
 
-  constructor() { 
+  constructor() {
     this.priorities = [
       { name: 'High' },
       { name: 'Medium' },
@@ -195,12 +206,15 @@ export class PageAuditReviewComponent implements OnInit, AfterViewInit, OnDestro
   }
   
   ngAfterViewInit(){
-    //this.element_issues = this.issue_element_map.elementIssues || []
     this.issues = this.issue_element_map.issues || []
     this.category_scores = this.issue_element_map.scores || []
-    
-    this.selectCategory('CONTENT')
-    
+
+    if (this.issues.length) {
+      this.splitIssues()
+      this.resultsReady = true
+    }
+
+    this.selectCategory('OVERALL')
   }
  
   ngOnInit(): void {
@@ -650,6 +664,8 @@ export class PageAuditReviewComponent implements OnInit, AfterViewInit, OnDestro
                     
           this.category_scores = this.issue_element_map.scores || []
           this.category_scores.overallScore = (this.issue_element_map.scores.aestheticsScore + this.issue_element_map.scores.contentScore + this.issue_element_map.scores.informationArchitectureScore)/3
+          this.splitIssues()
+          this.resultsReady = true
           this.isLoading = false
           this.is_audit_started = false
         },
@@ -1072,7 +1088,207 @@ export class PageAuditReviewComponent implements OnInit, AfterViewInit, OnDestro
     if(issue?.goodExample && issue.goodExample.screenshotUrl.length > 0){
       return issue.goodExample.screenshotUrl;
     }
-    
+
     return "assets/placeholder-300x202.jpg"
+  }
+
+  /* ===== NEW METHODS FOR REDESIGNED UI ===== */
+
+  /**
+   * Split issues into visual (tied to rendered elements with coordinates)
+   * and non-visual (metadata, SEO, structural issues without element placement).
+   */
+  splitIssues(): void {
+    this.visualIssues = []
+    this.nonVisualIssues = []
+
+    for (const issue of this.issues) {
+      if (issue.priority === 'NONE') continue;
+
+      const elementKey = this.issue_element_map.issueElementMap
+        ? this.issue_element_map.issueElementMap[issue.key]
+        : null;
+
+      let isVisual = false;
+      if (elementKey && this.elements) {
+        const element = this.elements.find(el => el.key === elementKey);
+        if (element && (element.xlocation > 0 || element.ylocation > 0)) {
+          isVisual = true;
+        }
+      }
+
+      if (isVisual) {
+        this.visualIssues.push(issue);
+      } else {
+        this.nonVisualIssues.push(issue);
+      }
+    }
+
+    this.groupNonVisualIssues();
+  }
+
+  /**
+   * Group non-visual issues by their category field.
+   */
+  groupNonVisualIssues(): void {
+    const groupMap: Record<string, UXIssueMessage[]> = {};
+
+    for (const issue of this.nonVisualIssues) {
+      const cat = issue.category || 'OTHER';
+      if (!groupMap[cat]) {
+        groupMap[cat] = [];
+      }
+      groupMap[cat].push(issue);
+    }
+
+    this.nonVisualIssueGroups = Object.keys(groupMap)
+      .filter(key => groupMap[key].length > 0)
+      .map(key => ({
+        type: key,
+        label: this.titleCase(key),
+        issues: groupMap[key]
+      }));
+  }
+
+  /**
+   * Filter issues by the selected category. Returns all if OVERALL is selected.
+   */
+  getFilteredIssues(issueList: UXIssueMessage[]): UXIssueMessage[] {
+    if (!issueList) return [];
+
+    let filtered = issueList.filter(i => i.priority !== 'NONE');
+
+    if (this.selected_category !== 'OVERALL') {
+      filtered = this.categoryPipe.transform(filtered, this.selected_category);
+    }
+
+    return filtered;
+  }
+
+  /**
+   * Select an element on the screenshot and open its first issue in the panel.
+   */
+  selectElementIssues(elementKey: string): void {
+    this.selected_element = elementKey;
+    this.activeTab = 'visual';
+
+    const elementIssues = this.getElementIssues(elementKey);
+    if (elementIssues.length > 0) {
+      const firstVisibleIssue = elementIssues.find(i => i.priority !== 'NONE');
+      if (firstVisibleIssue) {
+        this.issue_selected = firstVisibleIssue.key;
+        // Scroll to the issue in the panel
+        setTimeout(() => {
+          document.getElementById(firstVisibleIssue.key)?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+        }, 100);
+      }
+    }
+  }
+
+  /**
+   * Count visible issues for an element, respecting category filter.
+   */
+  getVisibleElementIssueCount(elementKey: string): number {
+    const elementIssues = this.getElementIssues(elementKey);
+    return this.getFilteredIssues(elementIssues).length;
+  }
+
+  /**
+   * Get the highest priority among issues for an element.
+   */
+  getHighestPriority(elementKey: string): string {
+    const elementIssues = this.getElementIssues(elementKey);
+    const priorities = elementIssues
+      .filter(i => i.priority !== 'NONE')
+      .map(i => i.priority);
+
+    if (priorities.includes('HIGH')) return 'HIGH';
+    if (priorities.includes('MEDIUM')) return 'MEDIUM';
+    if (priorities.includes('LOW')) return 'LOW';
+    return 'LOW';
+  }
+
+  /**
+   * Stubbed AI assist — generates a fix suggestion after a simulated delay.
+   */
+  requestAIAssist(issue: UXIssueMessage): void {
+    if (this.aiSuggestions[issue.key] || this.aiLoadingKeys[issue.key]) return;
+
+    this.aiLoadingKeys[issue.key] = true;
+
+    setTimeout(() => {
+      this.aiLoadingKeys[issue.key] = false;
+
+      if (issue.type === 'COLOR_CONTRAST') {
+        const contrast = issue.contrast ? issue.contrast.toFixed(2) : 'unknown';
+        const fg = issue.foregroundColor ? this.convertToHex(issue.foregroundColor) : 'the text color';
+        const bg = issue.backgroundColor ? this.convertToHex(issue.backgroundColor) : 'the background color';
+        this.aiSuggestions[issue.key] =
+          `The current contrast ratio is ${contrast}:1, which does not meet WCAG AA requirements (minimum 4.5:1 for normal text, 3:1 for large text).\n\n` +
+          `Suggested fix: Update ${fg} (foreground) or ${bg} (background) to achieve at least a 4.5:1 contrast ratio.\n\n` +
+          `For example, try darkening the text color or lightening the background to increase separation. You can verify your updated colors at a contrast checker tool.`;
+      } else {
+        const wcag = issue.wcagCompliance || 'general accessibility best practices';
+        this.aiSuggestions[issue.key] =
+          `To fix "${issue.title}":\n\n` +
+          `${issue.recommendation}\n\n` +
+          `This addresses WCAG compliance: ${wcag}.\n\n` +
+          `Additional context: ${issue.description || 'Review the element and apply the recommended changes to improve accessibility.'}`;
+      }
+    }, 2000);
+  }
+
+  /**
+   * Export PDF report — downloads the audit as a PDF file.
+   */
+  exportPDFReport(): void {
+    this.isReportDownloadDialogDisplayed = true;
+    const pageKey = sessionStorage.getItem("page_key") || '';
+    const url = sessionStorage.getItem("url") || '';
+
+    this.segmentio.trackExportReportAuthenticatedClick(url, pageKey);
+
+    this.report_service.getPDFReport(pageKey).subscribe(
+      result => {
+        const downloadURL = window.URL.createObjectURL(result);
+        const link = document.createElement('a');
+        link.href = downloadURL;
+        link.download = "accessibility_audit_report.pdf";
+        link.click();
+        this.isReportDownloadDialogDisplayed = false;
+      },
+      () => {
+        this.addError("There was an error generating the PDF report. Please try again.");
+        this.isReportDownloadDialogDisplayed = false;
+      }
+    );
+  }
+
+  /**
+   * Return an SVG path for a non-visual issue group icon based on category.
+   */
+  getNonVisualGroupIcon(type: string): string {
+    switch (type.toUpperCase()) {
+      case 'CONTENT':
+      case 'WRITTEN_CONTENT':
+        return 'M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z';
+      case 'INFORMATION_ARCHITECTURE':
+      case 'SEO':
+      case 'METADATA':
+        return 'M4 5a1 1 0 011-1h14a1 1 0 011 1v2a1 1 0 01-1 1H5a1 1 0 01-1-1V5zM4 13a1 1 0 011-1h6a1 1 0 011 1v6a1 1 0 01-1 1H5a1 1 0 01-1-1v-6zM16 13a1 1 0 011-1h2a1 1 0 011 1v6a1 1 0 01-1 1h-2a1 1 0 01-1-1v-6z';
+      case 'AESTHETICS':
+      case 'COLOR_MANAGEMENT':
+      case 'TYPOGRAPHY':
+        return 'M7 21a4 4 0 01-4-4V5a2 2 0 012-2h4a2 2 0 012 2v12a4 4 0 01-4 4zm0 0h12a2 2 0 002-2v-4a2 2 0 00-2-2h-2.343M11 7.343l1.657-1.657a2 2 0 012.828 0l2.829 2.829a2 2 0 010 2.828l-8.486 8.485M7 17h.01';
+      default:
+        return 'M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z';
+    }
+  }
+
+  /**
+   * Called from the onboarding component when user clicks "View Results".
+   */
+  showResults(): void {
+    this.resultsReady = true;
   }
 }


### PR DESCRIPTION
## Summary

- **Landing page** — new public entry point at `/` with dark hero, URL input form, and feature highlights (no auth required)
- **Audit onboarding flow** — animated progress stepper with 5 audit stages and a rotating feature preview carousel shown while the audit runs
- **Redesigned results view** — split-panel layout with screenshot + severity-colored issue bubbles on the right, and a tabbed issue list (Visual Issues / Non-Visual Issues grouped by category) on the left
- **AI Assist** — stubbed per-issue button that generates contextual fix suggestions (color contrast ratios, WCAG references, actionable recommendations)
- **PDF export** — toolbar button to download a comprehensive accessibility audit PDF report
- **Layout updates** — sidebar nav hidden on landing and review pages; new `/audit/:id/review` route for the public flow

## New files
- `components/landing/` — LandingComponent (TS, HTML, SCSS)
- `components/audit-onboarding/` — AuditOnboardingComponent (TS, HTML, SCSS)

## Modified files
- `page-audit-review.component.ts/html/scss` — full rewrite with visual/non-visual tabs, issue bubbles, AI assist, PDF export
- `app-routing.module.ts` — public landing route, `/audit/:id/review` route
- `app.component.ts/html` — conditional sidebar visibility
- `app.module.ts` — register new components

## Test plan
- [ ] Verify landing page renders at `/` without authentication
- [ ] Enter a URL and confirm audit starts, navigating to `/audit/:id/review`
- [ ] Verify onboarding stepper animates through stages while audit loads
- [ ] Confirm results view shows screenshot with issue bubbles colored by severity
- [ ] Switch between Visual Issues and Non-Visual Issues tabs
- [ ] Expand an issue and click AI Assist to see stubbed suggestion
- [ ] Click Export PDF and verify download triggers
- [ ] Confirm existing `/audit/:id/page` route still works for authenticated users
- [ ] Verify sidebar nav is hidden on landing and review pages but visible elsewhere

https://claude.ai/code/session_01EQYCbiwXvJCZETFyGVF9ny