### PR TITLE
Add provider-agnostic LLM integration layer with Anthropic support

### DIFF
--- a/LookseeCore/looksee-llm/pom.xml
+++ b/LookseeCore/looksee-llm/pom.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>com.looksee</groupId>
+		<artifactId>A11yParent</artifactId>
+		<version>0.5.0</version>
+	</parent>
+
+	<artifactId>A11yLlm</artifactId>
+	<name>A11y Core LLM</name>
+	<description>Provider-agnostic LLM integration layer: client interface, Anthropic implementation, redaction, caching, budgeting, retry, metrics and test fakes.</description>
+
+	<dependencies>
+		<dependency>
+			<groupId>com.looksee</groupId>
+			<artifactId>A11yModels</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-configuration-processor</artifactId>
+			<optional>true</optional>
+		</dependency>
+
+		<!-- Resilience4j (already used elsewhere in LookseeCore) -->
+		<dependency>
+			<groupId>io.github.resilience4j</groupId>
+			<artifactId>resilience4j-retry</artifactId>
+			<version>1.7.1</version>
+		</dependency>
+		<dependency>
+			<groupId>io.github.resilience4j</groupId>
+			<artifactId>resilience4j-circuitbreaker</artifactId>
+			<version>1.7.1</version>
+		</dependency>
+
+		<!-- Caching -->
+		<dependency>
+			<groupId>com.github.ben-manes.caffeine</groupId>
+			<artifactId>caffeine</artifactId>
+			<version>2.9.3</version>
+		</dependency>
+
+		<!-- Metrics -->
+		<dependency>
+			<groupId>io.micrometer</groupId>
+			<artifactId>micrometer-core</artifactId>
+		</dependency>
+
+		<!-- Jackson (for request/response JSON + schema-mode parsing) -->
+		<dependency>
+			<groupId>com.fasterxml.jackson.core</groupId>
+			<artifactId>jackson-databind</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+</project>

--- a/LookseeCore/looksee-llm/src/main/java/com/looksee/llm/ImagePart.java
+++ b/LookseeCore/looksee-llm/src/main/java/com/looksee/llm/ImagePart.java
@@ -1,0 +1,36 @@
+package com.looksee.llm;
+
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.HexFormat;
+import lombok.Value;
+
+/**
+ * A single image attached to a multimodal LLM request.
+ *
+ * <p>Use {@link #sha256()} when computing cache keys so that identical image
+ * payloads hit the same cache entry regardless of how they were sourced.
+ */
+@Value
+public class ImagePart {
+
+    byte[] bytes;
+    String mimeType;
+
+    public static ImagePart of(byte[] bytes, String mimeType) {
+        return new ImagePart(bytes, mimeType);
+    }
+
+    /**
+     * Stable hex-encoded SHA-256 of the image bytes.
+     */
+    public String sha256() {
+        try {
+            MessageDigest md = MessageDigest.getInstance("SHA-256");
+            return HexFormat.of().formatHex(md.digest(bytes));
+        } catch (NoSuchAlgorithmException e) {
+            // SHA-256 is required by every JRE; this is unreachable.
+            throw new IllegalStateException("SHA-256 unavailable", e);
+        }
+    }
+}

--- a/LookseeCore/looksee-llm/src/main/java/com/looksee/llm/LlmClient.java
+++ b/LookseeCore/looksee-llm/src/main/java/com/looksee/llm/LlmClient.java
@@ -1,0 +1,39 @@
+package com.looksee.llm;
+
+import java.util.List;
+
+/**
+ * Provider-agnostic entry point for all LLM calls made by Look-see services.
+ *
+ * <p>Implementations are expected to be Spring beans. A single {@code @Primary}
+ * {@link LlmClient} is assembled by {@link com.looksee.llm.config.LlmAutoConfiguration}
+ * by composing the provider implementation with safety, caching, retry and
+ * metrics decorators. Callers should always inject the interface, never a
+ * concrete implementation.
+ */
+public interface LlmClient {
+
+    /**
+     * Executes a text-only completion against the configured provider.
+     */
+    LlmResponse complete(LlmRequest request);
+
+    /**
+     * Executes a multimodal (text + images) completion. Implementations must
+     * fail fast with {@link LlmException} if the resolved model does not
+     * report {@link ModelInfo#isSupportsVision()}.
+     */
+    LlmResponse completeWithVision(LlmRequest request, List<ImagePart> images);
+
+    /**
+     * Stable identifier for the underlying provider, e.g. {@code "anthropic"}.
+     * Used as a metrics tag and as part of the cache key.
+     */
+    String providerId();
+
+    /**
+     * Metadata about the model that will be used if {@link LlmRequest#getModelHint()}
+     * is not set. Decorators inspect this for cost bookkeeping and capability checks.
+     */
+    ModelInfo modelInfo();
+}

--- a/LookseeCore/looksee-llm/src/main/java/com/looksee/llm/LlmException.java
+++ b/LookseeCore/looksee-llm/src/main/java/com/looksee/llm/LlmException.java
@@ -1,0 +1,47 @@
+package com.looksee.llm;
+
+/**
+ * Base type for all LLM-layer errors. Unchecked so that it composes cleanly
+ * with Resilience4j's retry policy, which distinguishes retryable subclasses
+ * from terminal ones.
+ */
+public class LlmException extends RuntimeException {
+
+    public LlmException(String message) {
+        super(message);
+    }
+
+    public LlmException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    /**
+     * Provider rate limit (HTTP 429). Retryable.
+     */
+    public static class LlmRateLimitException extends LlmException {
+        public LlmRateLimitException(String message) { super(message); }
+        public LlmRateLimitException(String message, Throwable cause) { super(message, cause); }
+    }
+
+    /**
+     * Provider refused the request due to safety/content policy. NOT retryable.
+     */
+    public static class LlmContentFilterException extends LlmException {
+        public LlmContentFilterException(String message) { super(message); }
+    }
+
+    /**
+     * Account has exhausted its daily LLM budget. NOT retryable.
+     */
+    public static class LlmBudgetExceededException extends LlmException {
+        public LlmBudgetExceededException(String message) { super(message); }
+    }
+
+    /**
+     * Request violates a capability of the resolved model (e.g. asking for
+     * vision on a text-only model). NOT retryable.
+     */
+    public static class LlmCapabilityException extends LlmException {
+        public LlmCapabilityException(String message) { super(message); }
+    }
+}

--- a/LookseeCore/looksee-llm/src/main/java/com/looksee/llm/LlmRequest.java
+++ b/LookseeCore/looksee-llm/src/main/java/com/looksee/llm/LlmRequest.java
@@ -1,0 +1,76 @@
+package com.looksee.llm;
+
+import java.util.Collections;
+import java.util.Map;
+import lombok.Builder;
+import lombok.Value;
+
+/**
+ * Immutable request passed to an {@link LlmClient}. Callers should use the
+ * Lombok-generated builder.
+ *
+ * <p>{@code metadata} carries feature-level context (e.g. {@code feature="alt_text"},
+ * {@code accountId="..."}) that decorators read for metrics, budget attribution
+ * and cache keying. It is never sent to the provider.
+ */
+@Value
+@Builder(toBuilder = true)
+public class LlmRequest {
+
+    public enum ResponseFormat { TEXT, JSON_SCHEMA }
+
+    /**
+     * Optional system prompt (role/instructions). May be null.
+     */
+    String systemPrompt;
+
+    /**
+     * Required user prompt.
+     */
+    String userPrompt;
+
+    /**
+     * Hard ceiling on output tokens.
+     */
+    @Builder.Default
+    int maxTokens = 1024;
+
+    /**
+     * Sampling temperature. Requests at {@code 0.0} are treated as
+     * deterministic and are eligible for long-TTL caching.
+     */
+    @Builder.Default
+    double temperature = 0.0;
+
+    @Builder.Default
+    ResponseFormat responseFormat = ResponseFormat.TEXT;
+
+    /**
+     * JSON schema for {@link ResponseFormat#JSON_SCHEMA} requests. Ignored
+     * otherwise. Providers that don't support native schema mode will fall back
+     * to prompt-based JSON instruction.
+     */
+    String jsonSchema;
+
+    /**
+     * Optional hint: {@code "default"} (capable model) or {@code "cheap"}
+     * (high-volume model). Resolved by the provider implementation.
+     */
+    @Builder.Default
+    String modelHint = "default";
+
+    /**
+     * Non-sensitive metadata used by decorators. Must not contain PII.
+     * Common keys: {@code feature}, {@code accountId}, {@code traceId}.
+     */
+    @Builder.Default
+    Map<String, String> metadata = Collections.emptyMap();
+
+    public String feature() {
+        return metadata.getOrDefault("feature", "unknown");
+    }
+
+    public String accountId() {
+        return metadata.get("accountId");
+    }
+}

--- a/LookseeCore/looksee-llm/src/main/java/com/looksee/llm/LlmResponse.java
+++ b/LookseeCore/looksee-llm/src/main/java/com/looksee/llm/LlmResponse.java
@@ -1,0 +1,41 @@
+package com.looksee.llm;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+import lombok.Builder;
+import lombok.Value;
+import lombok.With;
+
+/**
+ * Result of a single {@link LlmClient} invocation.
+ *
+ * <p>{@code metadata} is used by decorators to attach non-payload information
+ * such as redaction reports or budget usage, without changing the shape of the
+ * wire response.
+ */
+@Value
+@Builder(toBuilder = true)
+public class LlmResponse {
+
+    String text;
+
+    @Builder.Default
+    Optional<JsonNode> parsedJson = Optional.empty();
+
+    int inputTokens;
+    int outputTokens;
+
+    String finishReason;
+    String providerRequestId;
+    long latencyMs;
+
+    @With
+    boolean cacheHit;
+
+    String modelId;
+
+    @Builder.Default
+    Map<String, Object> metadata = Collections.emptyMap();
+}

--- a/LookseeCore/looksee-llm/src/main/java/com/looksee/llm/ModelInfo.java
+++ b/LookseeCore/looksee-llm/src/main/java/com/looksee/llm/ModelInfo.java
@@ -1,0 +1,20 @@
+package com.looksee.llm;
+
+import lombok.Builder;
+import lombok.Value;
+
+/**
+ * Static metadata about a resolved model. Cost fields are in USD per 1K tokens
+ * and are used by {@link com.looksee.llm.safety.BudgetedLlmClient} to track
+ * per-account spend.
+ */
+@Value
+@Builder
+public class ModelInfo {
+    String provider;
+    String modelId;
+    int contextWindow;
+    boolean supportsVision;
+    double inputCostPer1k;
+    double outputCostPer1k;
+}

--- a/LookseeCore/looksee-llm/src/main/java/com/looksee/llm/anthropic/AnthropicLlmClient.java
+++ b/LookseeCore/looksee-llm/src/main/java/com/looksee/llm/anthropic/AnthropicLlmClient.java
@@ -1,0 +1,247 @@
+package com.looksee.llm.anthropic;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.looksee.llm.ImagePart;
+import com.looksee.llm.LlmClient;
+import com.looksee.llm.LlmException;
+import com.looksee.llm.LlmException.LlmCapabilityException;
+import com.looksee.llm.LlmException.LlmContentFilterException;
+import com.looksee.llm.LlmException.LlmRateLimitException;
+import com.looksee.llm.LlmRequest;
+import com.looksee.llm.LlmResponse;
+import com.looksee.llm.ModelInfo;
+import com.looksee.llm.config.LlmProperties;
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.Base64;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Anthropic implementation of {@link LlmClient}.
+ *
+ * <p>Uses the JDK's built-in {@link HttpClient} rather than pulling in a
+ * third-party SDK — this keeps the dependency surface minimal and avoids
+ * coupling the shared library to a specific SDK release cadence. The wire
+ * format follows the public Anthropic Messages API.
+ *
+ * <p>Exceptions are mapped as follows:
+ * <ul>
+ *   <li>HTTP 429 &rarr; {@link LlmRateLimitException} (retryable)</li>
+ *   <li>HTTP 400 with {@code type=="invalid_request_error"} mentioning content policy
+ *       &rarr; {@link LlmContentFilterException} (terminal)</li>
+ *   <li>Any other error &rarr; generic {@link LlmException}</li>
+ * </ul>
+ */
+@Slf4j
+public class AnthropicLlmClient implements LlmClient {
+
+    private static final String MESSAGES_ENDPOINT = "https://api.anthropic.com/v1/messages";
+    private static final String API_VERSION = "2023-06-01";
+
+    private final LlmProperties properties;
+    private final HttpClient http;
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    public AnthropicLlmClient(LlmProperties properties) {
+        this.properties = properties;
+        this.http = HttpClient.newBuilder()
+                .connectTimeout(Duration.ofSeconds(10))
+                .build();
+    }
+
+    // Visible for testing.
+    AnthropicLlmClient(LlmProperties properties, HttpClient http) {
+        this.properties = properties;
+        this.http = http;
+    }
+
+    @Override
+    public String providerId() {
+        return "anthropic";
+    }
+
+    @Override
+    public ModelInfo modelInfo() {
+        return modelInfoFor(properties.getAnthropic().getDefaultModel());
+    }
+
+    @Override
+    public LlmResponse complete(LlmRequest request) {
+        return invoke(request, Collections.emptyList());
+    }
+
+    @Override
+    public LlmResponse completeWithVision(LlmRequest request, List<ImagePart> images) {
+        ModelInfo info = modelInfoFor(resolveModelId(request));
+        if (!info.isSupportsVision()) {
+            throw new LlmCapabilityException(
+                    "Model " + info.getModelId() + " does not support vision input");
+        }
+        return invoke(request, images);
+    }
+
+    private LlmResponse invoke(LlmRequest request, List<ImagePart> images) {
+        String modelId = resolveModelId(request);
+        ObjectNode body = buildRequestBody(request, images, modelId);
+
+        HttpRequest httpRequest;
+        try {
+            httpRequest = HttpRequest.newBuilder()
+                    .uri(URI.create(MESSAGES_ENDPOINT))
+                    .timeout(Duration.ofSeconds(60))
+                    .header("x-api-key", properties.getAnthropic().getApiKey())
+                    .header("anthropic-version", API_VERSION)
+                    .header("content-type", "application/json")
+                    .POST(HttpRequest.BodyPublishers.ofString(mapper.writeValueAsString(body)))
+                    .build();
+        } catch (IOException e) {
+            throw new LlmException("Failed to serialize Anthropic request", e);
+        }
+
+        long start = System.currentTimeMillis();
+        HttpResponse<String> resp;
+        try {
+            resp = http.send(httpRequest, HttpResponse.BodyHandlers.ofString());
+        } catch (IOException e) {
+            // IOException is retryable by RetryingLlmClient.
+            throw new LlmException("Anthropic request failed: " + e.getMessage(), e);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new LlmException("Anthropic request interrupted", e);
+        }
+        long latency = System.currentTimeMillis() - start;
+
+        mapErrorIfAny(resp);
+        return parseResponse(resp.body(), modelId, latency, request);
+    }
+
+    private ObjectNode buildRequestBody(LlmRequest request, List<ImagePart> images, String modelId) {
+        ObjectNode body = mapper.createObjectNode();
+        body.put("model", modelId);
+        body.put("max_tokens", request.getMaxTokens());
+        body.put("temperature", request.getTemperature());
+
+        if (request.getSystemPrompt() != null && !request.getSystemPrompt().isEmpty()) {
+            body.put("system", request.getSystemPrompt());
+        }
+
+        ArrayNode messages = body.putArray("messages");
+        ObjectNode userMsg = messages.addObject();
+        userMsg.put("role", "user");
+
+        ArrayNode content = userMsg.putArray("content");
+        for (ImagePart image : images) {
+            ObjectNode imgNode = content.addObject();
+            imgNode.put("type", "image");
+            ObjectNode source = imgNode.putObject("source");
+            source.put("type", "base64");
+            source.put("media_type", image.getMimeType());
+            source.put("data", Base64.getEncoder().encodeToString(image.getBytes()));
+        }
+        ObjectNode textNode = content.addObject();
+        textNode.put("type", "text");
+        textNode.put("text", userPromptWithFormatInstruction(request));
+        return body;
+    }
+
+    private String userPromptWithFormatInstruction(LlmRequest request) {
+        if (request.getResponseFormat() == LlmRequest.ResponseFormat.JSON_SCHEMA
+                && request.getJsonSchema() != null) {
+            return request.getUserPrompt()
+                    + "\n\nRespond ONLY with valid JSON conforming to this schema:\n"
+                    + request.getJsonSchema();
+        }
+        return request.getUserPrompt();
+    }
+
+    private void mapErrorIfAny(HttpResponse<String> resp) {
+        int status = resp.statusCode();
+        if (status >= 200 && status < 300) {
+            return;
+        }
+        String body = resp.body() == null ? "" : resp.body();
+        if (status == 429) {
+            throw new LlmRateLimitException("Anthropic rate limited: " + body);
+        }
+        if (body.contains("content policy") || body.contains("content_policy")) {
+            throw new LlmContentFilterException("Anthropic content filter: " + body);
+        }
+        throw new LlmException("Anthropic HTTP " + status + ": " + body);
+    }
+
+    private LlmResponse parseResponse(String body, String modelId, long latencyMs, LlmRequest request) {
+        try {
+            JsonNode root = mapper.readTree(body);
+            String text = "";
+            JsonNode contentArr = root.path("content");
+            if (contentArr.isArray() && contentArr.size() > 0) {
+                JsonNode first = contentArr.get(0);
+                text = first.path("text").asText("");
+            }
+            int inputTokens = root.path("usage").path("input_tokens").asInt(0);
+            int outputTokens = root.path("usage").path("output_tokens").asInt(0);
+            String stopReason = root.path("stop_reason").asText(null);
+            String providerRequestId = root.path("id").asText(null);
+
+            Optional<JsonNode> parsedJson = Optional.empty();
+            if (request.getResponseFormat() == LlmRequest.ResponseFormat.JSON_SCHEMA) {
+                try {
+                    parsedJson = Optional.of(mapper.readTree(text));
+                } catch (IOException ignored) {
+                    log.warn("LLM returned non-JSON body for JSON_SCHEMA request; feature={} ",
+                            request.feature());
+                }
+            }
+
+            return LlmResponse.builder()
+                    .text(text)
+                    .parsedJson(parsedJson)
+                    .inputTokens(inputTokens)
+                    .outputTokens(outputTokens)
+                    .finishReason(stopReason)
+                    .providerRequestId(providerRequestId)
+                    .latencyMs(latencyMs)
+                    .cacheHit(false)
+                    .modelId(modelId)
+                    .build();
+        } catch (IOException e) {
+            throw new LlmException("Failed to parse Anthropic response", e);
+        }
+    }
+
+    private String resolveModelId(LlmRequest request) {
+        if ("cheap".equalsIgnoreCase(request.getModelHint())) {
+            return properties.getAnthropic().getCheapModel();
+        }
+        return properties.getAnthropic().getDefaultModel();
+    }
+
+    private ModelInfo modelInfoFor(String modelId) {
+        // Static table; costs approximate and used only for internal budget
+        // accounting. Update when pricing changes.
+        if (modelId == null) {
+            modelId = "claude-opus-4-6";
+        }
+        boolean vision = modelId.contains("opus") || modelId.contains("sonnet") || modelId.contains("haiku");
+        double in = modelId.contains("opus") ? 0.015 : modelId.contains("sonnet") ? 0.003 : 0.001;
+        double out = modelId.contains("opus") ? 0.075 : modelId.contains("sonnet") ? 0.015 : 0.005;
+        return ModelInfo.builder()
+                .provider("anthropic")
+                .modelId(modelId)
+                .contextWindow(200_000)
+                .supportsVision(vision)
+                .inputCostPer1k(in)
+                .outputCostPer1k(out)
+                .build();
+    }
+}

--- a/LookseeCore/looksee-llm/src/main/java/com/looksee/llm/cache/CachingLlmClient.java
+++ b/LookseeCore/looksee-llm/src/main/java/com/looksee/llm/cache/CachingLlmClient.java
@@ -1,0 +1,102 @@
+package com.looksee.llm.cache;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.looksee.llm.ImagePart;
+import com.looksee.llm.LlmClient;
+import com.looksee.llm.LlmRequest;
+import com.looksee.llm.LlmResponse;
+import com.looksee.llm.ModelInfo;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.time.Duration;
+import java.util.HexFormat;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Caffeine-backed cache in front of an {@link LlmClient}.
+ *
+ * <p>Only deterministic requests ({@code temperature == 0.0}) are cached;
+ * sampled requests bypass the cache so callers never get stale "creative"
+ * output. Cache hits return a copy of the stored response with
+ * {@link LlmResponse#isCacheHit()} set to {@code true} — decorators upstream
+ * (notably {@link com.looksee.llm.safety.BudgetedLlmClient}) rely on this flag
+ * to avoid double-charging.
+ */
+public class CachingLlmClient implements LlmClient {
+
+    private final LlmClient delegate;
+    private final Cache<String, LlmResponse> cache;
+    private final boolean enabled;
+
+    public CachingLlmClient(LlmClient delegate, boolean enabled, int maxSize, Duration ttl) {
+        this.delegate = delegate;
+        this.enabled = enabled;
+        this.cache = Caffeine.newBuilder()
+                .maximumSize(maxSize)
+                .expireAfterWrite(ttl)
+                .build();
+    }
+
+    @Override
+    public LlmResponse complete(LlmRequest request) {
+        if (!enabled || request.getTemperature() != 0.0) {
+            return delegate.complete(request);
+        }
+        String key = keyFor(request, List.of());
+        LlmResponse cached = cache.getIfPresent(key);
+        if (cached != null) {
+            return cached.withCacheHit(true);
+        }
+        LlmResponse resp = delegate.complete(request);
+        cache.put(key, resp);
+        return resp;
+    }
+
+    @Override
+    public LlmResponse completeWithVision(LlmRequest request, List<ImagePart> images) {
+        if (!enabled || request.getTemperature() != 0.0) {
+            return delegate.completeWithVision(request, images);
+        }
+        String key = keyFor(request, images);
+        LlmResponse cached = cache.getIfPresent(key);
+        if (cached != null) {
+            return cached.withCacheHit(true);
+        }
+        LlmResponse resp = delegate.completeWithVision(request, images);
+        cache.put(key, resp);
+        return resp;
+    }
+
+    long size() {
+        return cache.estimatedSize();
+    }
+
+    private String keyFor(LlmRequest request, List<ImagePart> images) {
+        StringBuilder sb = new StringBuilder();
+        sb.append(delegate.providerId()).append('|');
+        sb.append(delegate.modelInfo().getModelId()).append('|');
+        sb.append(request.getModelHint()).append('|');
+        sb.append(request.getResponseFormat()).append('|');
+        sb.append(Objects.toString(request.getJsonSchema(), "")).append('|');
+        sb.append(Objects.toString(request.getSystemPrompt(), "")).append('|');
+        sb.append(request.getUserPrompt()).append('|');
+        for (ImagePart img : images) {
+            sb.append(img.sha256()).append('|');
+        }
+        return sha256(sb.toString());
+    }
+
+    private String sha256(String input) {
+        try {
+            MessageDigest md = MessageDigest.getInstance("SHA-256");
+            return HexFormat.of().formatHex(md.digest(input.getBytes()));
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    @Override public String providerId() { return delegate.providerId(); }
+    @Override public ModelInfo modelInfo() { return delegate.modelInfo(); }
+}

--- a/LookseeCore/looksee-llm/src/main/java/com/looksee/llm/config/LlmAutoConfiguration.java
+++ b/LookseeCore/looksee-llm/src/main/java/com/looksee/llm/config/LlmAutoConfiguration.java
@@ -1,0 +1,98 @@
+package com.looksee.llm.config;
+
+import com.looksee.llm.LlmClient;
+import com.looksee.llm.anthropic.AnthropicLlmClient;
+import com.looksee.llm.cache.CachingLlmClient;
+import com.looksee.llm.metrics.MeteredLlmClient;
+import com.looksee.llm.resilience.RetryingLlmClient;
+import com.looksee.llm.safety.BudgetedLlmClient;
+import com.looksee.llm.safety.LlmBudgetService;
+import com.looksee.llm.safety.PiiRedactor;
+import com.looksee.llm.safety.RedactingLlmClient;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+
+/**
+ * Assembles the canonical {@link LlmClient} bean by composing the provider
+ * implementation (e.g. {@link AnthropicLlmClient}) with decorators, in this
+ * execution order (outermost → innermost):
+ *
+ * <pre>
+ *   Metered → Retrying → Caching → Budgeted → Redacting → Provider
+ * </pre>
+ *
+ * Caching sits inside budget so that cache hits never consume spend; metering
+ * is outermost so it observes every decision the stack makes, including
+ * content-filter failures.
+ *
+ * <p>Applications that want a different assembly can define their own
+ * {@code @Primary LlmClient} bean; this auto-config backs off when one is
+ * already present.
+ */
+@Configuration
+@EnableConfigurationProperties(LlmProperties.class)
+public class LlmAutoConfiguration {
+
+    @Bean
+    @ConditionalOnMissingBean(name = "anthropicLlmClient")
+    @ConditionalOnProperty(prefix = "looksee.llm", name = "provider", havingValue = "anthropic", matchIfMissing = true)
+    public LlmClient anthropicLlmClient(LlmProperties properties) {
+        return new AnthropicLlmClient(properties);
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public PiiRedactor piiRedactor() {
+        return new PiiRedactor();
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public LlmBudgetService.TierResolver llmTierResolver() {
+        // Default: treat everyone as FREE. Applications with an Account graph
+        // override this bean to read com.looksee.models.Account.subscriptionTier.
+        return accountId -> "FREE";
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public LlmBudgetService llmBudgetService(LlmProperties properties,
+                                             LlmBudgetService.TierResolver resolver) {
+        return new LlmBudgetService(properties.getBudget(), resolver);
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public MeterRegistry llmMeterRegistry() {
+        return new SimpleMeterRegistry();
+    }
+
+    @Bean
+    @Primary
+    @ConditionalOnMissingBean(name = "llmClient")
+    public LlmClient llmClient(@Qualifier("anthropicLlmClient") LlmClient provider,
+                               PiiRedactor redactor,
+                               LlmBudgetService budget,
+                               LlmProperties properties,
+                               MeterRegistry meterRegistry) {
+        LlmClient chain = new RedactingLlmClient(provider, redactor,
+                properties.getRedaction().isEnabled());
+        chain = new BudgetedLlmClient(chain, budget);
+        chain = new CachingLlmClient(chain,
+                properties.getCache().isEnabled(),
+                properties.getCache().getMaxSize(),
+                properties.getCache().getTtl());
+        chain = new RetryingLlmClient(chain,
+                properties.getRetry().getMaxAttempts(),
+                properties.getRetry().getInitialBackoffMillis());
+        chain = new MeteredLlmClient(chain, meterRegistry);
+        return chain;
+    }
+}

--- a/LookseeCore/looksee-llm/src/main/java/com/looksee/llm/config/LlmProperties.java
+++ b/LookseeCore/looksee-llm/src/main/java/com/looksee/llm/config/LlmProperties.java
@@ -1,0 +1,56 @@
+package com.looksee.llm.config;
+
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * All configuration for the LLM layer lives here. Bound via Spring Boot's
+ * {@code @ConfigurationProperties} from {@code application.yml} under the
+ * {@code looksee.llm} prefix. See {@code README} in this module for an example.
+ */
+@Data
+@ConfigurationProperties("looksee.llm")
+public class LlmProperties {
+
+    private String provider = "anthropic";
+    private Anthropic anthropic = new Anthropic();
+    private Cache cache = new Cache();
+    private Budget budget = new Budget();
+    private Redaction redaction = new Redaction();
+    private Retry retry = new Retry();
+
+    @Data
+    public static class Anthropic {
+        private String apiKey;
+        private String defaultModel = "claude-opus-4-6";
+        private String cheapModel = "claude-haiku-4-5-20251001";
+    }
+
+    @Data
+    public static class Cache {
+        private boolean enabled = true;
+        private int maxSize = 10_000;
+        private Duration ttl = Duration.ofDays(7);
+    }
+
+    @Data
+    public static class Budget {
+        private double defaultDailyUsd = 5.00;
+        private Map<String, Double> tierOverrides = new HashMap<>();
+    }
+
+    @Data
+    public static class Redaction {
+        private boolean enabled = true;
+        private boolean strict = false;
+    }
+
+    @Data
+    public static class Retry {
+        private int maxAttempts = 4;
+        private long initialBackoffMillis = 1000L;
+    }
+}

--- a/LookseeCore/looksee-llm/src/main/java/com/looksee/llm/metrics/MeteredLlmClient.java
+++ b/LookseeCore/looksee-llm/src/main/java/com/looksee/llm/metrics/MeteredLlmClient.java
@@ -1,0 +1,85 @@
+package com.looksee.llm.metrics;
+
+import com.looksee.llm.ImagePart;
+import com.looksee.llm.LlmClient;
+import com.looksee.llm.LlmException;
+import com.looksee.llm.LlmRequest;
+import com.looksee.llm.LlmResponse;
+import com.looksee.llm.ModelInfo;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tags;
+import io.micrometer.core.instrument.Timer;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Micrometer instrumentation wrapper. Emits:
+ * <ul>
+ *   <li>{@code llm.requests} (timer) with tags
+ *       {@code provider}, {@code model}, {@code feature}, {@code outcome}</li>
+ *   <li>{@code llm.tokens.input} / {@code llm.tokens.output} counters</li>
+ *   <li>{@code llm.cost.usd} counter</li>
+ *   <li>{@code llm.cache.hits} counter</li>
+ * </ul>
+ *
+ * <p>The {@code feature} tag is sourced from {@link LlmRequest#feature()} so
+ * downstream teams can slice cost/latency by business feature without changing
+ * the metrics surface.
+ */
+public class MeteredLlmClient implements LlmClient {
+
+    private final LlmClient delegate;
+    private final MeterRegistry registry;
+
+    public MeteredLlmClient(LlmClient delegate, MeterRegistry registry) {
+        this.delegate = delegate;
+        this.registry = registry;
+    }
+
+    @Override
+    public LlmResponse complete(LlmRequest request) {
+        return timed(request, () -> delegate.complete(request));
+    }
+
+    @Override
+    public LlmResponse completeWithVision(LlmRequest request, List<ImagePart> images) {
+        return timed(request, () -> delegate.completeWithVision(request, images));
+    }
+
+    private LlmResponse timed(LlmRequest request, java.util.function.Supplier<LlmResponse> call) {
+        long start = System.nanoTime();
+        String outcome = "success";
+        LlmResponse resp = null;
+        try {
+            resp = call.get();
+            return resp;
+        } catch (LlmException e) {
+            outcome = e.getClass().getSimpleName();
+            throw e;
+        } finally {
+            Tags tags = Tags.of(
+                    "provider", delegate.providerId(),
+                    "model", delegate.modelInfo().getModelId(),
+                    "feature", request.feature(),
+                    "outcome", outcome);
+            Timer.builder("llm.requests")
+                    .tags(tags)
+                    .register(registry)
+                    .record(System.nanoTime() - start, TimeUnit.NANOSECONDS);
+            if (resp != null) {
+                registry.counter("llm.tokens.input", tags).increment(resp.getInputTokens());
+                registry.counter("llm.tokens.output", tags).increment(resp.getOutputTokens());
+                ModelInfo info = delegate.modelInfo();
+                double cost = ((resp.getInputTokens() / 1000.0) * info.getInputCostPer1k())
+                        + ((resp.getOutputTokens() / 1000.0) * info.getOutputCostPer1k());
+                registry.counter("llm.cost.usd", tags).increment(cost);
+                if (resp.isCacheHit()) {
+                    registry.counter("llm.cache.hits", tags).increment();
+                }
+            }
+        }
+    }
+
+    @Override public String providerId() { return delegate.providerId(); }
+    @Override public ModelInfo modelInfo() { return delegate.modelInfo(); }
+}

--- a/LookseeCore/looksee-llm/src/main/java/com/looksee/llm/resilience/RetryingLlmClient.java
+++ b/LookseeCore/looksee-llm/src/main/java/com/looksee/llm/resilience/RetryingLlmClient.java
@@ -1,0 +1,102 @@
+package com.looksee.llm.resilience;
+
+import com.looksee.llm.ImagePart;
+import com.looksee.llm.LlmClient;
+import com.looksee.llm.LlmException;
+import com.looksee.llm.LlmException.LlmBudgetExceededException;
+import com.looksee.llm.LlmException.LlmCapabilityException;
+import com.looksee.llm.LlmException.LlmContentFilterException;
+import com.looksee.llm.LlmException.LlmRateLimitException;
+import com.looksee.llm.LlmRequest;
+import com.looksee.llm.LlmResponse;
+import com.looksee.llm.ModelInfo;
+import java.io.IOException;
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Retries LLM calls with exponential backoff on retryable errors only.
+ *
+ * <p>Retryable: {@link LlmRateLimitException}, {@link IOException} wrapped in
+ * {@link LlmException}. <b>Terminal</b> (never retried):
+ * {@link LlmContentFilterException}, {@link LlmBudgetExceededException},
+ * {@link LlmCapabilityException}.
+ *
+ * <p>Implementation note: we roll a small bespoke retry loop rather than wiring
+ * Resilience4j's fluent API because the retry-vs-terminal distinction here is
+ * by exception type and we want timing to be deterministic for tests. The
+ * shape mirrors {@link com.looksee.gcp.PubSubPublisher}'s retry idiom.
+ */
+@Slf4j
+public class RetryingLlmClient implements LlmClient {
+
+    private final LlmClient delegate;
+    private final int maxAttempts;
+    private final long initialBackoffMillis;
+    private final Sleeper sleeper;
+
+    public RetryingLlmClient(LlmClient delegate, int maxAttempts, long initialBackoffMillis) {
+        this(delegate, maxAttempts, initialBackoffMillis, Thread::sleep);
+    }
+
+    // Visible for testing.
+    RetryingLlmClient(LlmClient delegate, int maxAttempts, long initialBackoffMillis, Sleeper sleeper) {
+        this.delegate = delegate;
+        this.maxAttempts = maxAttempts;
+        this.initialBackoffMillis = initialBackoffMillis;
+        this.sleeper = sleeper;
+    }
+
+    @FunctionalInterface
+    interface Sleeper {
+        void sleep(long millis) throws InterruptedException;
+    }
+
+    @Override
+    public LlmResponse complete(LlmRequest request) {
+        return withRetry(() -> delegate.complete(request));
+    }
+
+    @Override
+    public LlmResponse completeWithVision(LlmRequest request, List<ImagePart> images) {
+        return withRetry(() -> delegate.completeWithVision(request, images));
+    }
+
+    private LlmResponse withRetry(java.util.function.Supplier<LlmResponse> call) {
+        LlmException last = null;
+        long backoff = initialBackoffMillis;
+        for (int attempt = 1; attempt <= maxAttempts; attempt++) {
+            try {
+                return call.get();
+            } catch (LlmContentFilterException | LlmBudgetExceededException | LlmCapabilityException terminal) {
+                throw terminal;
+            } catch (LlmRateLimitException e) {
+                last = e;
+                log.warn("LLM rate limited (attempt {}/{}): {}", attempt, maxAttempts, e.getMessage());
+            } catch (LlmException e) {
+                if (!isRetryable(e)) {
+                    throw e;
+                }
+                last = e;
+                log.warn("LLM transient failure (attempt {}/{}): {}", attempt, maxAttempts, e.getMessage());
+            }
+            if (attempt < maxAttempts) {
+                try {
+                    sleeper.sleep(backoff);
+                } catch (InterruptedException ie) {
+                    Thread.currentThread().interrupt();
+                    throw new LlmException("Retry interrupted", ie);
+                }
+                backoff *= 2;
+            }
+        }
+        throw new LlmException("LLM call failed after " + maxAttempts + " attempts", last);
+    }
+
+    private boolean isRetryable(LlmException e) {
+        return e.getCause() instanceof IOException;
+    }
+
+    @Override public String providerId() { return delegate.providerId(); }
+    @Override public ModelInfo modelInfo() { return delegate.modelInfo(); }
+}

--- a/LookseeCore/looksee-llm/src/main/java/com/looksee/llm/safety/BudgetedLlmClient.java
+++ b/LookseeCore/looksee-llm/src/main/java/com/looksee/llm/safety/BudgetedLlmClient.java
@@ -1,0 +1,63 @@
+package com.looksee.llm.safety;
+
+import com.looksee.llm.ImagePart;
+import com.looksee.llm.LlmClient;
+import com.looksee.llm.LlmException.LlmBudgetExceededException;
+import com.looksee.llm.LlmRequest;
+import com.looksee.llm.LlmResponse;
+import com.looksee.llm.ModelInfo;
+import java.util.List;
+
+/**
+ * Enforces per-account daily USD caps. Throws
+ * {@link LlmBudgetExceededException} <b>before</b> hitting the provider when
+ * the account is already over budget, and records actual cost after every
+ * successful call using the resolved model's per-1K rates.
+ */
+public class BudgetedLlmClient implements LlmClient {
+
+    private final LlmClient delegate;
+    private final LlmBudgetService budget;
+
+    public BudgetedLlmClient(LlmClient delegate, LlmBudgetService budget) {
+        this.delegate = delegate;
+        this.budget = budget;
+    }
+
+    @Override
+    public LlmResponse complete(LlmRequest request) {
+        checkBudget(request);
+        LlmResponse resp = delegate.complete(request);
+        chargeIfLive(request, resp);
+        return resp;
+    }
+
+    @Override
+    public LlmResponse completeWithVision(LlmRequest request, List<ImagePart> images) {
+        checkBudget(request);
+        LlmResponse resp = delegate.completeWithVision(request, images);
+        chargeIfLive(request, resp);
+        return resp;
+    }
+
+    private void checkBudget(LlmRequest request) {
+        if (!budget.hasHeadroom(request.accountId())) {
+            throw new LlmBudgetExceededException(
+                    "Daily LLM budget exhausted for account=" + request.accountId()
+                            + " feature=" + request.feature());
+        }
+    }
+
+    private void chargeIfLive(LlmRequest request, LlmResponse resp) {
+        if (resp.isCacheHit()) {
+            return; // cache hits never consume budget
+        }
+        ModelInfo info = delegate.modelInfo();
+        double cost = ((resp.getInputTokens() / 1000.0) * info.getInputCostPer1k())
+                + ((resp.getOutputTokens() / 1000.0) * info.getOutputCostPer1k());
+        budget.recordSpend(request.accountId(), cost);
+    }
+
+    @Override public String providerId() { return delegate.providerId(); }
+    @Override public ModelInfo modelInfo() { return delegate.modelInfo(); }
+}

--- a/LookseeCore/looksee-llm/src/main/java/com/looksee/llm/safety/LlmBudgetService.java
+++ b/LookseeCore/looksee-llm/src/main/java/com/looksee/llm/safety/LlmBudgetService.java
@@ -1,0 +1,85 @@
+package com.looksee.llm.safety;
+
+import com.looksee.llm.config.LlmProperties;
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.DoubleAdder;
+
+/**
+ * In-memory daily USD budget tracker keyed on {@code accountId}. This is a
+ * deliberate first-pass: it's correct within a single service instance and
+ * fast. A future revision can back it with Redis or Neo4j for cross-instance
+ * accounting.
+ *
+ * <p>Budgets come from {@link LlmProperties.Budget}: {@code defaultDailyUsd}
+ * with per-tier overrides. Tier lookup is pluggable via
+ * {@link TierResolver} so tests don't need a full Neo4j graph.
+ */
+public class LlmBudgetService {
+
+    /**
+     * Resolves an account id to a subscription tier name (e.g. {@code "FREE"},
+     * {@code "PRO"}, {@code "ENTERPRISE"}). Implementations typically read
+     * {@code com.looksee.models.Account.subscriptionTier}.
+     */
+    public interface TierResolver {
+        String resolve(String accountId);
+    }
+
+    private final LlmProperties.Budget config;
+    private final TierResolver tierResolver;
+    private final Map<String, DoubleAdder> dailySpend = new ConcurrentHashMap<>();
+    private volatile LocalDate bucketDate = LocalDate.now(ZoneOffset.UTC);
+
+    public LlmBudgetService(LlmProperties.Budget config, TierResolver tierResolver) {
+        this.config = config;
+        this.tierResolver = tierResolver;
+    }
+
+    /**
+     * True if {@code accountId} has at least one cent of headroom remaining
+     * today. A null or unknown account gets the default budget.
+     */
+    public boolean hasHeadroom(String accountId) {
+        rotateIfNewDay();
+        double spent = dailySpend.getOrDefault(keyFor(accountId), new DoubleAdder()).sum();
+        return spent < limitFor(accountId);
+    }
+
+    /**
+     * Records that {@code costUsd} was spent for {@code accountId}. Must be
+     * called by the caller after every successful provider invocation.
+     */
+    public void recordSpend(String accountId, double costUsd) {
+        rotateIfNewDay();
+        dailySpend.computeIfAbsent(keyFor(accountId), k -> new DoubleAdder()).add(costUsd);
+    }
+
+    public double remainingUsd(String accountId) {
+        rotateIfNewDay();
+        double spent = dailySpend.getOrDefault(keyFor(accountId), new DoubleAdder()).sum();
+        return Math.max(0.0, limitFor(accountId) - spent);
+    }
+
+    private double limitFor(String accountId) {
+        String tier = accountId == null ? null : tierResolver.resolve(accountId);
+        if (tier != null && config.getTierOverrides().containsKey(tier)) {
+            return config.getTierOverrides().get(tier);
+        }
+        return config.getDefaultDailyUsd();
+    }
+
+    private String keyFor(String accountId) {
+        return accountId == null ? "__anonymous__" : accountId;
+    }
+
+    private synchronized void rotateIfNewDay() {
+        LocalDate today = LocalDate.now(ZoneOffset.UTC);
+        if (!today.equals(bucketDate)) {
+            dailySpend.clear();
+            bucketDate = today;
+        }
+    }
+}

--- a/LookseeCore/looksee-llm/src/main/java/com/looksee/llm/safety/PiiRedactor.java
+++ b/LookseeCore/looksee-llm/src/main/java/com/looksee/llm/safety/PiiRedactor.java
@@ -1,0 +1,156 @@
+package com.looksee.llm.safety;
+
+import com.looksee.llm.safety.RedactionReport.Category;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Scrubs common PII and secrets out of strings before they are forwarded to a
+ * third-party LLM provider. This is intentionally conservative: over-redaction
+ * is acceptable (the LLM still sees placeholder tokens and the task succeeds
+ * for the vast majority of accessibility use cases), under-redaction is not.
+ *
+ * <p>This class is stateless and thread-safe. Callers should obtain a singleton
+ * from Spring.
+ */
+public class PiiRedactor {
+
+    private static final Pattern EMAIL = Pattern.compile(
+            "[A-Za-z0-9._%+\\-]+@[A-Za-z0-9.\\-]+\\.[A-Za-z]{2,}");
+    private static final Pattern PHONE = Pattern.compile(
+            "(?<![\\w-])(?:\\+?\\d{1,3}[\\s.\\-]?)?(?:\\(?\\d{3}\\)?[\\s.\\-]?)\\d{3}[\\s.\\-]?\\d{4}(?![\\w-])");
+    private static final Pattern SSN = Pattern.compile("(?<!\\d)\\d{3}-\\d{2}-\\d{4}(?!\\d)");
+    private static final Pattern IPV4 = Pattern.compile(
+            "(?<![\\d.])(?:\\d{1,3}\\.){3}\\d{1,3}(?![\\d.])");
+    private static final Pattern JWT = Pattern.compile(
+            "eyJ[A-Za-z0-9_\\-]+\\.[A-Za-z0-9_\\-]+\\.[A-Za-z0-9_\\-]+");
+    // Rough shape: sk_... / pk_... / AKIA..., or long hex/base64 strings labeled
+    // as keys.
+    private static final Pattern API_KEY = Pattern.compile(
+            "(?:sk|pk|api[_-]?key|token|secret)[_\\-:=\"' ]+[A-Za-z0-9_\\-]{16,}",
+            Pattern.CASE_INSENSITIVE);
+    // 13-19 digit runs — Luhn-validated before we commit to redacting.
+    private static final Pattern CC_CANDIDATE = Pattern.compile("(?<!\\d)\\d{13,19}(?!\\d)");
+
+    private static final Pattern HTML_PASSWORD_INPUT = Pattern.compile(
+            "(<input\\b[^>]*type\\s*=\\s*[\"'](?:password|email|tel)[\"'][^>]*\\bvalue\\s*=\\s*)[\"'][^\"']*[\"']",
+            Pattern.CASE_INSENSITIVE);
+    private static final Pattern CSRF_META = Pattern.compile(
+            "<meta\\s+[^>]*name\\s*=\\s*[\"']csrf-token[\"'][^>]*>",
+            Pattern.CASE_INSENSITIVE);
+    private static final Pattern COOKIE_HEADER = Pattern.compile(
+            "(?i)(?:cookie|set-cookie)\\s*:\\s*[^\\n\\r]+");
+    private static final Pattern URL_SECRET = Pattern.compile(
+            "([?&](?:access_token|api_key|apikey|token|secret|password|pwd)=)([^&\\s\"'<>]+)",
+            Pattern.CASE_INSENSITIVE);
+
+    /**
+     * Result of redacting a single payload.
+     */
+    public record Result(String text, RedactionReport report) {}
+
+    /**
+     * Redacts the given payload and returns both the scrubbed text and a
+     * report of what was removed. If {@code input} is null, returns an empty
+     * result.
+     */
+    public Result redact(String input) {
+        if (input == null || input.isEmpty()) {
+            return new Result(input == null ? "" : input, RedactionReport.empty());
+        }
+        RedactionReport.Builder report = RedactionReport.builder();
+        String out = input;
+
+        out = applyRegex(out, EMAIL, Category.EMAIL, "[REDACTED:EMAIL]", report);
+        out = applyRegex(out, PHONE, Category.PHONE, "[REDACTED:PHONE]", report);
+        out = applyRegex(out, SSN, Category.SSN, "[REDACTED:SSN]", report);
+        out = applyRegex(out, JWT, Category.JWT, "[REDACTED:JWT]", report);
+        out = applyRegex(out, API_KEY, Category.API_KEY, "[REDACTED:API_KEY]", report);
+        out = applyRegex(out, IPV4, Category.IP_ADDRESS, "[REDACTED:IP]", report);
+
+        out = redactLuhnCandidates(out, report);
+
+        out = applyRegexWithBackref(out, HTML_PASSWORD_INPUT, Category.HTML_SENSITIVE_INPUT,
+                "$1\"[REDACTED]\"", report);
+        out = applyRegex(out, CSRF_META, Category.CSRF_TOKEN, "[REDACTED:CSRF_META]", report);
+        out = applyRegex(out, COOKIE_HEADER, Category.COOKIE, "[REDACTED:COOKIE]", report);
+        out = applyUrlSecretRedaction(out, report);
+
+        return new Result(out, report.build());
+    }
+
+    private String applyRegex(String input, Pattern pattern, Category category,
+                              String replacement, RedactionReport.Builder report) {
+        Matcher m = pattern.matcher(input);
+        int count = 0;
+        StringBuilder sb = new StringBuilder();
+        String quoted = Matcher.quoteReplacement(replacement);
+        while (m.find()) {
+            count++;
+            m.appendReplacement(sb, quoted);
+        }
+        m.appendTail(sb);
+        report.increment(category, count);
+        return sb.toString();
+    }
+
+    private String applyRegexWithBackref(String input, Pattern pattern, Category category,
+                                         String replacement, RedactionReport.Builder report) {
+        Matcher m = pattern.matcher(input);
+        int count = 0;
+        StringBuilder sb = new StringBuilder();
+        while (m.find()) {
+            count++;
+            m.appendReplacement(sb, replacement);
+        }
+        m.appendTail(sb);
+        report.increment(category, count);
+        return sb.toString();
+    }
+
+    private String applyUrlSecretRedaction(String input, RedactionReport.Builder report) {
+        Matcher m = URL_SECRET.matcher(input);
+        int count = 0;
+        StringBuilder sb = new StringBuilder();
+        while (m.find()) {
+            count++;
+            m.appendReplacement(sb, m.group(1) + "[REDACTED]");
+        }
+        m.appendTail(sb);
+        report.increment(Category.URL_SECRET, count);
+        return sb.toString();
+    }
+
+    private String redactLuhnCandidates(String input, RedactionReport.Builder report) {
+        Matcher m = CC_CANDIDATE.matcher(input);
+        StringBuilder sb = new StringBuilder();
+        int count = 0;
+        while (m.find()) {
+            String candidate = m.group();
+            if (luhnValid(candidate)) {
+                count++;
+                m.appendReplacement(sb, "[REDACTED:CC]");
+            } else {
+                m.appendReplacement(sb, Matcher.quoteReplacement(candidate));
+            }
+        }
+        m.appendTail(sb);
+        report.increment(Category.CREDIT_CARD, count);
+        return sb.toString();
+    }
+
+    private boolean luhnValid(String digits) {
+        int sum = 0;
+        boolean alt = false;
+        for (int i = digits.length() - 1; i >= 0; i--) {
+            int n = digits.charAt(i) - '0';
+            if (alt) {
+                n *= 2;
+                if (n > 9) n -= 9;
+            }
+            sum += n;
+            alt = !alt;
+        }
+        return sum % 10 == 0;
+    }
+}

--- a/LookseeCore/looksee-llm/src/main/java/com/looksee/llm/safety/RedactingLlmClient.java
+++ b/LookseeCore/looksee-llm/src/main/java/com/looksee/llm/safety/RedactingLlmClient.java
@@ -1,0 +1,68 @@
+package com.looksee.llm.safety;
+
+import com.looksee.llm.ImagePart;
+import com.looksee.llm.LlmClient;
+import com.looksee.llm.LlmRequest;
+import com.looksee.llm.LlmResponse;
+import com.looksee.llm.ModelInfo;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Scrubs {@link LlmRequest#getSystemPrompt()} and {@link LlmRequest#getUserPrompt()}
+ * via {@link PiiRedactor} before forwarding. The resulting redaction report is
+ * attached to {@link LlmResponse#getMetadata()} under the key {@code "redaction"}.
+ *
+ * <p>Image payloads are not scrubbed; callers responsible for sensitive imagery
+ * should redact pixels upstream.
+ */
+public class RedactingLlmClient implements LlmClient {
+
+    private final LlmClient delegate;
+    private final PiiRedactor redactor;
+    private final boolean enabled;
+
+    public RedactingLlmClient(LlmClient delegate, PiiRedactor redactor, boolean enabled) {
+        this.delegate = delegate;
+        this.redactor = redactor;
+        this.enabled = enabled;
+    }
+
+    @Override
+    public LlmResponse complete(LlmRequest request) {
+        if (!enabled) return delegate.complete(request);
+        PiiRedactor.Result sys = redactor.redact(request.getSystemPrompt());
+        PiiRedactor.Result usr = redactor.redact(request.getUserPrompt());
+        LlmRequest scrubbed = request.toBuilder()
+                .systemPrompt(sys.text())
+                .userPrompt(usr.text())
+                .build();
+        LlmResponse resp = delegate.complete(scrubbed);
+        return attachReport(resp, sys.report(), usr.report());
+    }
+
+    @Override
+    public LlmResponse completeWithVision(LlmRequest request, List<ImagePart> images) {
+        if (!enabled) return delegate.completeWithVision(request, images);
+        PiiRedactor.Result sys = redactor.redact(request.getSystemPrompt());
+        PiiRedactor.Result usr = redactor.redact(request.getUserPrompt());
+        LlmRequest scrubbed = request.toBuilder()
+                .systemPrompt(sys.text())
+                .userPrompt(usr.text())
+                .build();
+        LlmResponse resp = delegate.completeWithVision(scrubbed, images);
+        return attachReport(resp, sys.report(), usr.report());
+    }
+
+    private LlmResponse attachReport(LlmResponse resp, RedactionReport sys, RedactionReport usr) {
+        Map<String, Object> merged = new HashMap<>(resp.getMetadata());
+        merged.put("redaction.system.total", sys.total());
+        merged.put("redaction.user.total", usr.total());
+        merged.put("redaction.user.counts", usr.getCounts());
+        return resp.toBuilder().metadata(merged).build();
+    }
+
+    @Override public String providerId() { return delegate.providerId(); }
+    @Override public ModelInfo modelInfo() { return delegate.modelInfo(); }
+}

--- a/LookseeCore/looksee-llm/src/main/java/com/looksee/llm/safety/RedactionReport.java
+++ b/LookseeCore/looksee-llm/src/main/java/com/looksee/llm/safety/RedactionReport.java
@@ -1,0 +1,50 @@
+package com.looksee.llm.safety;
+
+import java.util.Collections;
+import java.util.EnumMap;
+import java.util.Map;
+import lombok.Value;
+
+/**
+ * Per-request summary of what {@link PiiRedactor} removed. Attached to
+ * {@link com.looksee.llm.LlmResponse#getMetadata()} under the key
+ * {@code "redaction"} so downstream code can audit safety without re-parsing
+ * the request.
+ */
+@Value
+public class RedactionReport {
+
+    public enum Category {
+        EMAIL, PHONE, CREDIT_CARD, SSN, IP_ADDRESS, JWT, API_KEY,
+        HTML_SENSITIVE_INPUT, CSRF_TOKEN, COOKIE, URL_SECRET
+    }
+
+    Map<Category, Integer> counts;
+
+    public static RedactionReport empty() {
+        return new RedactionReport(Collections.emptyMap());
+    }
+
+    public int total() {
+        return counts.values().stream().mapToInt(Integer::intValue).sum();
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private final EnumMap<Category, Integer> counts = new EnumMap<>(Category.class);
+
+        public Builder increment(Category category, int by) {
+            if (by > 0) {
+                counts.merge(category, by, Integer::sum);
+            }
+            return this;
+        }
+
+        public RedactionReport build() {
+            return new RedactionReport(Collections.unmodifiableMap(new EnumMap<>(counts)));
+        }
+    }
+}

--- a/LookseeCore/looksee-llm/src/main/java/com/looksee/llm/testing/FakeLlmClient.java
+++ b/LookseeCore/looksee-llm/src/main/java/com/looksee/llm/testing/FakeLlmClient.java
@@ -1,0 +1,97 @@
+package com.looksee.llm.testing;
+
+import com.looksee.llm.ImagePart;
+import com.looksee.llm.LlmClient;
+import com.looksee.llm.LlmRequest;
+import com.looksee.llm.LlmResponse;
+import com.looksee.llm.ModelInfo;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
+
+/**
+ * Deterministic, no-network {@link LlmClient} for unit tests.
+ *
+ * <p>Usage: either script responses with {@link #enqueue(LlmResponse)} for
+ * sequential scenarios, or install a {@link #setResponder(Function) responder}
+ * for input-dependent behavior. Exposes a {@link #invocationCount()} so tests
+ * can assert that caching wrappers did (or did not) call through.
+ */
+public class FakeLlmClient implements LlmClient {
+
+    private final List<LlmResponse> queue = new ArrayList<>();
+    private final AtomicInteger invocations = new AtomicInteger();
+    private Function<LlmRequest, LlmResponse> responder;
+    private RuntimeException throwOnNextN;
+    private int throwsRemaining = 0;
+
+    private final ModelInfo modelInfo = ModelInfo.builder()
+            .provider("fake")
+            .modelId("fake-model")
+            .contextWindow(100_000)
+            .supportsVision(true)
+            .inputCostPer1k(0.001)
+            .outputCostPer1k(0.002)
+            .build();
+
+    public FakeLlmClient enqueue(LlmResponse response) {
+        queue.add(response);
+        return this;
+    }
+
+    public FakeLlmClient setResponder(Function<LlmRequest, LlmResponse> responder) {
+        this.responder = responder;
+        return this;
+    }
+
+    /**
+     * The next {@code times} invocations will throw {@code ex} before
+     * returning to normal behavior.
+     */
+    public FakeLlmClient throwNext(int times, RuntimeException ex) {
+        this.throwsRemaining = times;
+        this.throwOnNextN = ex;
+        return this;
+    }
+
+    public int invocationCount() {
+        return invocations.get();
+    }
+
+    @Override
+    public LlmResponse complete(LlmRequest request) {
+        return respond(request);
+    }
+
+    @Override
+    public LlmResponse completeWithVision(LlmRequest request, List<ImagePart> images) {
+        return respond(request);
+    }
+
+    private LlmResponse respond(LlmRequest request) {
+        invocations.incrementAndGet();
+        if (throwsRemaining > 0) {
+            throwsRemaining--;
+            throw throwOnNextN;
+        }
+        if (responder != null) {
+            return responder.apply(request);
+        }
+        if (!queue.isEmpty()) {
+            return queue.remove(0);
+        }
+        return LlmResponse.builder()
+                .text("ok")
+                .inputTokens(10)
+                .outputTokens(5)
+                .finishReason("end_turn")
+                .providerRequestId("fake-" + invocations.get())
+                .latencyMs(1)
+                .modelId("fake-model")
+                .build();
+    }
+
+    @Override public String providerId() { return "fake"; }
+    @Override public ModelInfo modelInfo() { return modelInfo; }
+}

--- a/LookseeCore/looksee-llm/src/main/resources/META-INF/spring.factories
+++ b/LookseeCore/looksee-llm/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,2 @@
+org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
+com.looksee.llm.config.LlmAutoConfiguration

--- a/LookseeCore/looksee-llm/src/test/java/com/looksee/llm/cache/CachingLlmClientTest.java
+++ b/LookseeCore/looksee-llm/src/test/java/com/looksee/llm/cache/CachingLlmClientTest.java
@@ -1,0 +1,69 @@
+package com.looksee.llm.cache;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.looksee.llm.LlmRequest;
+import com.looksee.llm.LlmResponse;
+import com.looksee.llm.testing.FakeLlmClient;
+import java.time.Duration;
+import org.junit.jupiter.api.Test;
+
+class CachingLlmClientTest {
+
+    @Test
+    void deterministicRequestIsCached() {
+        FakeLlmClient fake = new FakeLlmClient();
+        CachingLlmClient caching = new CachingLlmClient(fake, true, 100, Duration.ofMinutes(5));
+        LlmRequest req = LlmRequest.builder()
+                .userPrompt("hello")
+                .temperature(0.0)
+                .build();
+
+        LlmResponse first = caching.complete(req);
+        LlmResponse second = caching.complete(req);
+
+        assertFalse(first.isCacheHit());
+        assertTrue(second.isCacheHit());
+        assertEquals(1, fake.invocationCount());
+    }
+
+    @Test
+    void sampledRequestBypassesCache() {
+        FakeLlmClient fake = new FakeLlmClient();
+        CachingLlmClient caching = new CachingLlmClient(fake, true, 100, Duration.ofMinutes(5));
+        LlmRequest req = LlmRequest.builder()
+                .userPrompt("hello")
+                .temperature(0.7)
+                .build();
+
+        caching.complete(req);
+        caching.complete(req);
+
+        assertEquals(2, fake.invocationCount());
+    }
+
+    @Test
+    void disabledCacheBypasses() {
+        FakeLlmClient fake = new FakeLlmClient();
+        CachingLlmClient caching = new CachingLlmClient(fake, false, 100, Duration.ofMinutes(5));
+        LlmRequest req = LlmRequest.builder().userPrompt("hello").build();
+
+        caching.complete(req);
+        caching.complete(req);
+
+        assertEquals(2, fake.invocationCount());
+    }
+
+    @Test
+    void differentPromptsGetDifferentKeys() {
+        FakeLlmClient fake = new FakeLlmClient();
+        CachingLlmClient caching = new CachingLlmClient(fake, true, 100, Duration.ofMinutes(5));
+
+        caching.complete(LlmRequest.builder().userPrompt("a").build());
+        caching.complete(LlmRequest.builder().userPrompt("b").build());
+
+        assertEquals(2, fake.invocationCount());
+    }
+}

--- a/LookseeCore/looksee-llm/src/test/java/com/looksee/llm/resilience/RetryingLlmClientTest.java
+++ b/LookseeCore/looksee-llm/src/test/java/com/looksee/llm/resilience/RetryingLlmClientTest.java
@@ -1,0 +1,68 @@
+package com.looksee.llm.resilience;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.looksee.llm.LlmException;
+import com.looksee.llm.LlmException.LlmContentFilterException;
+import com.looksee.llm.LlmException.LlmRateLimitException;
+import com.looksee.llm.LlmRequest;
+import com.looksee.llm.LlmResponse;
+import com.looksee.llm.testing.FakeLlmClient;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class RetryingLlmClientTest {
+
+    private final LlmRequest request = LlmRequest.builder().userPrompt("hi").build();
+
+    @Test
+    void retriesOnRateLimitThenSucceeds() {
+        FakeLlmClient fake = new FakeLlmClient()
+                .throwNext(2, new LlmRateLimitException("slow down"));
+        List<Long> sleeps = new ArrayList<>();
+        RetryingLlmClient retrying = new RetryingLlmClient(fake, 4, 10L, sleeps::add);
+
+        LlmResponse resp = retrying.complete(request);
+
+        assertEquals("ok", resp.getText());
+        assertEquals(3, fake.invocationCount());
+        // Backoff doubles: 10, 20 between the three attempts.
+        assertEquals(List.of(10L, 20L), sleeps);
+    }
+
+    @Test
+    void contentFilterIsNotRetried() {
+        FakeLlmClient fake = new FakeLlmClient()
+                .throwNext(1, new LlmContentFilterException("nope"));
+        List<Long> sleeps = new ArrayList<>();
+        RetryingLlmClient retrying = new RetryingLlmClient(fake, 4, 10L, sleeps::add);
+
+        assertThrows(LlmContentFilterException.class, () -> retrying.complete(request));
+        assertEquals(1, fake.invocationCount());
+        assertEquals(0, sleeps.size());
+    }
+
+    @Test
+    void exhaustsAttemptsAndWraps() {
+        FakeLlmClient fake = new FakeLlmClient()
+                .throwNext(10, new LlmRateLimitException("429"));
+        RetryingLlmClient retrying = new RetryingLlmClient(fake, 3, 1L, ms -> {});
+
+        assertThrows(LlmException.class, () -> retrying.complete(request));
+        assertEquals(3, fake.invocationCount());
+    }
+
+    @Test
+    void retriesOnIoExceptionWrappedInLlmException() {
+        FakeLlmClient fake = new FakeLlmClient()
+                .throwNext(1, new LlmException("network", new IOException("boom")));
+        RetryingLlmClient retrying = new RetryingLlmClient(fake, 3, 1L, ms -> {});
+
+        LlmResponse resp = retrying.complete(request);
+        assertEquals("ok", resp.getText());
+        assertEquals(2, fake.invocationCount());
+    }
+}

--- a/LookseeCore/looksee-llm/src/test/java/com/looksee/llm/safety/BudgetedLlmClientTest.java
+++ b/LookseeCore/looksee-llm/src/test/java/com/looksee/llm/safety/BudgetedLlmClientTest.java
@@ -1,0 +1,85 @@
+package com.looksee.llm.safety;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.looksee.llm.LlmException.LlmBudgetExceededException;
+import com.looksee.llm.LlmRequest;
+import com.looksee.llm.LlmResponse;
+import com.looksee.llm.config.LlmProperties;
+import com.looksee.llm.testing.FakeLlmClient;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class BudgetedLlmClientTest {
+
+    private LlmBudgetService service(double defaultUsd) {
+        LlmProperties.Budget cfg = new LlmProperties.Budget();
+        cfg.setDefaultDailyUsd(defaultUsd);
+        return new LlmBudgetService(cfg, accountId -> "FREE");
+    }
+
+    private LlmRequest request(String accountId) {
+        return LlmRequest.builder()
+                .userPrompt("hi")
+                .metadata(Map.of("accountId", accountId, "feature", "test"))
+                .build();
+    }
+
+    @Test
+    void allowsCallsUnderLimit() {
+        FakeLlmClient fake = new FakeLlmClient().enqueue(
+                LlmResponse.builder().text("ok").inputTokens(100).outputTokens(50).build());
+        BudgetedLlmClient budgeted = new BudgetedLlmClient(fake, service(10.0));
+
+        LlmResponse resp = budgeted.complete(request("acct-1"));
+        assertEquals("ok", resp.getText());
+    }
+
+    @Test
+    void throwsOnceBudgetExhausted() {
+        LlmBudgetService svc = service(0.0001);
+        // Burn the budget preemptively.
+        svc.recordSpend("acct-1", 1.0);
+
+        FakeLlmClient fake = new FakeLlmClient();
+        BudgetedLlmClient budgeted = new BudgetedLlmClient(fake, svc);
+
+        assertThrows(LlmBudgetExceededException.class,
+                () -> budgeted.complete(request("acct-1")));
+        assertEquals(0, fake.invocationCount());
+    }
+
+    @Test
+    void cacheHitsDoNotChargeBudget() {
+        LlmBudgetService svc = service(10.0);
+        FakeLlmClient fake = new FakeLlmClient().enqueue(
+                LlmResponse.builder()
+                        .text("cached")
+                        .inputTokens(1000)
+                        .outputTokens(1000)
+                        .cacheHit(true)
+                        .build());
+        BudgetedLlmClient budgeted = new BudgetedLlmClient(fake, svc);
+
+        budgeted.complete(request("acct-1"));
+        assertEquals(10.0, svc.remainingUsd("acct-1"), 0.0001);
+    }
+
+    @Test
+    void liveCallsDecrementBudget() {
+        LlmBudgetService svc = service(10.0);
+        FakeLlmClient fake = new FakeLlmClient().enqueue(
+                LlmResponse.builder()
+                        .text("x")
+                        .inputTokens(1000) // 1000 tokens * 0.001/1k = 0.001 USD
+                        .outputTokens(1000) // 1000 tokens * 0.002/1k = 0.002 USD
+                        .build());
+        BudgetedLlmClient budgeted = new BudgetedLlmClient(fake, svc);
+
+        budgeted.complete(request("acct-1"));
+        assertTrue(svc.remainingUsd("acct-1") < 10.0);
+        assertTrue(svc.remainingUsd("acct-1") > 9.99);
+    }
+}

--- a/LookseeCore/looksee-llm/src/test/java/com/looksee/llm/safety/PiiRedactorTest.java
+++ b/LookseeCore/looksee-llm/src/test/java/com/looksee/llm/safety/PiiRedactorTest.java
@@ -1,0 +1,88 @@
+package com.looksee.llm.safety;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.looksee.llm.safety.RedactionReport.Category;
+import org.junit.jupiter.api.Test;
+
+class PiiRedactorTest {
+
+    private final PiiRedactor redactor = new PiiRedactor();
+
+    @Test
+    void redactsEmail() {
+        PiiRedactor.Result r = redactor.redact("Contact me at alice@example.com please");
+        assertTrue(r.text().contains("[REDACTED:EMAIL]"));
+        assertFalse(r.text().contains("alice@example.com"));
+        assertEquals(1, r.report().getCounts().get(Category.EMAIL));
+    }
+
+    @Test
+    void redactsUsPhone() {
+        PiiRedactor.Result r = redactor.redact("Call (415) 555-1234 now");
+        assertTrue(r.text().contains("[REDACTED:PHONE]"));
+    }
+
+    @Test
+    void redactsValidCreditCard() {
+        // 4111 1111 1111 1111 is the canonical Luhn-valid Visa test number.
+        PiiRedactor.Result r = redactor.redact("card 4111111111111111 end");
+        assertTrue(r.text().contains("[REDACTED:CC]"));
+    }
+
+    @Test
+    void doesNotRedactLuhnInvalidDigits() {
+        PiiRedactor.Result r = redactor.redact("order 1234567890123456 end");
+        assertTrue(r.text().contains("1234567890123456"));
+    }
+
+    @Test
+    void redactsSsn() {
+        PiiRedactor.Result r = redactor.redact("ssn 123-45-6789");
+        assertTrue(r.text().contains("[REDACTED:SSN]"));
+    }
+
+    @Test
+    void redactsJwt() {
+        String jwt = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.abcDEF123";
+        PiiRedactor.Result r = redactor.redact("token=" + jwt);
+        assertTrue(r.text().contains("[REDACTED:JWT]"));
+    }
+
+    @Test
+    void redactsApiKey() {
+        PiiRedactor.Result r = redactor.redact("api_key=sk_live_abcdefghijklmnopqrstuv");
+        assertTrue(r.text().contains("[REDACTED:API_KEY]"));
+    }
+
+    @Test
+    void redactsHtmlPasswordInputValue() {
+        String html = "<input type=\"password\" value=\"hunter2\" name=\"pw\">";
+        PiiRedactor.Result r = redactor.redact(html);
+        assertFalse(r.text().contains("hunter2"));
+        assertTrue(r.text().contains("[REDACTED]"));
+    }
+
+    @Test
+    void redactsUrlQuerySecret() {
+        PiiRedactor.Result r = redactor.redact("https://api.example.com/x?access_token=abc123&q=foo");
+        assertTrue(r.text().contains("access_token=[REDACTED]"));
+        assertTrue(r.text().contains("q=foo"));
+    }
+
+    @Test
+    void emptyInputReturnsEmptyReport() {
+        PiiRedactor.Result r = redactor.redact("");
+        assertEquals(0, r.report().total());
+    }
+
+    @Test
+    void passesThroughCleanText() {
+        String clean = "The quick brown fox jumps over the lazy dog.";
+        PiiRedactor.Result r = redactor.redact(clean);
+        assertEquals(clean, r.text());
+        assertEquals(0, r.report().total());
+    }
+}

--- a/LookseeCore/looksee-llm/src/test/java/com/looksee/llm/safety/RedactingLlmClientTest.java
+++ b/LookseeCore/looksee-llm/src/test/java/com/looksee/llm/safety/RedactingLlmClientTest.java
@@ -1,0 +1,47 @@
+package com.looksee.llm.safety;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.looksee.llm.LlmRequest;
+import com.looksee.llm.LlmResponse;
+import com.looksee.llm.testing.FakeLlmClient;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.Test;
+
+class RedactingLlmClientTest {
+
+    @Test
+    void scrubsPromptBeforeForwarding() {
+        AtomicReference<LlmRequest> seen = new AtomicReference<>();
+        FakeLlmClient fake = new FakeLlmClient().setResponder(req -> {
+            seen.set(req);
+            return LlmResponse.builder().text("ok").build();
+        });
+        RedactingLlmClient redacting = new RedactingLlmClient(fake, new PiiRedactor(), true);
+
+        LlmRequest req = LlmRequest.builder()
+                .systemPrompt("system")
+                .userPrompt("email alice@example.com")
+                .build();
+        LlmResponse resp = redacting.complete(req);
+
+        assertFalse(seen.get().getUserPrompt().contains("alice@example.com"));
+        assertTrue(seen.get().getUserPrompt().contains("[REDACTED:EMAIL]"));
+        assertEquals(1, resp.getMetadata().get("redaction.user.total"));
+    }
+
+    @Test
+    void disabledPassesThrough() {
+        AtomicReference<LlmRequest> seen = new AtomicReference<>();
+        FakeLlmClient fake = new FakeLlmClient().setResponder(req -> {
+            seen.set(req);
+            return LlmResponse.builder().text("ok").build();
+        });
+        RedactingLlmClient redacting = new RedactingLlmClient(fake, new PiiRedactor(), false);
+
+        redacting.complete(LlmRequest.builder().userPrompt("email alice@example.com").build());
+        assertTrue(seen.get().getUserPrompt().contains("alice@example.com"));
+    }
+}

--- a/LookseeCore/pom.xml
+++ b/LookseeCore/pom.xml
@@ -16,6 +16,7 @@
 		<module>looksee-gcp</module>
 		<module>looksee-nlp</module>
 		<module>looksee-utils</module>
+		<module>looksee-llm</module>
 		<module>looksee-core</module>
 	</modules>
 
@@ -98,6 +99,11 @@
 			<dependency>
 				<groupId>com.looksee</groupId>
 				<artifactId>A11yUtils</artifactId>
+				<version>${looksee.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>com.looksee</groupId>
+				<artifactId>A11yLlm</artifactId>
 				<version>${looksee.version}</version>
 			</dependency>
 		</dependencies>


### PR DESCRIPTION
## Summary
Introduces a new `looksee-llm` module that provides a provider-agnostic LLM client interface with a complete Anthropic implementation, plus a composable decorator stack for safety, caching, resilience, and observability.

## Key Changes

**Core Interfaces & Models**
- `LlmClient`: Provider-agnostic interface for text and vision completions
- `LlmRequest` / `LlmResponse`: Immutable request/response types with metadata support
- `ModelInfo`: Static model metadata (context window, vision support, pricing)
- `ImagePart`: Multimodal image payload with SHA-256 hashing for cache keying
- `LlmException` hierarchy: Distinguishes retryable (rate limit, I/O) from terminal (content filter, budget) errors

**Anthropic Provider**
- `AnthropicLlmClient`: Uses JDK `HttpClient` (no SDK dependency) to call the Anthropic Messages API
- Supports system prompts, JSON schema responses, vision inputs, and temperature control
- Maps HTTP errors to typed exceptions (429 → `LlmRateLimitException`, 400 content policy → `LlmContentFilterException`)

**Safety & Compliance**
- `PiiRedactor`: Stateless scrubber for emails, phones, SSNs, JWTs, API keys, credit cards, HTML password inputs, CSRF tokens, cookies, and URL secrets
- `RedactingLlmClient`: Decorator that redacts prompts before forwarding; attaches redaction report to response metadata
- `BudgetedLlmClient`: Per-account daily USD budget enforcement with tier-based overrides; charges actual cost post-call using model pricing
- `LlmBudgetService`: In-memory daily spend tracker with pluggable tier resolution

**Resilience & Performance**
- `RetryingLlmClient`: Exponential backoff retry loop (retries rate limits and I/O errors; fails fast on content filter and budget)
- `CachingLlmClient`: Caffeine-backed cache for deterministic requests (temperature=0.0); cache hits bypass budget charges
- `MeteredLlmClient`: Micrometer instrumentation emitting request latency, token counts, cost, and cache hit metrics

**Configuration & Testing**
- `LlmAutoConfiguration`: Spring Boot auto-config that assembles the decorator stack in order: Metered → Retrying → Caching → Budgeted → Redacting → Provider
- `LlmProperties`: YAML-bound configuration for provider selection, API keys, model hints, cache TTL, budget limits, and retry parameters
- `FakeLlmClient`: Deterministic test double with response queueing, input-dependent responders, and invocation counting

## Notable Implementation Details

- **No third-party SDK**: Uses JDK `HttpClient` to minimize dependency surface and avoid coupling to SDK release cadence
- **Decorator composition**: Stack order ensures cache hits never consume budget, and metrics observe all decisions including failures
- **Conservative redaction**: Over-redaction is acceptable for accessibility use cases; Luhn validation for credit cards prevents false positives
- **Deterministic caching**: Only temperature=0.0 requests are cached; sampled requests always bypass to avoid stale "creative" output
- **Pluggable tier resolution**: Budget service accepts a `TierResolver` interface so tests don't require a full Neo4j graph
- **Metadata propagation**: Request metadata (feature, accountId, traceId) flows through decorators for metrics and budget attribution without being sent to the provider

https://claude.ai/code/session_01TMyYYJE12WDgXoiSqKJBmZ