### PR TITLE
UX redesign: docs + Phase A design system foundation

### DIFF
--- a/Look-see-UI-v3/UX_REDESIGN.md
+++ b/Look-see-UI-v3/UX_REDESIGN.md
@@ -1,0 +1,705 @@
+# Look-see UI — End-to-End UX Redesign
+
+> Companion to `REDESIGN_PLAN.md`. That document covers the **visual design system** (colors, type, spacing, components). This document covers the **UX architecture** — flows, onboarding friction, information hierarchy, interaction patterns, and copy. Read the two together.
+
+**Author:** Principal UX review
+**Scope:** Full product, optimized for non-expert first-time users with depth available for power users
+**Status:** Proposal — no code changes made
+
+---
+
+## 0. Product thesis (re-stated)
+
+Look-see is a **self-serve UX audit tool** whose value prop collapses to one sentence:
+
+> *Paste a URL. Get a prioritized list of UX, accessibility, and content fixes. Ship them.*
+
+Every design decision below is measured against that sentence. If a screen, click, or word doesn't move the user toward that outcome, it's cut.
+
+The product is competing for attention with Lighthouse, axe DevTools, Wave, SiteImprove, Siteimprove, AccessiBe, and a long tail of AI audit tools. Our wedge is not "more checks" — it's **clarity of action**. The user's emotional journey should be:
+
+1. *Curiosity* — "I wonder how my site does."
+2. *Surprise* — "Oh, there's more wrong than I thought."
+3. *Relief* — "But I can see exactly what to fix, and why it matters."
+4. *Confidence* — "I can share this with my team and make it better."
+
+The current UI sometimes delivers step 2 but often fumbles steps 3 and 4. This redesign is about getting all four right.
+
+---
+
+## 1. Primary persona — "Mixed, optimize for non-expert first"
+
+**Primary: Morgan, the Accidental Auditor.** A product manager, marketer, founder, or small-agency owner who suspects their site has issues but doesn't know WCAG from WCAF. They have 10 minutes, not an hour. They need plain language and prioritization, not a 47-item checklist.
+
+**Secondary: Priya, the Pro.** A designer, front-end engineer, or accessibility specialist who needs the *depth* — element selectors, WCAG references, fix snippets, and exportable reports for stakeholders.
+
+**Design rule:** Morgan sees a clean, opinionated surface. Priya can drill into raw specifics with one or two clicks. Never make Morgan pay a complexity tax for Priya's power tools.
+
+**Jobs to be done:**
+- *Morgan:* "Show me what's broken, what matters, and what to do next."
+- *Priya:* "Give me the issue, the element, the WCAG reference, and a shareable report."
+
+---
+
+## 2. Current state — friction diagnosis
+
+From the code review, the top ten friction points. I've re-grouped them by the moment in the journey where they hurt.
+
+### First impression (before signup)
+1. **Landing URL input is punitive.** Hardcoded TLD regex rejects valid URLs (`.io`, `.co`, `.me`). A user's very first interaction fails with a generic error. **Severity: critical** — this is the top-of-funnel.
+2. **"1 free audit for guests" dialog is pessimistic.** Verbatim: *"Unfortunately we only provide 1 free audit for visitors without an account."* That word "unfortunately" frames the product as stingy at the exact moment we're trying to convert.
+3. **No trust scaffolding on the landing page.** No customer logos, sample report preview, or "10,000 sites audited" social proof. Morgan has nothing to believe in yet.
+
+### During the audit (the scariest wait)
+4. **Onboarding carousel auto-rotates every 5s regardless of user focus.** Content slides out from under the user while they're reading.
+5. **No ETA, no way to cancel, no reassurance if the audit stalls.** Hard-coded 18s delays in `audit-onboarding` don't match reality for domain audits that take 5+ minutes.
+6. **No status visibility for in-progress audits** once the user navigates away. The audit list doesn't show PENDING/RUNNING/FAILED states.
+
+### Reading results (the "aha" moment that isn't)
+7. **`page-audit-review` is a 1,293-LOC monolith** with panels that scroll independently and lose context.
+8. **Tone drift in results copy.** "Astounding!!!!", "truly exception experience" (sic) — breaks Morgan's trust. Priya sees it as sloppy.
+9. **Results are dumped, not prioritized.** Issues appear in load-order, not impact-order. Morgan doesn't know what to fix first.
+
+### After results (the handoff)
+10. **Guest users can't export.** Audit finishes, user feels the "aha," clicks Export PDF, and is hard-walled into signup with no preview of what they'd get. Conversion leaks here.
+
+Underlying all ten: **the product talks to itself more than to the user.** Screens are organized around the backend data model (audits, domains, page-audits, stats) rather than the user's goal (find problems, fix them, prove the fix).
+
+---
+
+## 3. Redesign principles
+
+These are the five rules the rest of this document is derived from. When a decision is hard, return here.
+
+1. **Demonstrate value before asking for anything.** The first full audit experience — including viewing results, seeing the prioritized fix list, and reading one AI recommendation — happens before signup. Signup unlocks *saving, exporting, and re-auditing*, not *seeing*.
+2. **Progressive disclosure.** Morgan sees a score, a top-3 issue list, and a "what to do next" CTA. Priya clicks one button to reveal WCAG refs, selectors, and raw JSON.
+3. **Status is a first-class citizen.** Every long-running operation has a visible state, an ETA, a way to leave and come back, and a notification when it's done.
+4. **Prioritize for impact, not for taxonomy.** Default view is "Top 10 fixes ranked by estimated user impact × effort," not "Visual Design → Color → Contrast → 47 items."
+5. **One tone, always.** Warm, plainspoken, mildly witty, never cute. No "!!!!"'s. No "Unfortunately." Every piece of copy passes a single voice test (see §10).
+
+---
+
+## 4. Information architecture — proposed
+
+### 4.1 Current IA problems
+- `/dashboard` is orphaned (no nav link).
+- Two different review paths (`/audit/:id/page` vs `/audit/:id/review`) with subtle guard differences.
+- `/how-it-works` and `/integration` are public but sit alongside workspace pages in the nav.
+- No concept of *projects* or *workspaces* — every audit is equal peers in a flat list.
+
+### 4.2 Proposed IA
+
+```
+Public (no auth)
+├── /                      Landing (try it now)
+├── /r/:shareToken         Shared audit result (read-only, no nav chrome)
+├── /pricing               Pricing & plans
+└── /how-it-works          Educational marketing
+
+Authenticated (app shell)
+├── /home                  Workspace home — recent activity, quick audit, monitored sites
+├── /sites                 Site list (formerly "Domains")
+│   └── /sites/:id         Site overview (aggregate scores, page list, trends)
+├── /audits                Full audit history (paginated, filterable)
+│   └── /audits/:id        Audit results (unified, adapts to single-page vs domain)
+├── /integrations          Integrations marketplace
+├── /settings              Account, billing, team, notifications
+└── /help                  In-app help (merged with how-it-works)
+```
+
+**Key moves:**
+- Rename **Domain → Site** everywhere in the UI. "Domain" is an engineer's word; "site" is everyone else's.
+- Collapse the two review routes into one `/audits/:id` that adapts to its shape.
+- Introduce **`/home`** as the post-login default — a dashboard that answers "what happened since I was last here?" instead of dumping the user into a list.
+- Move `/integrations` to a lower nav priority until integrations actually ship.
+- Move legal and help to a footer, not the primary nav.
+
+### 4.3 Proposed sidebar
+
+```
+┌──────────────────────────┐
+│  ◆ Look-see              │   ← logo + wordmark, 24px
+│  ────────────────────    │
+│                          │
+│  ⚡ New audit   [ + ]    │   ← always-visible primary action
+│                          │
+│  WORKSPACE               │
+│    ⌂ Home                │
+│    ◈ Sites               │
+│    ≡ Audits              │
+│                          │
+│  LEARN                   │
+│    ? Help                │
+│    ⇄ Integrations    •   │   ← dot = "new" or "early access"
+│                          │
+│  ─────────────────────   │
+│  [ MB ] Morgan B.    ⌃   │   ← user menu, collapses up
+└──────────────────────────┘
+```
+
+Rationale: the "New audit" button is the app's single most important action. It lives outside any list, always one click away. The sidebar collapses to a 56px icon rail on narrower viewports.
+
+---
+
+## 5. First-run experience — the onboarding redesign
+
+This section is the core of the brief. The current first-run has ~8 friction points in ~90 seconds. Below is the target flow.
+
+### 5.1 Target flow (happy path, non-expert guest)
+
+```
+T+0s       Land on /          →  Immediate URL input, autofocused
+T+3s       User types URL
+T+4s       Click "Audit my site"  (no login yet)
+T+4s       Audit starts. Full-screen progress scene.
+T+4-30s    Live feed of what we're checking, actual findings streaming in
+T+30s      Results slide in. Score, top 3 fixes, "see all 27 issues"
+T+45s      User reads top fix. Clicks "Why this matters."
+T+60s      "Save this report?" soft prompt, inline signup (Google, email)
+T+90s      Signed up. Report saved. Next audit unlocked.
+```
+
+Target activation metric: **70% of URL submissions reach "results visible" state; 35% of those complete signup within 5 minutes.**
+
+### 5.2 Landing page redesign
+
+**Above the fold — only three things:**
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│  ◆ Look-see                         Pricing   Log in   [Try it] │
+│                                                                 │
+│                                                                 │
+│      Find what's broken on your website.                        │
+│      In under a minute. Without opening DevTools.               │
+│                                                                 │
+│      ┌─────────────────────────────────────┬───────────────┐    │
+│      │  🌐  https://your-site.com          │  Audit my site │    │
+│      └─────────────────────────────────────┴───────────────┘    │
+│                                                                 │
+│      Free, no signup. We'll check accessibility,                │
+│      content quality, visual design, and SEO.                   │
+│                                                                 │
+│      ▸ Trusted by teams at [logo] [logo] [logo] [logo]          │
+│                                                                 │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+**Fixes applied:**
+- New headline: concrete, benefit-first, uses plain language. Old: *"Find and fix accessibility issues in seconds."* New: *"Find what's broken on your website."* (Accessibility is *one* of the things we find; leading with it narrows the addressable market.)
+- Input is the hero, CTA is adjacent, not below.
+- "Free, no signup" removes the #1 guest conversion barrier.
+- Microcopy lists the four audit dimensions so the user knows what they'll get.
+- Social proof lives above the fold, not in a separate testimonials section.
+- **URL validation is permissive.** Accept anything that parses as a URL; prepend `https://` if scheme is missing; let the backend reject if unreachable. Remove the TLD regex entirely.
+
+**Below the fold, three sections only:**
+1. **Live example.** A canned audit of a well-known site rendered in an iframe-like preview, showing the results UI the user is about to experience. Sells the product by showing it.
+2. **How it works** (three steps with illustrations — reuse existing assets in `/assets/illustrations/`).
+3. **What we check.** The four audit dimensions explained in one paragraph each, each with a "See a sample issue →" link that scrolls to an inline example.
+
+Cut: the second CTA section, the "aggressive hot pink" banner flagged in the existing plan, the footer-as-secondary-nav pattern.
+
+### 5.3 The progress scene (T+4s to T+30s)
+
+This is the most underrated screen in the product. The user has committed something (a URL) and is waiting. Every second of that wait either builds confidence or erodes it.
+
+**Current:** a 4-slide carousel auto-rotates every 5s with generic marketing copy while 5 hardcoded "steps" tick past on fake timers.
+
+**Proposed:** a **live audit feed** — the user watches their site being audited in real time.
+
+```
+┌───────────────────────────────────────────────────────┐
+│                                                       │
+│   Auditing yoursite.com                               │
+│                                                       │
+│   [ progress bar: 43% ]           about 20s remaining │
+│                                                       │
+│   ┌─────────────────────┐  ┌────────────────────────┐ │
+│   │                     │  │ ✓ Captured page (2.1s)│ │
+│   │                     │  │ ✓ Fetched 14 assets    │ │
+│   │  [ live screenshot  │  │ ⋯ Checking contrast…   │ │
+│   │    of target page ] │  │ ✓ Found 3 heading      │ │
+│   │                     │  │   hierarchy issues     │ │
+│   │                     │  │ ⋯ Analyzing typography │ │
+│   └─────────────────────┘  └────────────────────────┘ │
+│                                                       │
+│   [ Leave and notify me when done ]                   │
+│                                                       │
+└───────────────────────────────────────────────────────┘
+```
+
+**Why this works:**
+- The screenshot thumbnail turns an abstract wait into "we're looking at *your* site" — immediate trust.
+- The streaming feed gives concrete evidence of work. Every checkmark is a tiny dopamine hit.
+- Real findings begin appearing *before* the audit is done ("Found 3 heading hierarchy issues") — the user starts extracting value at T+10s, not T+30s.
+- The "Leave and notify me when done" button acknowledges that audits take time and treats the user's time as precious. This is enabled by email capture at this step (optional) or a browser notification permission request.
+- **No carousel.** If we need to educate the user while they wait, do it as an "optional" panel they can open, not as involuntary content.
+
+**Implementation note:** the WebSocket/Pusher pipeline flagged in the review already streams `auditUpdate` events; this screen just needs to render them well. Today the data flows in but isn't surfaced. The audit service's existing event shapes (`pageFound`, `auditUpdate`) support this with minor additions.
+
+### 5.4 The results reveal (T+30s)
+
+When the audit finishes, the progress scene transitions (not jumps) to results. The first view is radically simpler than today's `page-audit-review`:
+
+```
+┌───────────────────────────────────────────────────────────────┐
+│   yoursite.com/                         Audit complete ✓      │
+│                                                               │
+│   ┌────────┐   UX Health Score                                │
+│   │   72   │   Room to improve. You have 3 critical issues    │
+│   │   /100 │   and 24 minor ones. Start with the top 3 below. │
+│   └────────┘   ◎ Accessibility 64  ◎ Content 81  ◎ Visual 78  │
+│                                                               │
+│   ─────────────────────────────────────────────────────────   │
+│                                                               │
+│   🔴  Contrast too low on primary CTA button                  │
+│       Users with low vision may not see your "Sign up" button │
+│       Affects: 1 element • WCAG 2.1 AA                        │
+│       [ View details → ]                                      │
+│                                                               │
+│   🔴  Missing alt text on 8 images                            │
+│       Screen readers can't describe these images to users     │
+│       Affects: 8 elements • WCAG 2.1 A                        │
+│       [ View details → ]                                      │
+│                                                               │
+│   🟡  Heading hierarchy skips H2                              │
+│       Your page jumps from H1 to H3, confusing assistive tech │
+│       Affects: 3 elements • WCAG 2.1 AA                       │
+│       [ View details → ]                                      │
+│                                                               │
+│   ─────────────────────────────────────────────────────────   │
+│   Show 24 more issues ▾                                       │
+│                                                               │
+│   [ Save report ]  [ Export PDF ]  [ Share link ]             │
+└───────────────────────────────────────────────────────────────┘
+```
+
+**Key moves:**
+- Score lives with **one sentence of plain-English meaning.** No user should have to wonder "is 72 good?"
+- Sub-scores are one line, not five huge cards.
+- **Top 3 issues, ranked by impact × severity**, with human-language descriptions. The taxonomic breakdown ("Visual Design → Color → Contrast → Specific-check-name") is *inside* the detail view, not the list.
+- "Show 24 more" is an accordion, not another page. The full list is one scroll away.
+- The three action buttons at the bottom are the *only* CTAs on this screen. "Save report" triggers signup inline (see §5.5).
+
+### 5.5 Inline signup, not a wall
+
+Current: clicking Export PDF as a guest opens a modal demanding signup.
+
+Proposed: an **inline prompt card** appears above the Export button once the guest user has been on the results page for >15 seconds or scrolls past the 3rd issue:
+
+```
+┌─────────────────────────────────────────────────────────┐
+│  Save this report for later?                            │
+│                                                         │
+│  We'll keep your audit history, track your score over   │
+│  time, and unlock 9 more free audits this month.        │
+│                                                         │
+│  [ Continue with Google ]  [ Sign up with email ]       │
+│                                                         │
+│  Already have an account? Log in                        │
+└─────────────────────────────────────────────────────────┘
+```
+
+**Fixes applied:**
+- No "Unfortunately." Signup is framed as *unlocking*, not *paywalling*.
+- Concrete number of free audits ("9 more this month"), not vague "10 free audits to users."
+- Two auth options visible, not hidden in a dialog.
+- **Report is already saved to a share link** the user can bookmark even without signing up — so "Continue without signing up" is a real option. Reduce the sense of coercion.
+
+### 5.6 What signup unlocks vs. what it doesn't
+
+| Capability                 | Guest | Free | Paid |
+|----------------------------|-------|------|------|
+| Run single-page audit      | ✓     | ✓    | ✓    |
+| View results               | ✓     | ✓    | ✓    |
+| Shareable link (30 days)   | ✓     | ✓    | ✓    |
+| Save audit history         | ✗     | ✓    | ✓    |
+| Export PDF                 | ✗ (preview) | ✓ | ✓ |
+| Re-run / compare audits    | ✗     | ✓    | ✓    |
+| Domain / multi-page audit  | ✗     | limited | ✓ |
+| Monitoring & scheduled runs | ✗    | ✗    | ✓    |
+| Team + sharing with editors | ✗    | ✗    | ✓    |
+
+Guests see a watermarked PDF *preview* in-browser, not a download. That demonstrates the product without giving it away.
+
+---
+
+## 6. Core loop — returning user experience
+
+### 6.1 `/home` — the new default
+
+After login, the user lands on `/home`, not `/audits`. The list is a secondary screen; the home is a state-of-the-world summary.
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│  Good morning, Morgan.                                          │
+│                                                                 │
+│  ┌──────────────────────────────────────────────┐               │
+│  │  ⚡ Run a new audit                          │               │
+│  │  [ https://...                       ][ Go ] │               │
+│  └──────────────────────────────────────────────┘               │
+│                                                                 │
+│  Your sites                                       Add site →    │
+│  ┌────────────────┐ ┌────────────────┐ ┌────────────────┐       │
+│  │ acme.com       │ │ shop.acme.com  │ │ docs.acme.com  │       │
+│  │ 82 / 100  ↑3   │ │ 67 / 100  ↓2   │ │ 91 / 100  —    │       │
+│  │ 3 new issues   │ │ 11 new issues  │ │ all clear      │       │
+│  └────────────────┘ └────────────────┘ └────────────────┘       │
+│                                                                 │
+│  Recent audits                                    See all →     │
+│  ─────────────────────────────────────────────────────────────  │
+│  acme.com/pricing           72 / 100   2 hours ago       ⋯      │
+│  shop.acme.com/checkout     54 / 100   yesterday         ⋯      │
+│  acme.com/                  82 / 100   3 days ago        ⋯      │
+│                                                                 │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+This answers "what's changed since I was last here?" in three seconds. The new-audit input is always at the top, because that's the primary action.
+
+### 6.2 `/audits` — the list, done right
+
+The current audit list is a cramped 12-column grid with no pagination, no filtering, inconsistent status handling, and an empty state that says "Enter a URL above" when the form is below.
+
+**Proposed:**
+
+- Default sort: recent first. Secondary sort options: score (low to high for triage), URL.
+- **Status column is first-class.** Pending / Running (with live % from WebSocket) / Complete / Failed — with clickable retry for failed.
+- **Bulk actions.** Select multiple audits to compare side-by-side, export together, or delete.
+- **Filter chips** above the table: Site, Date range, Status, Score range.
+- **Skeleton rows during load** (the existing plan calls this out; keep it).
+- **Empty state says "Run your first audit"** with the input *right there*, not above.
+- **Row action menu**: View, Re-run, Compare with previous, Share, Delete.
+
+Remove the three-column-of-icons score pattern. Each row gets one badge showing the overall score, color-coded, and the row expands to show sub-scores on click.
+
+### 6.3 `/audits/:id` — unified results (replaces `page-audit-review`)
+
+One route, one component, shaped by whether the target is a single page or a site.
+
+**Single-page audit layout:**
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│  ← Back to audits         yoursite.com/pricing     Share  Export │
+│                                                                 │
+│  ┌────────┐  UX Health 72                                        │
+│  │   72   │  ◎ Access 64  ◎ Content 81  ◎ Visual 78  ◎ SEO 70   │
+│  └────────┘  Audited 2 min ago by Morgan · Re-run               │
+│                                                                 │
+│  ┌─────────────────────────┬────────────────────────────────┐   │
+│  │  [ Top issues (27) ]   ││  ┌──────────────────────────┐  │   │
+│  │  Filter: All | A11y |  ││  │                          │  │   │
+│  │         Content | Vis  ││  │  [ page screenshot with  │  │   │
+│  │  Sort:  Impact ▾       ││  │    issue hotspots ]      │  │   │
+│  │                        ││  │                          │  │   │
+│  │  ▼ Critical (3)        ││  │                          │  │   │
+│  │    • Contrast on CTA   ││  │                          │  │   │
+│  │    • Missing alt text  ││  │                          │  │   │
+│  │    • Form label missing││  └──────────────────────────┘  │   │
+│  │                        ││                                │   │
+│  │  ▼ Major (8)           ││  ┌──────────────────────────┐  │   │
+│  │    …                   ││  │ Selected: Contrast on CTA│  │   │
+│  │                        ││  │ ──────────────────────── │  │   │
+│  │  ▸ Minor (16)          ││  │ Why it matters           │  │   │
+│  │                        ││  │ Users with low vision…   │  │   │
+│  │                        ││  │                          │  │   │
+│  │                        ││  │ WCAG 2.1 AA · 1.4.3      │  │   │
+│  │                        ││  │                          │  │   │
+│  │                        ││  │ How to fix               │  │   │
+│  │                        ││  │ Change background from…  │  │   │
+│  │                        ││  │                          │  │   │
+│  │                        ││  │ [ Copy fix ] [ Mark done]│  │   │
+│  │                        ││  └──────────────────────────┘  │   │
+│  └─────────────────────────┴────────────────────────────────┘   │
+│                                                                 │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+**Key design decisions:**
+
+- **Three panels, each independently scrollable, with sticky headers.** The current design has panels that scroll independently but lose context — fix by making the issue row always in view in the left rail when the detail panel shows it.
+- **Grouped by severity by default**, because that's what Morgan needs. Power users can re-group by category via the Sort/Group control.
+- **Screenshot with hotspots.** Each visual issue gets a numbered dot on the screenshot. Clicking the dot selects the issue in the left rail and scrolls it into view. Clicking an issue in the rail highlights the dot. This is the tight loop the current `element-info-dialog` approximates clumsily.
+- **Detail panel** always has the same four sections: *Why it matters* (Morgan-facing plain English), *WCAG / standards reference* (Priya-facing), *How to fix* (AI-generated, copyable), *Action* (Mark done / Assign / Ignore). Anything else is collapsed.
+- **"Mark done" is a first-class verb.** Users can check off fixes as they ship them. The score then re-calculates in a next-audit preview. This is the state change the current product is missing.
+- **Keyboard nav.** `j`/`k` to move between issues, `x` to mark done, `/` to focus filter, `?` for shortcuts cheat sheet. This serves Priya without bothering Morgan.
+
+**Site-audit layout** uses the same shell but replaces the screenshot panel with a page list (what the current `audit-dashboard` does), and replaces the issue list with an aggregated issue view grouped by "issues affecting the most pages."
+
+### 6.4 Screenshot + element interaction
+
+Currently, `element-info-dialog` opens as a modal to show element details. Modals are context-breaking. Replace with:
+
+- **Hover a screenshot hotspot** → tooltip with issue title and severity chip.
+- **Click a hotspot** → selects the issue; detail panel updates.
+- **Hover an issue in the left rail** → hotspot on the screenshot gets an outline + label.
+- **Double-click a hotspot** → expands to a zoomed-in crop of that element, with the element's DOM selector copyable.
+
+No modal needed. Everything stays on one page.
+
+### 6.5 Sharing & collaboration
+
+Current product has an analytics event `'Clicked share button'` but no clear collaboration model. Proposed:
+
+- Every audit has a **public share URL** (`/r/:shareToken`) that's view-only, no login required, no nav chrome. Rendered as a single-page, print-friendly version of the results.
+- **Expires after 30 days** for guests, 1 year for free users, unlimited for paid.
+- **Comments** on issues (paid feature) — team members can discuss and resolve issues inline.
+- **Assign issues** to teammates (paid feature) — issue becomes a todo with an owner.
+- Export formats: PDF (stakeholder-ready), CSV (engineering triage), Jira/Linear (once integrations ship).
+
+---
+
+## 7. Screen-by-screen specs
+
+Short treatments of the remaining pages.
+
+### 7.1 `/sites/:id` — Site overview
+
+**Current `audit-dashboard` problems (from review):** 5-column score card grid too cramped, "Coming soon" labels in the middle of scores, page list duplicates the audit list template.
+
+**Proposed structure:**
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│  acme.com                    [ Run full audit ] [ Settings ]│
+│                                                             │
+│  ┌──────┐  Site health  76                                  │
+│  │  76  │  ↑ 4 points since last audit (7 days ago)         │
+│  └──────┘  ◎ Access 64  ◎ Content 81  ◎ Visual 78  ◎ SEO 81│
+│                                                             │
+│  ▸ Score trend (last 30 days)  [sparkline chart]            │
+│                                                             │
+│  Pages audited (23)                  Sort: Lowest score ▾   │
+│  ─────────────────────────────────────────────────────────  │
+│  /pricing          54   ■■■■■■■■■■□□□□  17 issues   → view  │
+│  /checkout         62   ■■■■■■■■■■■■□□  12 issues   → view  │
+│  /login            71   ■■■■■■■■■■■■■■□   8 issues  → view  │
+│  /                 82   ■■■■■■■■■■■■■■■   3 issues  → view  │
+│  …                                                          │
+└─────────────────────────────────────────────────────────────┘
+```
+
+- **"Coming soon" sub-scores are removed until they work.** Showing an empty promise in the middle of a working UI is worse than not showing anything. Ship one new sub-score at a time with a "New" badge.
+- Sort default: lowest score first (triage mode — show me where to work).
+- Each page row links to its `/audits/:auditId` result.
+
+### 7.2 `/sites` — Site list
+
+A lightweight dashboard of every site the user has added. Card-based, each card shows health score, trend, and last audit time. An "Add site" card uses the same pattern. Clicking a card routes to `/sites/:id`.
+
+### 7.3 `/integrations`
+
+**Current:** 6 grayed-out cards, all "Coming soon," no hover state.
+
+**Proposed:** either **ship something real** (Slack notifications for completed audits is the lowest-effort win, Jira export is next), **or don't show the page at all** until at least one integration works.
+
+If the page stays, each card gets:
+- Clear status chip: **Available** / **Beta** / **Request access**
+- For "Request access" cards, a working email capture with confirmation.
+- For "Available" cards, a "Connect" button that starts the OAuth flow.
+
+Never show dead UI.
+
+### 7.4 `/settings`
+
+Tabbed page: **Account** (name, email, password, delete account) • **Billing** (current plan, upgrade, invoices) • **Team** (paid: invite members, manage roles) • **Notifications** (email, Slack, browser) • **API keys** (paid).
+
+Current `user-profile` is a minimal stub; this is greenfield.
+
+### 7.5 `/help`
+
+Merge `/how-it-works` into `/help`. In-app help uses a command palette (`⌘K`) as the primary discovery surface for power users, with a flat searchable article list as the fallback.
+
+### 7.6 Footer
+
+Minimal site-wide footer: logo, © 2026 Look-see, Privacy, Terms, Status, Contact. Kill the 2021 copyright.
+
+---
+
+## 8. Component library — what to build first
+
+Assuming the existing `REDESIGN_PLAN.md`'s Phase 1 design system lands, here are the behavior-focused components this UX redesign needs:
+
+1. **`URLInput`** — permissive URL input with scheme auto-prepend, validation on blur (not on submit), clear error states, and a "try this URL" suggestion if validation fails.
+2. **`AuditProgress`** — full-screen progress scene driven by WebSocket events; includes screenshot preview, feed, ETA, and "notify me" affordance.
+3. **`IssueRow`** — severity chip, title, one-line why-it-matters, affected-count, click to select. Used in results and site overview.
+4. **`IssueDetailPanel`** — four-section layout (Why / WCAG / Fix / Action); keyboard-navigable.
+5. **`ScreenshotCanvas`** — clickable, pannable, zoomable screenshot with issue hotspots. This is the single most technically interesting component and the biggest visual-clarity unlock.
+6. **`ScoreGauge`** — circular score with semantic color, sized `sm`/`md`/`lg`/`xl`. Replaces three different inline SVG implementations.
+7. **`TrendChart`** — score sparkline with deltas. Used on home, site overview, and site list cards.
+8. **`EmptyState`** — illustration + headline + body + CTA; matched to context (no audits / no sites / no results / no issues).
+9. **`ShareLink`** — inline copyable URL with expiry indicator.
+10. **`SkeletonLoader`** — for audit list, site list, home, results.
+
+These map cleanly onto the REDESIGN_PLAN's Phase 1 foundation but add the *behavior* layer that plan focuses less on.
+
+---
+
+## 9. Accessibility — eat our own cooking
+
+We sell accessibility. Our product must model it.
+
+- **WCAG 2.1 AA baseline, AAA where possible.** Every shipped component passes axe + manual screen reader testing.
+- **Full keyboard nav.** Every interactive element reachable by tab; skip-to-content link; focus rings visible and high-contrast.
+- **Semantic HTML** throughout. The current templates lean on `<div>` for interactive elements (flagged in the existing plan). Fix systematically.
+- **ARIA live regions** for audit progress updates (screen reader users hear streaming findings instead of silence).
+- **Reduced-motion respect.** The progress scene's streaming animations honor `prefers-reduced-motion: reduce` by switching to static updates.
+- **Color contrast** on every state. The current brand pink `#FF0050` fails AA on white for normal text; use it only for large text or decorative, and darken to `#D40043` (or similar) for body-text accent uses.
+- **Dark mode.** Flagged but not implemented. Add as part of the token system from day one so we're not retrofitting.
+
+---
+
+## 10. Copy & voice
+
+### 10.1 Voice test
+
+Every string passes this three-question check:
+1. Would Morgan, a smart non-expert, understand this without a glossary?
+2. Is it specific (a number, a name) rather than vague?
+3. Does it sound like a helpful colleague, not a vending machine or a cheerleader?
+
+### 10.2 Rewrites — before / after
+
+| Context | Before | After |
+|---|---|---|
+| Guest dialog | *"Unfortunately we only provide 1 free audit for visitors without an account. On the bright side, we allow up to 10 free audits…"* | *"Create a free account to run 9 more audits this month — and save this one."* |
+| Abandon confirmation | *"Are you sure that you want to start a new audit? Starting a new audit will cause the currently running audit to be abandoned."* | *"This will cancel the audit in progress. Start a new one anyway?"* |
+| Results praise | *"Astounding!!!! truly exception experience"* | *"No issues found in this category. "* |
+| Loading | *"Please wait while we load your audits…"* | *"Loading your audits…"* (skeletons do the real work) |
+| Landing headline | *"Find and fix accessibility issues in seconds"* | *"Find what's broken on your website — in under a minute."* |
+| Empty audit list | *"Enter a website URL above to run your first UX audit."* | *"Run your first audit."* (with the input directly below) |
+| Mobile block modal | *"Hey there! Look-see works best on desktop."* | *"Look-see works best on desktop. We'll email you a link so you can pick up where you left off."* + email capture |
+
+### 10.3 Tone principles
+
+- **No exclamation points** except in genuine celebration (audit complete, first issue fixed).
+- **No "Oops"** or other cute error words. Be direct: *"We couldn't reach that URL. Check the address and try again."*
+- **No "Unfortunately," "We're sorry," "Please forgive,"** or other apologetic hedges in transactional flows.
+- **Numbers over adjectives.** "9 more audits this month" beats "plenty of free audits."
+- **Second person.** "You have 3 critical issues." Not "There are 3 critical issues" and definitely not "The user has 3 critical issues."
+
+---
+
+## 11. Responsive strategy
+
+The current product has a partial mobile block modal and no serious tablet/mobile experience. Given that audit results are inherently visual and information-dense, **full mobile parity isn't the goal** — *mobile-useful* is.
+
+- **Mobile (< 640px):** View-only experience. Users can read shared audit links, view the top-3 issues, read details, share. Cannot initiate new audits or compare. Entry points that require the full UI show a "Best on desktop — email me a link" card, with email capture and deep link.
+- **Tablet (640–1024px):** Single-panel responsive layout. The three-panel results view collapses to tabs (Issues / Screenshot / Detail) with a drawer pattern for the detail panel.
+- **Desktop (> 1024px):** Full three-panel layout as specified.
+
+The mobile-block modal becomes unnecessary — every screen degrades gracefully instead.
+
+---
+
+## 12. Metrics — what to measure after launch
+
+This redesign is only worth the cost if we can tell whether it worked. Instrument these events from day one (piggyback on the existing Segment integration):
+
+**Activation funnel (the most important):**
+1. `Landing: URL submitted`
+2. `Audit: started` (split by guest vs. authed)
+3. `Audit: first-finding-surfaced` (new — t < audit complete)
+4. `Results: viewed`
+5. `Results: issue-detail-opened` (proves the user engaged with a finding)
+6. `Results: action-taken` (save, export, share, mark-done)
+7. `Auth: signup-completed`
+
+Track time between each step. The 1→4 conversion is the north-star activation rate.
+
+**Value moments:**
+- `Results: copy-fix-suggestion`
+- `Results: mark-issue-done`
+- `Audit: re-run-after-fixes`
+- `Share: link-viewed` (by recipient)
+
+**Friction signals:**
+- `Landing: URL-validation-failed` (should go to ~0 after regex removal)
+- `Audit: abandoned-during-progress`
+- `Results: scroll-without-click` (dwell without engagement)
+- `Signup: dialog-dismissed`
+
+---
+
+## 13. Implementation sequencing
+
+This redesign is large. Ship it in four phases, each with independent user value.
+
+### Phase A — Foundation & onboarding (2–3 sprints)
+
+Biggest conversion lift. Lowest technical lift.
+
+1. Fix landing URL validation (permissive parsing, remove TLD regex).
+2. Rewrite landing hero copy and CTA.
+3. Replace onboarding carousel with live audit feed (reuse existing WebSocket events).
+4. Inline signup prompt (replace hard-wall dialog).
+5. Guest share link with 30-day expiry.
+6. Copy pass on all dialog and error strings.
+
+### Phase B — Results redesign (3–4 sprints)
+
+The core loop.
+
+7. Unify `/audit/:id/page` and `/audit/:id/review` routes.
+8. Build `IssueRow`, `IssueDetailPanel`, `ScreenshotCanvas` components.
+9. Default issue sort by severity × impact.
+10. "Mark done" action and post-fix re-audit preview.
+11. Keyboard nav + shortcut cheat sheet.
+12. Replace `element-info-dialog` modal with inline detail panel.
+
+### Phase C — IA & workspace (3 sprints)
+
+13. Rename Domains → Sites throughout.
+14. Build `/home` as post-login default.
+15. Build `/sites/:id` redesign.
+16. Redesign `/audits` list with status column, filters, bulk actions, pagination.
+17. Consolidate `/how-it-works` into `/help`.
+
+### Phase D — Polish & power (ongoing)
+
+18. Responsive & mobile view-only.
+19. Dark mode.
+20. Ship at least one real integration (Slack notifications).
+21. Team collaboration features (comments, assignments) — paid tier.
+22. Monitoring & scheduled audits — paid tier.
+
+---
+
+## 14. Risks & open questions
+
+These need product-side answers before implementation:
+
+1. **Pricing model.** The "9 free audits this month" number is placeholder. Real limits need to come from billing/Stripe configuration. Current `start-audit-login-required-dialog` hardcodes "10 free audits" — that needs to be a config value.
+2. **Backend streaming support.** The "live findings" progress scene assumes findings can be surfaced as they're computed. Today, `auditUpdate` Pusher events carry progress metadata but not partial findings. Needs backend work in `audit-service` + `AuditManager`.
+3. **Share token architecture.** Public share links (`/r/:token`) need a tokenized, time-limited, revocable scheme. Likely a new backend endpoint + token table.
+4. **Re-run / compare flow.** "Mark done" previewing the next score assumes we can simulate the fix. Either we actually re-run the audit (costly) or we provide a projected score with a caveat ("Estimated after fixes — run a new audit to confirm"). The latter is cheaper and honest.
+5. **Multi-page audit data shape.** The unified `/audits/:id` route needs the detail component to handle both single-page and site audits cleanly. This is a template architecture question best resolved during Phase B.
+6. **Copy ownership.** This redesign rewrites ~30 user-facing strings. Decide if copy lives in code, in i18n files (opening the door to localization), or in a CMS.
+7. **Analytics consent.** The review notes Segment fires without a consent banner. Before this redesign ships to EU users, GDPR consent needs to gate Segment initialization — this is a compliance risk today, not a design question, but the redesign is the right moment to fix it.
+
+---
+
+## 15. Summary — what changes, in one screen
+
+```
+Before                              After
+──────                              ─────
+URL regex rejects .io domains  →   Permissive URL parsing
+"Unfortunately" gate dialog    →   Inline signup after value shown
+4-slide marketing carousel     →   Live audit feed with findings streaming
+1293-LOC results monolith      →   3-panel results with 4 focused components
+Issues in load order           →   Issues ranked by impact × severity
+Separate modal for elements    →   Inline detail panel, same screen
+Domains / How it works in nav  →   Sites / Help, with orphans removed
+Audits-first default           →   Home-first with state-of-world summary
+"Coming soon" grayed cards     →   Real integrations or no page at all
+Copyright 2021                 →   Copyright 2026, clean footer
+```
+
+Every change above is traceable to one of the five redesign principles in §3. If any of them can't be, cut them.
+
+---
+
+*End of redesign document.*

--- a/Look-see-UI-v3/docs/design/00-index.md
+++ b/Look-see-UI-v3/docs/design/00-index.md
@@ -1,0 +1,69 @@
+# Look-see UI — Design Docs & Feature Specs
+
+This directory contains actionable feature specs derived from the [UX Redesign](../../UX_REDESIGN.md) and the existing [Visual Redesign Plan](../../REDESIGN_PLAN.md). Each doc addresses one cluster of problems with a concrete, shippable design.
+
+## Status legend
+
+- **Draft** — under design review
+- **Ready** — approved, not yet in development
+- **In progress** — build started
+- **Shipped** — live in production
+
+---
+
+## Specs by phase
+
+### Phase A — Foundation & onboarding
+Ship order. Each spec is independently shippable.
+
+| # | Spec | Addresses | Status |
+|---|---|---|---|
+| 01 | [Design system & tokens](./01-design-system.md) | Design system issues: scattered colors, loose typography, inconsistent buttons, missing breakpoints, no dark mode foundation | Draft |
+| 02 | [Audit status model & live progress feed](./02-audit-status-and-progress.md) | Critical gap: no in-progress visibility. Onboarding handoff abrupt. Low-hanging fruit: status badges in audit list. | Draft |
+| 05 | [Landing & onboarding friction fixes](./05-landing-and-onboarding.md) | Low-hanging fruit: URL regex too strict, pessimistic guest dialog, auto-rotating carousel, copy rewrites | Draft |
+
+### Phase B — Core loop
+
+| # | Spec | Addresses | Status |
+|---|---|---|---|
+| 03 | [Results architecture refactor](./03-results-architecture.md) | Critical gap: 1,293-LOC page-audit-review monolith. Introduces IssueRow, IssueDetailPanel, ScreenshotCanvas. | Draft |
+| 06 | [Shared UI component library](./06-shared-components.md) | Low-hanging fruit: ScoreBadge, ScoreGauge, EmptyState, SkeletonLoader, StatusChip, DataCard reusables | Draft |
+
+### Phase C — IA & workspace
+
+| # | Spec | Addresses | Status |
+|---|---|---|---|
+| 04 | [Navigation & information architecture](./04-navigation-ia.md) | Critical gap: orphaned `/dashboard`, fragmented review routes, Domains → Sites rename, `/home` as default, breadcrumbs | Draft |
+
+---
+
+## Cross-cutting concerns tracked across all specs
+
+- **Accessibility:** WCAG 2.1 AA minimum on every spec. We sell accessibility; we must model it.
+- **Analytics:** Every spec lists the Segment events to instrument.
+- **Responsive:** Desktop-first, tablet-acceptable, mobile-read-only. No mobile-block modal in any final state.
+- **Copy:** Every user-facing string passes the voice test in UX_REDESIGN.md §10.
+
+## How to read a spec
+
+Each spec follows the same structure:
+
+1. **Problem** — what hurts today, cited with file:line where possible
+2. **Goals / Non-goals** — crisp boundaries
+3. **User stories** — Morgan (non-expert) and Priya (pro) framed
+4. **Design** — the proposed interface, with wireframes
+5. **Technical design** — components, state, data shape, token usage
+6. **Acceptance criteria** — testable, binary
+7. **Metrics** — what success looks like in the analytics pipeline
+8. **Risks & open questions** — what needs product/eng input before build
+9. **Phasing** — what ships first, what's deferred
+
+If any section is empty in a given spec, it means it doesn't apply (e.g., a pure refactor may have no metrics to move).
+
+---
+
+## Related documents
+
+- [UX_REDESIGN.md](../../UX_REDESIGN.md) — the end-to-end redesign these specs implement
+- [REDESIGN_PLAN.md](../../REDESIGN_PLAN.md) — original visual redesign plan (colors, typography, components)
+- [README.md](../../README.md) — product & deployment documentation

--- a/Look-see-UI-v3/docs/design/01-design-system.md
+++ b/Look-see-UI-v3/docs/design/01-design-system.md
@@ -1,0 +1,376 @@
+---
+id: 01
+title: Design system & tokens
+status: Draft
+phase: A
+addresses:
+  - Hardcoded colors scattered across components
+  - No responsive breakpoint coverage for tablets
+  - Typography hierarchy loose; button styles inconsistent
+  - No token inheritance (no Tailwind component classes)
+  - No dark mode foundation
+owner: Design + Frontend
+related:
+  - UX_REDESIGN.md §3, §8
+  - REDESIGN_PLAN.md §1
+---
+
+# 01 — Design system & tokens
+
+## Problem
+
+The codebase has partial design tokens but no single source of truth:
+
+- `tailwind.config.js` defines some brand colors (`brand.500 = #FF0050`, charcoal palette, shadow tokens) but components still hardcode values like `#231f20`, `#FF0050`, `#23D8A4`, `#F9BF08`, `#4f4b4c` in inline styles and SCSS files.
+- `styles.scss` has 30+ custom viewport-height classes (`h-5vh` through `h-100vh`) duplicating Tailwind functionality.
+- Semantic score colors (Good/Warning/Critical) are re-declared in multiple components.
+- Typography: `Open Sans` and `Cera Pro` both loaded; weights applied inconsistently; no defined scale.
+- Button styles inconsistent: some use `.btn-accent`, others inline `px-8 py-3` with hand-picked colors.
+- Responsive: mobile (`< 640px`) and desktop (`≥ 640px`) are handled; tablet range (640–1024px) has gaps (e.g., results grid jumps from 1 to 4 columns).
+- Angular Material theme is Deep Purple/Amber — conflicts with brand.
+- No dark mode tokens; `dark:` classes appear in nav markup but there is no dark theme implementation.
+
+**Impact:** every new component is an opportunity to drift further. Brand consistency erodes linearly with feature count. Designers cannot hand off because there's no canonical token name to reference.
+
+## Goals
+
+1. Establish **one source of truth** for tokens (colors, type, spacing, radius, shadow, motion) in `tailwind.config.js` + a thin SCSS layer for semantic aliases.
+2. Define a **semantic color layer** above raw brand colors (e.g., `score.good`, `score.warning`, `score.critical`, `surface.base`, `surface.raised`, `border.subtle`).
+3. Define a **typographic scale** with named roles (`display-xl`, `display`, `heading`, `subheading`, `body`, `body-sm`, `caption`, `overline`, `mono`).
+4. Standardize **button variants** as a single component with well-defined variants and sizes.
+5. Fill **tablet breakpoints** so layouts degrade through `sm` / `md` / `lg` / `xl` cleanly.
+6. Lay **dark mode groundwork** — every token has a light and dark value, even if dark mode stays off by default.
+7. **Replace the Material Deep Purple/Amber theme** with a Look-see theme derived from the same tokens.
+
+## Non-goals
+
+- Shipping dark mode to users (toggle is deferred until Phase D).
+- Rewriting every component in one sprint — this spec defines the tokens and the button component; other components adopt over time.
+- Changing the base framework (still Angular Material + Tailwind).
+
+## User stories
+
+- *As a designer*, I want to reference `surface.raised` in Figma and have it map to the same value the front-end developer uses, so handoffs don't lose fidelity.
+- *As a front-end dev*, I want to write `<button class="btn btn-primary btn-md">` (or an Angular component) and never hand-pick colors again.
+- *As Morgan (non-expert)*, I want a consistent visual language so I trust the product — subtle UI drift reads as sloppy.
+
+## Design
+
+### 1. Color tokens
+
+**Raw palette** (define in `tailwind.config.js` → `theme.extend.colors`):
+
+```js
+// Brand
+brand: {
+  50: '#fff1f4',
+  100: '#ffe1e9',
+  200: '#ffb8cb',
+  300: '#ff7da0',
+  400: '#ff4775',
+  500: '#ff0050',  // primary accent
+  600: '#d40043',
+  700: '#a80035',
+  800: '#7a0027',
+  900: '#4d0018',
+  950: '#2b000d',
+},
+
+// Ink / charcoal (replaces misc hex greys)
+ink: {
+  50: '#f7f7f7',
+  100: '#ebeaea',
+  200: '#d1cfd0',
+  300: '#aeabac',
+  400: '#7f7c7d',
+  500: '#5f5d5e',
+  600: '#4f4b4c',
+  700: '#3d3b3c',
+  800: '#2d2a2b',
+  900: '#231f20',   // primary dark
+  950: '#151313',
+},
+
+// Score (semantic, mapped from named greens/ambers/reds)
+score: {
+  good:     '#10b981',   // emerald-500
+  warning:  '#f59e0b',   // amber-500
+  critical: '#ef4444',   // red-500
+},
+```
+
+**Semantic aliases** (define as custom properties in `styles.scss` so dark mode can flip them in one place):
+
+```scss
+:root {
+  // Surfaces
+  --surface-base:    theme('colors.white');
+  --surface-raised:  theme('colors.white');
+  --surface-sunken:  theme('colors.ink.50');
+  --surface-inverse: theme('colors.ink.900');
+
+  // Text
+  --text-primary:    theme('colors.ink.900');
+  --text-secondary:  theme('colors.ink.600');
+  --text-muted:      theme('colors.ink.400');
+  --text-inverse:    theme('colors.white');
+  --text-accent:     theme('colors.brand.600');   // AA-compliant on white
+  --text-on-accent:  theme('colors.white');
+
+  // Borders
+  --border-subtle:   theme('colors.ink.100');
+  --border-default:  theme('colors.ink.200');
+  --border-strong:   theme('colors.ink.300');
+  --border-focus:    theme('colors.brand.500');
+
+  // Score
+  --score-good:      theme('colors.score.good');
+  --score-warning:   theme('colors.score.warning');
+  --score-critical:  theme('colors.score.critical');
+
+  // Focus ring
+  --focus-ring: 0 0 0 3px rgba(255, 0, 80, 0.35);
+}
+
+[data-theme='dark'] {
+  --surface-base:    theme('colors.ink.950');
+  --surface-raised:  theme('colors.ink.900');
+  --surface-sunken:  theme('colors.ink.950');
+  --surface-inverse: theme('colors.white');
+
+  --text-primary:    theme('colors.ink.50');
+  --text-secondary:  theme('colors.ink.300');
+  --text-muted:      theme('colors.ink.400');
+  --text-accent:     theme('colors.brand.400');   // brighter for dark
+  // …
+}
+```
+
+**Rule:** components never reference raw palette tokens. They reference semantic tokens. Raw palette tokens are only used in the token layer itself.
+
+**Contrast verification:** every semantic text-on-surface pair is validated for AA (4.5:1 for body, 3:1 for large text). `brand.500` (`#FF0050`) on white is 3.49:1 — fails AA for body text. `brand.600` (`#D40043`) is 4.56:1 — passes. **Therefore:** the brand pink used for text switches to `brand.600`; `brand.500` is reserved for large text, icons, and decorative accents only.
+
+### 2. Typography scale
+
+Consolidate on **Inter** for body (replaces Open Sans — better screen rendering, already fallback in the stack) and **Cera Pro** for display. Keep Cera Pro loaded only for display sizes to reduce payload.
+
+| Role | Size | Line-height | Weight | Tracking | Use |
+|---|---|---|---|---|---|
+| `display-xl` | 48px | 1.1 | 700 (Cera Pro) | -0.02em | Landing hero only |
+| `display` | 36px | 1.15 | 700 (Cera Pro) | -0.015em | Page heroes |
+| `heading-lg` | 28px | 1.25 | 700 | -0.01em | Section h1 |
+| `heading` | 22px | 1.3 | 600 | -0.005em | Card titles, h2 |
+| `subheading` | 18px | 1.4 | 600 | 0 | h3 |
+| `body-lg` | 17px | 1.55 | 400 | 0 | Large body |
+| `body` | 15px | 1.55 | 400 | 0 | Default body |
+| `body-sm` | 13px | 1.5 | 400 | 0 | Dense tables, helper text |
+| `caption` | 12px | 1.4 | 500 | 0.01em | Labels below inputs |
+| `overline` | 11px | 1.2 | 600 | 0.08em (uppercase) | Section eyebrows |
+| `mono` | 13px | 1.5 | 400 | 0 | Code, selectors |
+
+Implement as Tailwind plugin utilities:
+
+```js
+// tailwind.config.js (fragment)
+plugins: [
+  function({ addUtilities }) {
+    addUtilities({
+      '.text-display-xl': { 'font': '700 48px/1.1 "Cera Pro", Inter, sans-serif', 'letter-spacing': '-0.02em' },
+      '.text-display':    { 'font': '700 36px/1.15 "Cera Pro", Inter, sans-serif', 'letter-spacing': '-0.015em' },
+      '.text-heading-lg': { 'font': '700 28px/1.25 Inter, sans-serif', 'letter-spacing': '-0.01em' },
+      // …
+    });
+  },
+]
+```
+
+Base layer resets for `h1–h6` map to these utilities so plain markdown-ish HTML looks right out of the box.
+
+### 3. Spacing, radius, shadow, motion
+
+**Spacing scale:** adopt the Tailwind 4-px grid verbatim. Forbid arbitrary spacing (`pl-6` is fine; `pl-[23px]` is not). Add a lint rule.
+
+**Radius tokens:**
+```js
+borderRadius: {
+  'xs': '2px',
+  'sm': '4px',
+  'md': '6px',
+  'lg': '8px',
+  'xl': '12px',
+  '2xl': '16px',
+  'full': '9999px',
+}
+```
+Guidance: buttons = `md`, cards = `lg`, modals = `xl`, avatars/chips = `full`.
+
+**Shadow tokens:**
+```js
+boxShadow: {
+  'xs':    '0 1px 2px 0 rgb(0 0 0 / 0.04)',
+  'sm':    '0 1px 3px 0 rgb(0 0 0 / 0.06), 0 1px 2px -1px rgb(0 0 0 / 0.04)',
+  'md':    '0 4px 6px -1px rgb(0 0 0 / 0.08), 0 2px 4px -2px rgb(0 0 0 / 0.04)',
+  'lg':    '0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.06)',
+  'xl':    '0 20px 25px -5px rgb(0 0 0 / 0.1), 0 8px 10px -6px rgb(0 0 0 / 0.04)',
+  'focus': 'var(--focus-ring)',
+}
+```
+
+**Motion tokens:**
+```js
+transitionDuration: {
+  fast:   '120ms',
+  base:   '180ms',
+  slow:   '280ms',
+}
+transitionTimingFunction: {
+  'ease-out-soft': 'cubic-bezier(0.22, 1, 0.36, 1)',
+  'ease-in-out-soft': 'cubic-bezier(0.65, 0, 0.35, 1)',
+}
+```
+
+All interactive elements animate on `base` duration with `ease-out-soft`. Honor `prefers-reduced-motion: reduce` globally:
+
+```scss
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: 0.01ms !important;
+    transition-duration: 0.01ms !important;
+  }
+}
+```
+
+### 4. Responsive breakpoints
+
+Extend Tailwind defaults — no new breakpoints, but **every layout must be tested at all four.**
+
+| Token | Min-width | Device class |
+|---|---|---|
+| `sm` | 640px | Large phone / small tablet portrait |
+| `md` | 768px | Tablet portrait |
+| `lg` | 1024px | Tablet landscape / small laptop |
+| `xl` | 1280px | Desktop |
+| `2xl` | 1536px | Large desktop |
+
+**Rule:** no Tailwind utility jumps >1 breakpoint without passing through `md`. E.g., `grid-cols-1 md:grid-cols-2 xl:grid-cols-4` is legal; `grid-cols-1 xl:grid-cols-4` is a bug.
+
+### 5. Button system
+
+Replace ad-hoc buttons with one Angular component, three variants × three sizes × two emphasis modes.
+
+```html
+<looksee-button variant="primary" size="md">Start audit</looksee-button>
+<looksee-button variant="secondary" size="sm">Cancel</looksee-button>
+<looksee-button variant="ghost" size="md" icon="plus">New site</looksee-button>
+<looksee-button variant="danger" size="md">Delete</looksee-button>
+<looksee-button variant="primary" size="md" [loading]="true">Saving…</looksee-button>
+```
+
+| Variant | Use | Background | Text | Border |
+|---|---|---|---|---|
+| `primary` | Main CTA — one per screen | `ink.900` | white | — |
+| `accent` | Conversion CTA (Start audit, Sign up) | `brand.600` | white | — |
+| `secondary` | Secondary actions | `white` | `ink.900` | `ink.200` |
+| `ghost` | Low-emphasis inline | transparent | `ink.700` | — (hover: `ink.50` bg) |
+| `danger` | Destructive | `white` | `score.critical` | `score.critical` |
+| `link` | Inline anchor-like | transparent | `brand.600` | underline on hover |
+
+| Size | Height | Padding-x | Text |
+|---|---|---|---|
+| `sm` | 32px | 12px | `body-sm` |
+| `md` | 40px | 16px | `body` |
+| `lg` | 48px | 20px | `body-lg` |
+
+**States:** hover (darkens by one step), active (darkens two steps, subtle press via `translateY(1px)`), disabled (50% opacity, no pointer), focus (`shadow-focus` ring).
+
+**Loading:** spinner replaces icon, label dims to 70% opacity, button becomes non-interactive.
+
+### 6. Angular Material theme override
+
+Material uses SCSS mixins. Define a single theme file that maps Material's `$primary`, `$accent`, `$warn` palettes to our tokens:
+
+```scss
+// src/theme/material-overrides.scss
+@use '@angular/material' as mat;
+
+$looksee-primary: mat.define-palette((
+  50: #f7f7f7, 100: #ebeaea, …, 900: #231f20,
+  contrast: (50: #231f20, …, 900: #ffffff)
+));
+$looksee-accent:  mat.define-palette((…brand palette…));
+$looksee-warn:    mat.define-palette((…score.critical palette…));
+
+$looksee-theme: mat.define-light-theme((
+  color: (primary: $looksee-primary, accent: $looksee-accent, warn: $looksee-warn),
+  typography: mat.define-typography-config($font-family: '"Inter", sans-serif'),
+));
+
+@include mat.all-component-themes($looksee-theme);
+```
+
+## Technical design
+
+### File layout
+
+```
+src/
+├── theme/
+│   ├── tokens.scss             // CSS custom properties for semantic tokens
+│   ├── typography.scss         // @font-face + utility definitions
+│   └── material-overrides.scss // Material theme bound to our tokens
+├── styles.scss                 // imports the above, minimal else
+└── app/components/shared/
+    ├── button/                 // looksee-button component
+    ├── ...
+tailwind.config.js              // raw palette + utility plugins
+```
+
+### Migration strategy
+
+1. **Add** the new tokens alongside existing hex values. Don't remove anything yet.
+2. **Build** `LookseeButtonComponent` and Material override. Ship.
+3. **Migrate** components opportunistically — any component touched for another reason gets migrated.
+4. **Lint rule:** `no-hex-in-components` ESLint plugin that errors on hex literals in `.html`, `.ts`, `.scss` under `src/app/components/`. Allow in `src/theme/` and `tailwind.config.js` only.
+5. **Remove** old custom vh classes from `styles.scss` once no component references them.
+6. **Deprecate** Open Sans (keep load for two releases, then remove).
+
+### Dark mode groundwork
+
+Add `data-theme` attribute on `<html>`, toggled by a service `ThemeService` that persists choice to `localStorage`. Default is `light`. Dark CSS variables are defined but the toggle UI ships in Phase D.
+
+### Analytics
+
+No events added by this spec.
+
+## Acceptance criteria
+
+- [ ] `tailwind.config.js` has `brand`, `ink`, and `score` palettes with 50–950 scales.
+- [ ] `src/theme/tokens.scss` defines ≥ 20 semantic CSS custom properties with `[data-theme='dark']` overrides for each.
+- [ ] Typography plugin ships 10 named utilities; all `h1`–`h6` base styles map to them.
+- [ ] `LookseeButtonComponent` implemented with 6 variants × 3 sizes; passes AA contrast in Storybook or equivalent visual regression.
+- [ ] Angular Material primary/accent/warn palettes bound to brand tokens; one end-to-end Material component (e.g., `MatDialog`) reflects the change.
+- [ ] `prefers-reduced-motion` global opt-out works (manual QA).
+- [ ] ESLint rule `no-hex-in-components` configured and passing (may require legacy exceptions initially).
+- [ ] Design token reference page shipped in Storybook or `/docs/design/tokens.html`.
+
+## Metrics
+
+Not directly user-facing. Track as engineering-health KPIs:
+- Count of raw hex literals in `src/app/components/**` (baseline → target: 0 except in legacy SVGs).
+- Count of inline `style="…"` attributes in templates (baseline → target: ≤ 10% of current).
+- Lighthouse accessibility score for every page (target: ≥ 95).
+
+## Risks & open questions
+
+1. **Font licensing.** Confirm we have a production license for Cera Pro on the current domain(s). If not, replace with a similar-feel free alternative (e.g., General Sans, Satoshi) before Phase A ships.
+2. **Material version.** Angular Material 17 theming uses `define-theme` (M3) pattern; verify mixin API used here matches the version pinned in `package.json`.
+3. **Storybook vs. ad-hoc gallery.** Storybook is the industry default but adds build complexity. A single `/docs/design/tokens.html` page may be enough initially. Product decision.
+4. **Dark mode rollout.** Do we ship the toggle in Phase D, or gate behind a feature flag for beta users first? Recommend flag.
+5. **Custom vh classes usage audit.** Need to grep `h-5vh`..`h-100vh` to confirm removal is safe before deleting.
+
+## Phasing
+
+**Milestone 1 (week 1):** Tokens + typography + ESLint rule. No UI change visible.
+**Milestone 2 (week 2):** Button component + Material theme override. Migrate nav-bar and landing CTAs as reference implementations.
+**Milestone 3 (week 3–4):** Opportunistic migration of high-traffic components during Phase B work.
+**Milestone 4 (Phase D):** Dark mode toggle.

--- a/Look-see-UI-v3/docs/design/02-audit-status-and-progress.md
+++ b/Look-see-UI-v3/docs/design/02-audit-status-and-progress.md
@@ -1,0 +1,331 @@
+---
+id: 02
+title: Audit status model & live progress feed
+status: Draft
+phase: A
+addresses:
+  - No visual feedback for in-progress audits (critical gap)
+  - Onboarding and results handoff feels abrupt (critical gap)
+  - Auto-rotating marketing carousel during wait (low-hanging fruit)
+  - Status badges missing in audit list (low-hanging fruit)
+owner: Design + Frontend + Backend (audit-service)
+related:
+  - UX_REDESIGN.md §5.3, §6.2
+  - 03-results-architecture.md
+  - 06-shared-components.md (StatusChip)
+---
+
+# 02 — Audit status model & live progress feed
+
+## Problem
+
+Two related gaps, sharing the same underlying missing concept — **audit state machine.**
+
+1. **In-progress audits are invisible after navigation.** `audit-list` shows finished audits only (scores 0–100 render, but no state for "not done yet"). A user who starts a domain audit (5+ minutes), navigates away, and returns has no way to know it's still running, failed, or queued.
+
+2. **Onboarding is a fake wait.** `audit-onboarding` runs a 5-step progress animation on hardcoded timers (0s, 3s, 7s, 12s, 18s) and a 4-slide carousel auto-rotating every 5s. The animation doesn't reflect what the backend is doing; if the backend takes 30s, the user sees the animation finish at 18s and then stare at nothing. If it takes 3s, the animation is still running when results are ready.
+
+3. **No cancellation, no ETA, no "notify me."** Audits feel like a black box.
+
+The underlying cause: audits don't have an explicit client-side **state** the UI renders from. The data model has `AuditRecord` with scores, but state is inferred (missing scores → assume running).
+
+## Goals
+
+1. Introduce a first-class `AuditStatus` enum in the client data model.
+2. Build a **single live progress scene** that replaces `audit-onboarding` and reuses the same component in-list.
+3. Render accurate status chips in `audit-list` for every audit, at every state.
+4. Stream real findings into the progress scene as they arrive (not fake steps).
+5. Support **leave-and-return** — notifications when audits finish.
+6. Support **cancel** — users can abort a running audit.
+
+## Non-goals
+
+- Re-running audits, comparing audits — covered in 03-results-architecture.md.
+- Audit queue management (who runs first, priority) — out of scope; the backend decides.
+- Scheduled / recurring audits — Phase D feature.
+
+## User stories
+
+- *As Morgan*, I start an audit, switch tabs, and come back 3 minutes later. I want to see at a glance whether it's done, still running, or failed.
+- *As Morgan*, I start an audit and wait on the progress screen. I want to feel something is happening — actual findings, not fake animations.
+- *As Morgan*, I start an audit and realize I entered the wrong URL. I want to cancel without having to refresh or wait.
+- *As Priya*, I want to kick off an audit, get a browser notification when it's done, and open the result from the notification.
+
+## Design
+
+### 1. `AuditStatus` — the state machine
+
+```
+          ┌─────────┐
+          │ QUEUED  │ ← client just started; backend not yet acked
+          └────┬────┘
+               │ acked
+               ▼
+          ┌─────────┐
+          │ RUNNING │ ← backend actively auditing; progress updates streaming
+          └────┬────┘
+        ┌──────┼──────┐
+   done │      │ fail │ cancel
+        ▼      ▼      ▼
+   ┌─────────┐ ┌───────┐ ┌───────────┐
+   │COMPLETE │ │FAILED │ │ CANCELLED │
+   └─────────┘ └───────┘ └───────────┘
+```
+
+**Status meanings:**
+
+| Status | User-facing label | Chip color | Terminal? |
+|---|---|---|---|
+| `QUEUED` | *Queued* | ink.200 bg, ink.700 text | No |
+| `RUNNING` | *Auditing…* (with % if known) | brand.50 bg, brand.700 text + spinner | No |
+| `COMPLETE` | *Complete* | score.good/50 bg, score.good/700 text | Yes |
+| `FAILED` | *Failed* | score.critical/50 bg, score.critical/700 text | Yes |
+| `CANCELLED` | *Cancelled* | ink.100 bg, ink.600 text | Yes |
+
+**Transitions:**
+- Client sets `QUEUED` optimistically when user submits URL.
+- Backend ack flips to `RUNNING` (within 2s or timeout → `FAILED`).
+- `auditUpdate` events carry progress percentage (0–100) and the latest finding.
+- Terminal events (`auditComplete`, `auditFailed`, `auditCancelled`) flip state.
+
+### 2. Live progress feed
+
+Replaces the current `audit-onboarding` component entirely. Rendered at the route `/audits/:id` when `status !== COMPLETE`. Reused in-line in `audit-list` rows as an expandable "preview."
+
+**Full-screen version (on the audit route):**
+
+```
+┌────────────────────────────────────────────────────────────────┐
+│  ← Back to audits                                              │
+│                                                                │
+│                                                                │
+│   Auditing yoursite.com/pricing                                │
+│                                                                │
+│   ████████████████░░░░░░░░░░░░░░░░░  43%    about 20s left    │
+│                                                                │
+│   ┌───────────────────────┐  ┌───────────────────────────────┐ │
+│   │                       │  │  ✓  Captured page (2.1s)      │ │
+│   │   [live screenshot    │  │  ✓  Fetched 14 assets         │ │
+│   │    thumbnail of       │  │  ✓  Analyzed contrast         │ │
+│   │    the page being     │  │  ⋯  Checking heading hierarchy│ │
+│   │    audited]           │  │                               │ │
+│   │                       │  │  Found so far:                │ │
+│   │                       │  │  🔴 3 critical                │ │
+│   │                       │  │  🟡 8 major                   │ │
+│   │                       │  │  🔵 12 minor                  │ │
+│   └───────────────────────┘  └───────────────────────────────┘ │
+│                                                                │
+│                                                                │
+│   [ Cancel ]    [ Notify me when done ]                        │
+│                                                                │
+└────────────────────────────────────────────────────────────────┘
+```
+
+**Interaction rules:**
+
+- **Screenshot** appears as soon as the backend captures it (first `pageFound` event for a single-page audit, or the first page captured for a domain audit).
+- **Feed** prepends a line each time an `auditUpdate` event arrives. Animate with a subtle fade+slide (respecting `prefers-reduced-motion`).
+- **ETA** computed from elapsed time × (100 / percent) once percent ≥ 10%. Below 10%, show "calculating…" rather than a nonsense number.
+- **"Found so far" counters** update as issues arrive. If `status === RUNNING` and user clicks the counter, a drawer opens showing the partial findings. They can preview before the audit is done.
+- **Cancel** calls `DELETE /audits/:id`; optimistically flip to `CANCELLED`; backend confirmation follows.
+- **Notify me** requests `Notification.permission` (the browser API). If granted, shows browser notification on complete/failed. Also offers email opt-in inline ("Or email me at morgan@acme.com when it's done — [change]").
+- **On completion:** the progress scene cross-fades into the results view (see 03-results-architecture.md). Don't force-navigate; the URL stays `/audits/:id`, the component detects `status === COMPLETE` and swaps layouts.
+
+**In-list compact version (for `audit-list` rows with `RUNNING` status):**
+
+```
+┌───────────────────────────────────────────────────────────────┐
+│  yoursite.com/pricing   [Auditing… 43%] ████░░░  20s    ⋯    │
+│  ↳ Checking heading hierarchy                                 │
+└───────────────────────────────────────────────────────────────┘
+```
+
+### 3. Audit list — status-aware
+
+Every row shows a **StatusChip** (see 06-shared-components.md) as the leftmost column after URL. Rows with `RUNNING` status include the inline progress bar above. Rows with `FAILED` status include a retry affordance:
+
+```
+yoursite.com/checkout   [Failed]   2 hours ago   [ Retry ]  ⋯
+                        ⚠ The URL timed out. Check the URL and try again.
+```
+
+### 4. Notification design
+
+**Browser notification on completion:**
+
+> **Audit complete — yoursite.com/pricing**
+> Score 72 · 27 issues found
+> *Click to view results*
+
+**Email on completion (fallback if browser notifications declined):**
+
+Subject: `Your Look-see audit of yoursite.com/pricing is ready`
+
+Body (plain HTML email, branded):
+
+> We've finished auditing **yoursite.com/pricing**. Your UX Health Score is **72/100** — we found 27 issues, including 3 critical.
+>
+> [View the report →]
+>
+> This report link expires in 30 days. Sign up to save it permanently.
+
+### 5. Cancellation UX
+
+When the user clicks **Cancel** on the progress scene:
+
+1. A confirmation dialog:
+   > *Cancel this audit?*
+   > *We'll stop the analysis. Findings collected so far won't be saved.*
+   > `[ Keep auditing ] [ Cancel audit ]`
+2. On confirm: optimistic `CANCELLED` state, call `DELETE /audits/:id`, route to `/audits` with a toast:
+   > *Audit cancelled.*
+
+**No confirmation** when cancelling an audit < 5s old (it's trivially reversible — just run again).
+
+## Technical design
+
+### Client data model
+
+```ts
+// src/app/models/audit-status.enum.ts
+export enum AuditStatus {
+  QUEUED = 'QUEUED',
+  RUNNING = 'RUNNING',
+  COMPLETE = 'COMPLETE',
+  FAILED = 'FAILED',
+  CANCELLED = 'CANCELLED',
+}
+
+// src/app/models/audit-record.ts  (augment)
+export interface AuditRecord {
+  id: string;
+  url: string;
+  type: 'PAGE' | 'DOMAIN';
+  status: AuditStatus;
+  statusMessage?: string;        // free-text reason for FAILED
+  progressPercent?: number;      // 0–100, undefined if QUEUED
+  startedAt: string;
+  completedAt?: string;
+  screenshotUrl?: string;        // present as soon as captured
+  // … existing score fields
+  findingsPreview?: {            // live counters during RUNNING
+    critical: number;
+    major: number;
+    minor: number;
+  };
+  latestFindingLabel?: string;   // "Checking heading hierarchy" — for in-list display
+}
+```
+
+### Server-side additions (audit-service / AuditManager)
+
+- Ensure `AuditRecord` persists `status`, `progressPercent`, `statusMessage`, `startedAt`, `completedAt`.
+- Extend the Pusher `auditUpdate` event payload:
+  ```json
+  {
+    "auditId": "…",
+    "status": "RUNNING",
+    "progressPercent": 43,
+    "latestFindingLabel": "Checking heading hierarchy",
+    "findingsPreview": { "critical": 3, "major": 8, "minor": 12 },
+    "screenshotUrl": "https://…"
+  }
+  ```
+- Emit terminal events:
+  - `auditComplete` — final scores + status.
+  - `auditFailed` — `statusMessage`, optional retryable flag.
+  - `auditCancelled` — from client cancel or admin abort.
+- `DELETE /audits/:id` for cancel. Idempotent.
+- `POST /audits/:id/retry` for failed-audit retry (creates a new audit preserving URL/type).
+- `POST /audits/:id/subscribe` for email-on-complete opt-in (body: `{ email }`).
+
+### Client service updates
+
+`audit.service.ts`:
+- `cancelAudit(id: string): Observable<void>`
+- `retryAudit(id: string): Observable<AuditRecord>`
+- `subscribeToCompletion(id: string, email?: string): Observable<void>`
+
+`web-socket.service.ts`:
+- Ensure `auditUpdate` handlers merge partial payloads into an in-memory audit record (no clobbering).
+- Add handlers for `auditComplete`, `auditFailed`, `auditCancelled`.
+
+### Components
+
+**New:**
+- `AuditProgressSceneComponent` — full-screen progress view. Inputs: `auditRecord$`, `onCancel`, `onNotifyMe`. Replaces `audit-onboarding`.
+- `AuditProgressInlineComponent` — compact version for list rows. Same inputs, compact template.
+- `FindingsPreviewCountersComponent` — three-counter display with severity chips.
+- `StatusChipComponent` — see 06-shared-components.md.
+
+**Retired:**
+- `audit-onboarding/*` (the timer-driven fake-progress component and its carousel).
+
+**Updated:**
+- `AuditListComponent` — uses `StatusChip`, embeds `AuditProgressInline` for running rows, adds retry handler.
+- `PageAuditReviewComponent` — becomes status-aware; swaps its template between progress and results based on `auditRecord.status`.
+
+### Reduced motion
+
+All animations (slide-in feed lines, spinning dots, progress bar fill) respect `prefers-reduced-motion`. With reduce, feed lines appear without animation; progress bar snaps to new values.
+
+## Acceptance criteria
+
+**State machine:**
+- [ ] `AuditStatus` enum exists and is set correctly for every audit record returned by the API.
+- [ ] Transitions from `QUEUED → RUNNING → {COMPLETE|FAILED|CANCELLED}` are verified end-to-end in an integration test.
+- [ ] Orphaned audits (no ack from backend within 30s) auto-transition to `FAILED` client-side with a retry affordance.
+
+**Progress scene:**
+- [ ] Screenshot thumbnail appears within 3s of submission for URLs that respond within 2s.
+- [ ] Feed updates in real time (no polling); verified with WebSocket mock.
+- [ ] Progress bar fills 0→100% with accurate ETA after 10% threshold.
+- [ ] Cancel button works; calls `DELETE /audits/:id`; returns to list with toast.
+- [ ] "Notify me" requests browser notification permission; shows inline email fallback if declined.
+- [ ] On completion, progress scene transitions to results view without URL change or full-page reload.
+
+**Audit list:**
+- [ ] Every row shows a `StatusChip` matching the audit's current status.
+- [ ] `RUNNING` rows include compact progress + live label.
+- [ ] `FAILED` rows show `statusMessage` and a `[Retry]` button.
+- [ ] Updates propagate to list rows in real time if the user is on `/audits` during completion.
+
+**A11y:**
+- [ ] Progress updates announced via ARIA live region (`role="status"`, `aria-live="polite"`).
+- [ ] Status chip includes visually-hidden descriptive text for screen readers.
+- [ ] Cancel and Retry buttons keyboard-reachable with visible focus rings.
+
+## Metrics
+
+Track in Segment:
+- `Audit: started` (properties: `type`, `authenticated`, `referrer_screen`)
+- `Audit: first-finding-surfaced` (new) — time from `started` to first `auditUpdate` with a finding
+- `Audit: completed` (properties: `duration_ms`, `issues_found`, `score`)
+- `Audit: failed` (properties: `reason`, `duration_ms`)
+- `Audit: cancelled` (properties: `progress_percent_at_cancel`)
+- `Audit: retry-clicked`
+- `Audit: notify-me-opted-in` (properties: `channel: browser|email`)
+
+**Success metrics:**
+- ≥ 95% of submitted audits reach a terminal state within 5 minutes (today: unknown; suspected < 85%).
+- Progress scene abandonment rate (user navigates away before terminal) < 30%.
+- `notify-me` opt-in rate ≥ 40% among users who navigate away.
+
+## Risks & open questions
+
+1. **Backend work required.** This spec assumes `audit-service` can emit percentage progress and partial findings. Today `auditUpdate` carries coarse progress only. Needs a backend design doc to spec the stream contract.
+2. **Cancel semantics.** Should `CANCELLED` audits be visible in the list permanently, or auto-hidden after 24h? Recommend: show for 24h, then collapse into a "Recently cancelled" section.
+3. **Notification permissions UX.** iOS Safari doesn't support Web Push for non-PWA sites. Email fallback is the answer but adds a mail-delivery dependency. Confirm SES/SendGrid is in the stack.
+4. **Partial findings visibility.** Showing counters during `RUNNING` may mislead users into thinking the audit is done. Mitigation: counter label says "Found so far" and is clearly incrementing. Usability test this.
+5. **Failure recovery.** If the WebSocket disconnects mid-audit, how do we recover state? Proposal: on reconnect, the client re-fetches the audit record and replays any missed updates from a backend-provided `since` cursor. Needs backend support.
+6. **Multi-page domain audits.** For a domain audit with 50 pages, should the feed group findings by page or chronologically? Recommend: group by page, with expandable sections. Needs usability test.
+
+## Phasing
+
+**Milestone 1:** Status enum + `StatusChip` + audit-list status chips. No real-time work. Status resolved from scores/errors at read time.
+
+**Milestone 2:** WebSocket event schema extended server-side; client merges partial payloads. Full-screen `AuditProgressScene` with screenshot, feed, progress bar. Retires `audit-onboarding`.
+
+**Milestone 3:** Cancel, retry, notify-me. Email fallback. In-list progress for running rows.
+
+**Milestone 4 (Phase D):** Scheduled audits → audit list rows with `SCHEDULED` status (extends the same state machine).

--- a/Look-see-UI-v3/docs/design/03-results-architecture.md
+++ b/Look-see-UI-v3/docs/design/03-results-architecture.md
@@ -1,0 +1,391 @@
+---
+id: 03
+title: Results architecture refactor
+status: Draft
+phase: B
+addresses:
+  - page-audit-review is 1,293-LOC unmaintainable monolith (critical gap)
+  - Panels scroll independently and lose context
+  - Issues shown in load order, not impact order
+  - Element drill-down opens a modal that breaks context
+  - Tab navigation cramped; screenshots unreadable
+  - Duplicated template code between page audit and domain audit
+owner: Design + Frontend
+related:
+  - UX_REDESIGN.md §5.4, §6.3
+  - 02-audit-status-and-progress.md
+  - 06-shared-components.md
+---
+
+# 03 — Results architecture refactor
+
+## Problem
+
+`page-audit-review.component.ts` is 1,293 lines with one component managing:
+- audit record fetching
+- issue list rendering
+- category tabs
+- score gauges (inline SVG with manual circumference math)
+- screenshot display and element zoom
+- element drill-down dialog
+- filter / sort / search state
+- WebSocket update handlers
+- "mark as done" placeholder logic
+- PDF/Excel export
+- Segment tracking
+
+Symptoms:
+- Left issue list and right detail panel scroll independently — selecting an issue loses its row from view.
+- Issues render in load order; a user scrolling for critical issues has to skim all 40.
+- `element-info-dialog` is a modal — opening it covers the screenshot context the user was just reading.
+- Category tabs are oversized (`h-32`) with empty `<div>` spacers where the design system should have a tab underline.
+- Score display uses hand-calculated SVG circumference — every score gauge on every page has a copy-paste version.
+- Domain audits duplicate much of this template inside `audit-dashboard`, with subtle divergences.
+- Inline styles (`style="overflow-y:auto;height:40vh;max-height:45vh"`) scattered throughout the template.
+- ~200 lines of commented-out dead code.
+
+## Goals
+
+1. Replace the monolith with a **composable set of 6 components** around a typed data model.
+2. Default to **impact-ranked** issue ordering, with user-selectable grouping.
+3. Unify single-page and domain audit views under **one component tree** that adapts to payload shape.
+4. Replace the element-info modal with an **inline detail panel** that preserves context.
+5. Make the **screenshot canvas** the visual anchor — clickable hotspots tied bidirectionally to the issue list.
+6. Introduce **"mark done"** as a first-class verb that persists and updates the preview score.
+7. Full **keyboard navigation** for power users.
+
+## Non-goals
+
+- Backend issue-ranking algorithm redesign — use whatever `priority` + `severity` the backend supplies; client ranks at render time with a pluggable scorer.
+- Rewriting PDF/Excel export — delegate to existing `report.service.ts`, only the call-site moves.
+- Inline editing of issues (adding recommendations, observations) — preserved as is, repackaged behind a cleaner action menu.
+
+## User stories
+
+- *As Morgan*, I open my audit results and immediately see the top 3 issues ranked by severity. I click one and read a plain-English explanation without losing the issue list.
+- *As Morgan*, I look at the screenshot, see red dots over the broken parts, click a dot, and the detail panel scrolls to that issue.
+- *As Morgan*, I fix an issue in my site, come back, click "Mark done," and see my projected score go up.
+- *As Priya*, I press `j` and `k` to step through issues, `x` to mark done, `/` to focus the filter. I never touch the mouse.
+- *As Priya*, I click an issue and see the WCAG reference, the element selector, and a copyable AI-generated fix snippet.
+
+## Design
+
+### 1. Component tree
+
+```
+<looksee-audit-results>                    ← route component at /audits/:id
+├── <audit-header>                         ← score, sub-scores, actions
+├── <audit-results-shell>                  ← 3-panel layout, adapts to audit type
+│   ├── <issue-nav-panel>                  ← left rail
+│   │   ├── <issue-filter-bar>
+│   │   └── <issue-group-list>
+│   │       └── <issue-row> *n
+│   ├── <audit-canvas-panel>               ← center
+│   │   ├── <page-screenshot> (single-page)
+│   │   │   └── <issue-hotspot> *n
+│   │   ├── <page-list>          (domain audit)
+│   │   │   └── <page-row> *n
+│   │   └── <no-preview-empty-state> (fallback)
+│   └── <issue-detail-panel>               ← right
+│       ├── <issue-detail-header>
+│       ├── <issue-why-it-matters>
+│       ├── <issue-standards-ref>
+│       ├── <issue-fix-suggestion>
+│       ├── <issue-element-preview>
+│       └── <issue-action-bar>
+└── <audit-actions-bar>                    ← sticky bottom: Save, Export, Share
+```
+
+Each of these is a small, tested Angular standalone component. No component exceeds **250 lines** (enforced by ESLint).
+
+### 2. Layout: 3-panel desktop, tabs on tablet, scroll on mobile
+
+**Desktop (≥ 1024px):**
+
+```
+┌──────────────────────────────────────────────────────────────────────┐
+│  ← Back    yoursite.com/pricing      [Re-run] [Share] [Export ▾]    │
+├──────────────────────────────────────────────────────────────────────┤
+│ ┌──────┐ UX Health 72                                                │
+│ │  72  │ ◎ Access 64  ◎ Content 81  ◎ Visual 78  ◎ SEO 70           │
+│ └──────┘ Audited 2 min ago · 27 issues                               │
+├──────────────────────────────────────────────────────────────────────┤
+│                     │                       │                        │
+│  issue-nav-panel    │   audit-canvas-panel  │   issue-detail-panel   │
+│                     │                       │                        │
+│  [filter: All ▾]    │   [page screenshot    │   Selected:            │
+│  [sort: Impact ▾]   │    with hotspots]     │   Contrast on CTA      │
+│                     │                       │   ─────────────        │
+│  ▼ Critical (3)     │                       │   Why it matters       │
+│  ◉ Contrast on CTA  │                       │   …                    │
+│  ○ Missing alt text │                       │   WCAG 2.1 AA · 1.4.3 │
+│  ○ Form label       │                       │                        │
+│                     │                       │   How to fix           │
+│  ▼ Major (8)        │                       │   Change background…  │
+│  ○ …                │                       │                        │
+│                     │                       │   [Copy fix] [Done]   │
+│  ▸ Minor (16)       │                       │                        │
+│                     │                       │                        │
+│  width: 320px       │   fluid, min 400px    │   width: 360px         │
+│  scroll: yes        │   scroll: no          │   scroll: yes          │
+└─────────────────────┴───────────────────────┴────────────────────────┘
+```
+
+**Tablet (768–1023px):** canvas panel and detail panel collapse into tabs above a single content area; issue nav stays as left rail (240px).
+
+**Mobile (< 768px):** everything stacks. Single-column scrollable list with screenshot above. Detail opens as a full-screen drawer. This is the mobile view-only mode — no mark-done, no filter, no re-run.
+
+### 3. Issue ranking & grouping
+
+**Default sort: impact score.** Computed client-side:
+
+```
+impact_score = severity_weight × affected_element_count × visibility_weight
+  where
+    severity_weight  = CRITICAL: 3, MAJOR: 2, MINOR: 1
+    visibility_weight = aboveFold ? 1.2 : 1.0
+```
+
+Grouping options (one active at a time):
+
+- **Severity** (default) — Critical → Major → Minor groups.
+- **Category** — Accessibility / Content / Visual / SEO.
+- **WCAG level** — A / AA / AAA / Non-WCAG.
+- **Status** — Open / In Progress / Done / Ignored.
+
+Group headers collapse/expand with a disclosure icon. Collapsed state is persisted per user in localStorage, keyed by audit id.
+
+### 4. Screenshot with hotspots
+
+`<page-screenshot>` renders the captured full-page screenshot with numbered circular hotspots for each issue that has a positioned element.
+
+**Hotspot states:**
+
+| State | Appearance |
+|---|---|
+| Default | 24px circle, severity color bg, white number, 2px white ring |
+| Hovered | 28px, drop-shadow lg, tooltip with issue title |
+| Selected | 32px, brand border ring, persistent label |
+| Marked done | 50% opacity, strike-through number |
+
+**Interactions:**
+- Click a hotspot → selects issue; detail panel updates; row scrolls into view in nav panel.
+- Hover an issue row → corresponding hotspot pulses once.
+- Hover a hotspot → tooltip with issue title + severity.
+- Double-click or pinch-zoom → zooms into a 3× cropped view of the element. Escape exits zoom.
+- If screenshot is missing (audit failed before capture), show an `<no-preview-empty-state>` with a retry CTA.
+
+**Implementation:** hotspots are absolutely positioned inside a container that scales with the screenshot. Coordinates come from the backend's captured bounding box for each element; normalized to 0–1 so the UI can re-scale without drift.
+
+### 5. Detail panel — 4 sections, consistent
+
+Every issue's detail panel has the same four sections, in the same order:
+
+1. **Why it matters** (1–2 sentences, non-technical, Morgan-facing). Example: *"Users with low vision may not see your 'Sign up' button. About 1 in 12 men and 1 in 200 women have some form of color blindness."*
+2. **Standards reference** (WCAG criterion number + link to the spec, and any ADA/Section 508 note). Priya-facing, collapsible on small screens.
+3. **How to fix** (AI-generated suggestion + copy-to-clipboard + if code fix, a before/after diff in a code block).
+4. **Affected element(s)** (screenshot crop + CSS selector + copyable; if multiple, paginated: "Element 1 of 8 →").
+
+Below the four sections: the **action bar**.
+
+```
+[ Mark done ] [ Assign ▾ ] [ Ignore ▾ ]        View in page ↗
+```
+
+- **Mark done** — flips status to `DONE`, animates a checkmark, updates the "projected score" in the header.
+- **Assign** — paid feature, opens teammate picker (Phase D).
+- **Ignore** — with reason picker: "Not applicable", "Accepted risk", "Won't fix". Ignored issues move to a collapsed section.
+- **View in page** — opens the live site in a new tab, scrolled to the element (using `#element-id` or a URL fragment we compose).
+
+### 6. Mark-done & projected score
+
+When a user marks an issue done, the client:
+1. Optimistically updates issue status.
+2. Recomputes the projected score using the same algorithm the backend used, minus this issue's contribution.
+3. Shows the projected score next to the current score in the header:
+   ```
+   72 → 78 (projected after 3 fixes)
+   ```
+4. Persists to backend via `PATCH /audits/:id/issues/:issueId { status: 'DONE' }`.
+
+**Caveat copy:** *"Run a new audit to confirm your score."* Sits next to the projected score. Honest about the estimate.
+
+### 7. Keyboard shortcuts
+
+| Key | Action |
+|---|---|
+| `j` | Next issue |
+| `k` | Previous issue |
+| `x` | Mark current issue done |
+| `i` | Ignore current issue |
+| `/` | Focus filter |
+| `g` | Open grouping menu |
+| `z` | Zoom to current issue's element on screenshot |
+| `s` | Focus share action |
+| `e` | Focus export action |
+| `?` | Show shortcuts cheat sheet overlay |
+| `Esc` | Close drawers, cheat sheet, zoom |
+
+Cheat sheet overlay rendered by `<looksee-kbd-cheatsheet>`, triggered globally. Accessible, focusable, dismissable.
+
+## Technical design
+
+### State management
+
+Introduce a service `AuditResultsStore` (BehaviorSubject-backed) scoped to the route component:
+
+```ts
+interface AuditResultsState {
+  record: AuditRecord;
+  issues: Issue[];
+  selectedIssueId: string | null;
+  grouping: 'severity' | 'category' | 'wcag' | 'status';
+  filter: { categories: Set<Category>; severities: Set<Severity>; query: string };
+  ignoredReasons: Record<IssueId, string>;
+  collapsedGroups: Set<string>;
+  projectedScore: number | null;
+}
+```
+
+Components subscribe to slices via selectors; dispatch via typed action methods on the store (no raw `next()` from outside).
+
+### Data model (additions to existing)
+
+```ts
+interface Issue {
+  id: string;
+  auditId: string;
+  category: 'ACCESSIBILITY' | 'CONTENT' | 'VISUAL' | 'SEO';
+  severity: 'CRITICAL' | 'MAJOR' | 'MINOR';
+  status: 'OPEN' | 'IN_PROGRESS' | 'DONE' | 'IGNORED';
+  title: string;                    // 1 line, plain English
+  whyItMatters: string;             // 1–2 sentences
+  wcag?: { criterion: string; level: 'A' | 'AA' | 'AAA'; url: string };
+  fixSuggestion: {
+    description: string;
+    codeBefore?: string;
+    codeAfter?: string;
+    language?: string;
+  };
+  affectedElements: AffectedElement[];
+  impactScore: number;              // precomputed by backend, 0–100
+  aboveFold: boolean;
+}
+
+interface AffectedElement {
+  id: string;
+  selector: string;
+  screenshotCropUrl: string;
+  boundingBox: { x: number; y: number; width: number; height: number }; // normalized 0–1
+  snippetHtml?: string;
+}
+```
+
+### Route component
+
+```ts
+@Component({ standalone: true, selector: 'looksee-audit-results', ... })
+export class AuditResultsComponent {
+  constructor(private route: ActivatedRoute, private store: AuditResultsStore) {}
+
+  ngOnInit() {
+    const id = this.route.snapshot.paramMap.get('id')!;
+    this.store.load(id); // fetches audit record + issues, subscribes to WS updates
+  }
+}
+```
+
+### Removal
+
+- Delete `page-audit-review.component.ts/html/scss`.
+- Delete `element-info-dialog.component.*`.
+- Delete duplicated score-gauge SVG code in `audit-dashboard.component.html`.
+- Delete the ~200 lines of commented-out HTML.
+
+### A11y
+
+- Issue rows are `<li>` with `role="option"` inside an `<ul role="listbox">`. Selection follows listbox pattern.
+- Detail panel is a `<section aria-labelledby="issue-title">`.
+- Hotspots are `<button>` elements with `aria-label="Issue 3: Contrast on CTA, critical"`.
+- Cheat sheet is a `role="dialog"` with focus trap.
+- Live score updates announce via ARIA live region after mark-done.
+
+## Acceptance criteria
+
+**Structure:**
+- [ ] `page-audit-review` component deleted; replaced by the component tree in §1.
+- [ ] `element-info-dialog` deleted; its functionality served by `<issue-detail-panel>`.
+- [ ] No component in the new tree exceeds 250 lines.
+- [ ] No inline `style="…"` attributes in the new templates.
+
+**Layout:**
+- [ ] 3-panel layout at ≥ 1024px; tab layout at 768–1023px; stacked on < 768px.
+- [ ] Left and right panels scroll independently; selecting an issue in the list auto-scrolls it into view.
+
+**Issue ranking:**
+- [ ] Default sort: impact score descending, grouped by severity.
+- [ ] Grouping dropdown changes between Severity / Category / WCAG / Status.
+- [ ] Collapsed-group state persists in localStorage.
+
+**Screenshot:**
+- [ ] Hotspots render at correct positions across viewport sizes.
+- [ ] Clicking a hotspot selects the issue and scrolls it into view.
+- [ ] Hovering an issue row highlights the corresponding hotspot.
+- [ ] Double-click zooms into the element; Escape exits zoom.
+
+**Detail panel:**
+- [ ] Every issue shows Why / Standards / Fix / Affected sections, in order.
+- [ ] Copy-fix button copies the fix snippet and announces "Copied" to assistive tech.
+- [ ] Mark-done updates status, decrements group count, and updates projected score.
+- [ ] Ignore with reason moves the issue to a collapsed "Ignored" group.
+
+**Keyboard:**
+- [ ] All shortcuts in §7 work; cheat sheet accessible via `?`.
+- [ ] Focus management preserved when opening/closing zoom and drawers.
+
+**A11y:**
+- [ ] Axe passes with 0 serious violations on results page.
+- [ ] VoiceOver / NVDA smoke test passes (manual).
+
+## Metrics
+
+- `Results: viewed` — user landed on the results page (count: 1 per audit-view).
+- `Results: issue-detail-opened` (properties: `severity`, `category`) — proves engagement depth.
+- `Results: issue-marked-done`
+- `Results: issue-ignored` (properties: `reason`)
+- `Results: fix-copied`
+- `Results: hotspot-clicked` — verifies the canvas loop works.
+- `Results: keyboard-shortcut-used` (properties: `key`) — measures power-user adoption.
+
+**Success metrics:**
+- Time-to-first-detail-open (from results load) < 30s for 60% of sessions.
+- Mark-done rate among completed audits > 15% (a proxy for real value delivery).
+- Average issues-viewed-per-session ≥ 3 (vs. unknown today).
+
+## Risks & open questions
+
+1. **Backend issue data shape.** The `Issue` interface above assumes structured fields that may not match today's payload (which carries `ADAComplianceNote`, `UXIssueMessage`, etc., with variable fidelity). Needs a backend data-contract review before Phase B.
+2. **Hotspot coordinates.** Today's backend captures element screenshots but may not export normalized bounding boxes for the full-page screenshot. May need a rendering pass to recompute coordinates.
+3. **Projected score accuracy.** Client-side recomputation may drift from backend algorithm over time. Mitigation: backend endpoint `GET /audits/:id/preview-score?ignored=[]&done=[]` as the source of truth, cached by the client.
+4. **Mark-done for ignored issues.** If backend re-runs future audits and finds the "same" issue, do we auto-mark done from history? Recommend: yes, via a stable `issueFingerprint` (selector + rule id). Design TBD.
+5. **Domain audit canvas.** Replacing screenshot with a page list is clear, but what's the default sort for pages? Recommend: lowest-score first (triage mode).
+6. **Store library.** BehaviorSubject-based store is lightweight; consider NgRx Signals or akita if complexity grows. Keep simple for now.
+
+## Phasing
+
+**Milestone 1 (behind feature flag):**
+- New component tree shipped alongside legacy `page-audit-review`.
+- Feature flag `results_v2` toggles between them.
+- Internal dogfooding only.
+
+**Milestone 2:**
+- Flag on for 10% of users; measure engagement metrics vs. control.
+- Fix any regressions.
+
+**Milestone 3:**
+- Flag on for all; legacy component marked deprecated.
+- Delete legacy after 2 releases with no rollback.
+
+**Milestone 4 (Phase C):**
+- Team features (assign, comments on issues).
+- Compare with previous audit.

--- a/Look-see-UI-v3/docs/design/04-navigation-ia.md
+++ b/Look-see-UI-v3/docs/design/04-navigation-ia.md
@@ -1,0 +1,367 @@
+---
+id: 04
+title: Navigation & information architecture
+status: Draft
+phase: C
+addresses:
+  - Orphaned routes (`/dashboard`)
+  - Two divergent review routes (`/audit/:id/page` and `/audit/:id/review`)
+  - `Domains` nomenclature confuses non-expert users
+  - No `/home` landing; users dump into a flat audit list
+  - No breadcrumbs / location awareness in nested views
+  - `/how-it-works` and `/integrations` compete with workspace nav
+  - No site-level concept grouping related page audits
+owner: Design + Frontend
+related:
+  - UX_REDESIGN.md §4, §6.1
+  - 02-audit-status-and-progress.md
+  - 03-results-architecture.md
+---
+
+# 04 — Navigation & information architecture
+
+## Problem
+
+Today's route table has 11 defined routes; 3 of them are orphaned or redundant:
+
+- `/dashboard` — defined but no nav link points to it.
+- `/audit/:id/page` vs `/audit/:id/review` — two paths to the same screen with subtly different guards. The `review` path is used as a "shareable" route but has no share-token gating.
+- `/integration` (singular) — listed in the router; the nav link says "Integrations" (plural). Leads to the same grayed-out "coming soon" page.
+
+Navigation problems compound:
+
+- The sidebar mixes **workspace** pages (Audits) with **marketing** pages (How it works) and **coming-soon** pages (Integrations) as peers.
+- There is no **home** page. On login, users land on `/audit` which is a flat list of past audits — useful when you have history, useless on day 1.
+- There are no **breadcrumbs** on nested pages. A user on a page audit result has no visible path back to a domain/site.
+- **Domain** is the model name exposed in the UI. Non-technical users call this a **site**.
+- No concept of a **project** or **team workspace** — all audits are peers. If an agency audits 10 client sites, they all mingle in one list.
+
+## Goals
+
+1. Collapse duplicate routes; enforce one canonical URL per destination.
+2. Introduce `/home` as the post-login default.
+3. Rename `Domain` → `Site` in all user-facing copy. Keep backend model names unchanged.
+4. Add breadcrumbs to every nested view.
+5. Restructure sidebar into **workspace** vs **learn** sections.
+6. Retire `/integrations` route until at least one integration ships (or soft-hide behind a "beta" section).
+7. Introduce a shareable public route `/r/:token` for external viewing.
+
+## Non-goals
+
+- Multi-team workspaces / org support (Phase D).
+- Migrating URLs of live shared audit links — we'll honor old URLs with redirects for one year.
+- Changing the backend model names.
+
+## User stories
+
+- *As Morgan (returning)*, I log in and immediately see what changed since my last visit — not a flat list of every audit I've ever run.
+- *As Morgan (first visit)*, I go to `/home` after signup and see a clear CTA to run my first audit.
+- *As an engineer sharing a result*, I paste a link in Slack and my teammate (no account) reads the report without friction.
+- *As Priya*, I navigate from a page audit back up to its parent site with one click.
+
+## Design
+
+### 1. Route map (proposed)
+
+**Public (no auth):**
+
+| Path | Component | Notes |
+|---|---|---|
+| `/` | LandingComponent | The marketing + try-it-now page |
+| `/pricing` | PricingComponent | New; billing plans |
+| `/how-it-works` | HowItWorksComponent | Retained for marketing SEO |
+| `/r/:shareToken` | SharedAuditViewComponent | New; gated by token; renders read-only results, no nav chrome |
+| `/login` | LoginComponent | Auth0 entry |
+| `/logout` | (handled by Auth0) | |
+| `/404` | NotFoundComponent | Friendly 404 with links back |
+
+**Authenticated (app shell):**
+
+| Path | Component | Notes |
+|---|---|---|
+| `/home` | HomeComponent | Default after login; activity + quick audit |
+| `/sites` | SiteListComponent | Renamed from `Domains` |
+| `/sites/:id` | SiteDetailComponent | Aggregate scores + page list |
+| `/sites/:id/settings` | SiteSettingsComponent | Per-site options |
+| `/audits` | AuditListComponent | Full audit history |
+| `/audits/:id` | AuditResultsComponent | Unified single-page & domain results (see spec 03) |
+| `/settings` | SettingsComponent | Tabbed: Account / Billing / Team / Notifications / API |
+| `/help` | HelpComponent | In-app help (merged with `/how-it-works`) |
+
+**Retired:**
+
+| Old path | Redirects to | Rationale |
+|---|---|---|
+| `/dashboard` | `/home` | Orphan |
+| `/audit` | `/audits` | Singular → plural |
+| `/audit/:id/page` | `/audits/:id` | Duplicate of `/audit/:id/review` |
+| `/audit/:id/review` | `/audits/:id` | Unified |
+| `/audit/:id/domain` | `/audits/:id` | Unified; component adapts to audit type |
+| `/domains` | `/sites` | Rename |
+| `/integration` (singular) | `/integrations` | Fix typo |
+| `/integrations` | (hidden until live) | See §6 |
+| `/account` | `/settings` | Renamed |
+
+Redirects are **permanent (301)** via Angular router `redirectTo` with `pathMatch: 'full'`. Any inbound link from email, Slack, PDF exports, or external blogs keeps working.
+
+### 2. Sidebar structure
+
+```
+┌──────────────────────────────┐
+│  ◆ Look-see                  │
+│                              │
+│  ┌────────────────────────┐  │
+│  │ + New audit            │  │  ← always-visible primary action
+│  └────────────────────────┘  │
+│                              │
+│  WORKSPACE                   │  ← section label (overline type)
+│  ⌂  Home                     │
+│  ◈  Sites          [ 3 ]     │  ← badge: count of sites with new issues
+│  ≡  Audits                   │
+│                              │
+│  LEARN                       │
+│  ?  Help                     │
+│  ⇄  Integrations    beta     │  ← "beta" tag; present only when >=1 integration
+│                              │
+│  ─────────────────────────   │
+│  [ MB ] Morgan B.       ⌃   │  ← user menu (popover)
+└──────────────────────────────┘
+```
+
+**Interaction rules:**
+
+- Active route is marked with: brand color icon + brand color text + 3px left border. Not just text color (current pattern fails AA).
+- Badges show urgency (new failed audits, sites with score drops). Surfaced by backend polling or WS.
+- The user menu popover has: avatar + name + email, links to Settings, Log out.
+- Sidebar can collapse to a 56px icon rail via a toggle at the bottom — state persists in localStorage.
+- At `< 1024px`, sidebar auto-collapses; below `< 768px`, it becomes a hamburger-triggered drawer.
+
+### 3. Breadcrumbs
+
+Every nested authenticated route renders a breadcrumb row above the page title.
+
+Examples:
+
+```
+/audits/abc123                  →  Audits  /  yoursite.com/pricing
+/sites/xyz/settings             →  Sites  /  acme.com  /  Settings
+/sites/xyz                      →  Sites  /  acme.com
+/settings                       →  Settings
+/home                           →  (no breadcrumb — root)
+```
+
+**Rules:**
+- Each segment except the current is a link.
+- Separator is ` / ` with 1-char padding on each side, rendered in muted text.
+- The trailing segment matches the page's `<h1>` where possible, for redundancy.
+- Breadcrumb row also hosts page-level actions (Re-run, Settings, etc.) on the right — converges with current "audit-header" pattern.
+
+### 4. `/home` design
+
+```
+┌──────────────────────────────────────────────────────────────────────┐
+│                                                                      │
+│   Good morning, Morgan.                                              │
+│                                                                      │
+│   ┌────────────────────────────────────────────────────────────┐     │
+│   │  ⚡  Run a new audit                                       │     │
+│   │                                                            │     │
+│   │  [ https://…                              ] ( Audit )      │     │
+│   │                                                            │     │
+│   │  Audit type: ◉ Single page  ○ Whole site                   │     │
+│   └────────────────────────────────────────────────────────────┘     │
+│                                                                      │
+│   Your sites                               [ + Add site ]  See all → │
+│   ┌──────────────┐ ┌──────────────┐ ┌──────────────┐                 │
+│   │ acme.com     │ │ shop.acme    │ │ docs.acme    │                 │
+│   │  82 / 100  ↑3│ │  67 / 100 ↓2 │ │  91 / 100  — │                 │
+│   │ 3 new issues │ │ 11 new issues│ │ all clear    │                 │
+│   └──────────────┘ └──────────────┘ └──────────────┘                 │
+│                                                                      │
+│   Recent audits                                         See all →    │
+│   ─────────────────────────────────────────────────────────────      │
+│   ● acme.com/pricing           72 / 100   2 hours ago        ⋯       │
+│   ● shop.acme.com/checkout     54 / 100   yesterday          ⋯       │
+│   ● acme.com/                  82 / 100   3 days ago         ⋯       │
+│                                                                      │
+│   ● = status chip, colored                                           │
+└──────────────────────────────────────────────────────────────────────┘
+```
+
+**First-time home state:** when a user has zero sites and zero audits, the page simplifies to the quick-audit card + an empty-state illustration: *"Run your first audit to see your results here."*
+
+**Data sources:**
+- `GET /me/sites` — sites with aggregate score and delta.
+- `GET /audits?limit=5&sort=recent` — recent audits (any status).
+
+### 5. `/sites` — renamed and productized
+
+Current `/domains` has a placeholder "unauthenticated info cards" view and a commented-out authenticated view. Proposed:
+
+- Grid of **SiteCard** components (see 06-shared-components.md).
+- Each card: favicon, site name, current health score, 30-day sparkline, last audit timestamp, "Run audit" action.
+- "Add site" is a card-shaped primary action at the end of the grid.
+- Clicking a card routes to `/sites/:id`.
+
+`/sites/:id` layout was specified in UX_REDESIGN.md §7.1 — retained unchanged.
+
+### 6. Integrations — hide until live
+
+Current `/integrations` is a graveyard of "coming soon" cards. Proposed:
+
+1. **Remove the top-nav link until at least one integration ships.** Users have no reason to go there.
+2. When an integration ships (e.g., Slack notifications), re-introduce the nav link with a small **beta** badge until it's out of beta.
+3. The page design retains the card grid but adds real status:
+
+| Status | Card treatment |
+|---|---|
+| **Available** | Full color, "Connect" button |
+| **Beta** | Full color + "Beta" chip, "Connect" button |
+| **Waitlist** | 60% opacity, "Notify me" button with email capture |
+
+Never show a card with no working action.
+
+### 7. Public share route
+
+`/r/:shareToken` renders a **view-only**, no-nav-chrome version of the audit results. Intended for paste-in-Slack, paste-in-email, view-on-LinkedIn use.
+
+- Token issued by `POST /audits/:id/share` (authenticated users).
+- Token includes: audit id, expiry timestamp (default 30 days for free, 1 year for paid, 30 days for guests), scope (view).
+- Revocation: `DELETE /share/:token`.
+- Rendering: uses the same `<audit-results-shell>` component but hides the sidebar, sets a `readonly` input that suppresses actions (Mark done, Export without signup, Settings).
+- Fallback: if token is expired, show a *"This report link has expired"* page with a CTA to sign up and run a fresh audit.
+
+## Technical design
+
+### Router config
+
+```ts
+// app-routing.module.ts (new structure, abbreviated)
+const routes: Routes = [
+  // Public
+  { path: '', component: LandingComponent, data: { public: true } },
+  { path: 'pricing', component: PricingComponent, data: { public: true } },
+  { path: 'how-it-works', component: HowItWorksComponent, data: { public: true } },
+  { path: 'r/:shareToken', component: SharedAuditViewComponent, data: { public: true, noChrome: true } },
+
+  // Authenticated (inside AppShellComponent)
+  {
+    path: '',
+    component: AppShellComponent,
+    canActivate: [AuthGuard],
+    children: [
+      { path: 'home', component: HomeComponent },
+      { path: 'sites', component: SiteListComponent },
+      { path: 'sites/:id', component: SiteDetailComponent },
+      { path: 'sites/:id/settings', component: SiteSettingsComponent },
+      { path: 'audits', component: AuditListComponent },
+      { path: 'audits/:id', component: AuditResultsComponent },
+      { path: 'settings', component: SettingsComponent },
+      { path: 'help', component: HelpComponent },
+      { path: '', redirectTo: 'home', pathMatch: 'full' },
+    ],
+  },
+
+  // Redirects
+  { path: 'dashboard', redirectTo: 'home', pathMatch: 'full' },
+  { path: 'audit', redirectTo: 'audits', pathMatch: 'full' },
+  { path: 'audit/:id/page', redirectTo: 'audits/:id', pathMatch: 'full' },
+  { path: 'audit/:id/review', redirectTo: 'audits/:id', pathMatch: 'full' },
+  { path: 'audit/:id/domain', redirectTo: 'audits/:id', pathMatch: 'full' },
+  { path: 'domains', redirectTo: 'sites', pathMatch: 'full' },
+  { path: 'integration', redirectTo: 'integrations', pathMatch: 'full' },
+  { path: 'account', redirectTo: 'settings', pathMatch: 'full' },
+
+  // 404
+  { path: '**', component: NotFoundComponent },
+];
+```
+
+### Breadcrumb service
+
+```ts
+@Injectable({ providedIn: 'root' })
+export class BreadcrumbService {
+  crumbs$ = new BehaviorSubject<Breadcrumb[]>([]);
+  set(crumbs: Breadcrumb[]) { this.crumbs$.next(crumbs); }
+  clear() { this.crumbs$.next([]); }
+}
+
+// Each route component sets crumbs in ngOnInit, e.g.:
+ngOnInit() {
+  this.breadcrumbs.set([
+    { label: 'Sites', href: '/sites' },
+    { label: this.site.name, href: `/sites/${this.site.id}` },
+    { label: 'Settings' },  // no href = current
+  ]);
+}
+```
+
+`<looksee-breadcrumb-bar>` reads the service and renders.
+
+### Copy change: `Domain` → `Site`
+
+- **User-facing labels:** 100% of occurrences of "Domain" in templates, buttons, table headers, help text → "Site."
+- **Data model class names:** unchanged (`Domain`, `DomainSettings`, etc.). Localized in model files; UI maps label on render.
+- **Analytics event names:** keep historical event names for continuity; add new events alongside as needed.
+- **URLs:** the user-facing path is `/sites`. API calls to `/domains` remain until backend rename (out of scope).
+
+### App shell
+
+Introduce an `AppShellComponent` that owns: sidebar, breadcrumb bar, toast host, mobile-drawer state. Child routes render inside a `<router-outlet>` within its main content area.
+
+Public routes (landing, pricing, help, shared audit) do **not** use the app shell — they have their own layout with a marketing nav bar or no chrome.
+
+## Acceptance criteria
+
+- [ ] All orphan routes redirected via `redirectTo`.
+- [ ] Zero references to `/audit/:id/page` or `/audit/:id/review` in templates or code (except the router redirect entries).
+- [ ] Every user-facing instance of "Domain" replaced with "Site" (verified by grep of template files).
+- [ ] `/home` renders correctly for zero-state and populated-state users.
+- [ ] Sidebar is divided into Workspace / Learn sections with correct active-state styling.
+- [ ] Breadcrumbs render on every nested route; root route (`/home`) has no breadcrumb.
+- [ ] `/r/:shareToken` renders results without sidebar or authenticated-only actions.
+- [ ] Old share links (via expired routes like `/audit/:id/review`) redirect to new equivalent.
+- [ ] 404 page exists and renders friendly message + links.
+- [ ] A11y: keyboard-navigable skip link jumps past sidebar to main content; tab order logical.
+
+## Metrics
+
+- `Nav: sidebar-item-clicked` (properties: `item`) — distribution shows which nav items matter.
+- `Nav: breadcrumb-clicked` (properties: `depth`) — verifies breadcrumbs are used.
+- `Nav: new-audit-button-clicked` — the always-visible CTA in the sidebar; baseline for later optimization.
+- `Home: quick-audit-submitted` — proves `/home` is a useful primary surface.
+- `Share: token-created`, `Share: token-viewed` — measures shareable-link adoption.
+
+**Success metrics:**
+- `/home` returning-user engagement (≥ 1 action) > 80% of sessions.
+- Reduction in 404s from external links (tracking pre/post redirect rollout).
+- Domain → Site rename causes zero ticket volume (copy change is invisible).
+
+## Risks & open questions
+
+1. **SEO impact from route changes.** `/domains` and `/how-it-works` may have inbound links. Use `301 Moved Permanently` redirects (not 302) and monitor Search Console.
+2. **Shared link token architecture.** New endpoint + table needed server-side. Coordinate with backend team; token design should prevent enumeration (UUIDv4 + HMAC).
+3. **Breadcrumb fragility.** Components setting breadcrumbs in `ngOnInit` can race with async data loads. Recommend each component pushes two updates: initial (with placeholders like "Loading…") and final (with resolved names).
+4. **Rename scope.** "Domain" also appears in settings screens, emails, exports, and marketing pages. Need a comprehensive audit; some marketing copy may deliberately use "domain" for SEO — product decision.
+5. **Sidebar collapse state.** Persists to localStorage — but if user has multiple devices, their preference doesn't roam. Minor issue; defer.
+6. **Integrations retirement.** Do we keep `/integrations` route accessible (not linked from nav) for users bookmarking, or hard-redirect to `/home`? Recommend: redirect for now; restore when ready.
+
+## Phasing
+
+**Milestone 1 (Phase A pairing):**
+- Redirects in place; old links keep working.
+- Breadcrumb service + component shipped, used on 2–3 existing pages.
+
+**Milestone 2:**
+- Sidebar rebuilt with Workspace/Learn structure.
+- Domain → Site rename swept through templates.
+- `/home` component built and routed as default.
+
+**Milestone 3:**
+- `/sites` and `/sites/:id` rebuild (paired with SiteCard in spec 06).
+- `/settings` tabbed view.
+
+**Milestone 4:**
+- `/r/:shareToken` public share route.
+- Integrations nav re-added when first integration ships.

--- a/Look-see-UI-v3/docs/design/05-landing-and-onboarding.md
+++ b/Look-see-UI-v3/docs/design/05-landing-and-onboarding.md
@@ -1,0 +1,326 @@
+---
+id: 05
+title: Landing & onboarding friction fixes
+status: Draft
+phase: A
+addresses:
+  - URL validation regex rejects valid TLDs (.io, .co, .me)
+  - Pessimistic "Unfortunately" login-required dialog
+  - Auto-rotating marketing carousel during wait (see 02)
+  - No trust scaffolding on landing (no logos, no sample, no proof)
+  - Guest export wall — value lost before demonstrated
+  - Copy tone drift ("Astounding!!!!", typos)
+owner: Design + Frontend + Marketing
+related:
+  - UX_REDESIGN.md §5.1, §5.2, §5.5, §10
+  - 02-audit-status-and-progress.md
+---
+
+# 05 — Landing & onboarding friction fixes
+
+## Problem
+
+The top-of-funnel has four friction points within the first 60 seconds:
+
+1. **URL validation is punitive.** `landing.component.ts` validates URLs against a regex that hardcodes known TLDs. Valid modern URLs (`.io`, `.co`, `.me`, `.app`, `.dev`) get rejected with a generic error. This is the user's first interaction with the product and it fails.
+
+2. **Guest conversion dialog is pessimistic.** Verbatim: *"Unfortunately we only provide 1 free audit for visitors without an account. On the bright side, we allow up to 10 free audits to users that create a FREE account."* Starts with "Unfortunately" at the moment we're trying to convert. Leads with scarcity, not value.
+
+3. **No trust scaffolding above the fold.** Landing page goes URL input → features → footer. No customer logos, no sample report preview, no "X audits run," no testimonials. Morgan (the non-expert) has nothing to believe in.
+
+4. **Guest export wall.** Guest users who complete an audit can see results but clicking "Export PDF" opens a login modal. Users have experienced the value *and* been blocked from taking the obvious next action.
+
+Adjacent issues:
+- Copy drift: "Astounding!!!!", "truly exception experience" (typo), "Hey there!", "Please wait while we load your audits…".
+- Landing footer shows © 2021.
+
+## Goals
+
+1. **Permissive URL parsing** — accept anything that parses as a URL; never reject at the client level.
+2. **Inline, value-first signup** — demonstrate value before asking for signup; signup appears as an inline card, not a wall.
+3. **Rewrite guest/export/error dialogs** to be direct, specific, and numerate.
+4. **Add trust scaffolding** above the fold on the landing page.
+5. **Show, don't tell** — a live sample audit result visible from the landing page.
+
+## Non-goals
+
+- Pricing page design (separate spec).
+- A/B testing infrastructure — assume we can toggle via feature flag and measure via Segment.
+- Localization — English only.
+
+## User stories
+
+- *As Morgan*, I paste `acme.co` and it just works — no error, no scheme required.
+- *As Morgan*, I complete a guest audit, see my score, read the top issue, and only *then* am I asked to sign up — and the ask makes sense ("save this report").
+- *As a skeptic*, I land on `/` and see real customer logos and a sample report before I commit to entering a URL.
+- *As Priya*, I sign up because I need historical tracking and PDF export — the upgrade path from guest is transparent.
+
+## Design
+
+### 1. URL input — permissive
+
+**Validation at blur (not on submit):**
+
+```ts
+function normalizeUrl(input: string): { url: string; warning?: string } | { error: string } {
+  const trimmed = input.trim();
+  if (!trimmed) return { error: 'Enter a website URL.' };
+
+  // Prepend https:// if scheme missing
+  const withScheme = /^https?:\/\//i.test(trimmed) ? trimmed : `https://${trimmed}`;
+
+  let parsed: URL;
+  try {
+    parsed = new URL(withScheme);
+  } catch {
+    return { error: 'That doesn\'t look like a valid website address.' };
+  }
+
+  // Reject only obviously-invalid hosts
+  if (!parsed.hostname.includes('.') || parsed.hostname.endsWith('.')) {
+    return { error: 'That doesn\'t look like a valid website address.' };
+  }
+
+  // Reject local/private URLs politely
+  if (parsed.hostname === 'localhost' || parsed.hostname.startsWith('127.')) {
+    return { error: 'We can\'t audit local addresses. Try a public URL.' };
+  }
+
+  return { url: parsed.toString() };
+}
+```
+
+**Behaviors:**
+- No regex allow-list of TLDs. Anything `URL()` constructor accepts is accepted.
+- Scheme is auto-prepended if missing (`acme.co` → `https://acme.co`).
+- Validation runs on blur (input loses focus), not on every keystroke, so users aren't yelled at while typing.
+- If the server later rejects (DNS, 4xx, 5xx), the error surfaces from the backend with a specific, actionable message ("We couldn't reach this URL. Check the address and try again.").
+
+**Input UI:**
+
+```
+┌─────────────────────────────────────────────┬───────────────┐
+│ 🌐  https://your-site.com                   │  Audit my site│
+└─────────────────────────────────────────────┴───────────────┘
+   ↑ globe icon; scheme hint in placeholder
+```
+
+On focus, placeholder fades; cursor positioned at start. Clearing the field with `x` button.
+
+### 2. Landing page — above the fold
+
+See UX_REDESIGN.md §5.2 for the full layout. Key elements:
+
+- **Headline:** *"Find what's broken on your website."*
+- **Sub-headline:** *"In under a minute. Without opening DevTools."*
+- **URL input + CTA** (hero-sized).
+- **Micro-reassurance below the input:** *"Free, no signup. We'll check accessibility, content quality, visual design, and SEO."*
+- **Trust row:** *"Trusted by teams at"* + 4 customer logos. If no logos yet, replace with *"3,247 sites audited this month"* (live count from backend).
+
+### 3. Landing page — below the fold
+
+Three sections only:
+
+**Section 1 — Live sample.** An embedded preview of a canned audit result (e.g., audit of `wikipedia.org`). The actual results UI (see spec 03) rendered inline, with:
+- 3 visible issues
+- A hotspot on the embedded screenshot
+- A "Try it on your site ↑" link that scrolls back to the input
+
+This sells the product by showing exactly what the user will get.
+
+**Section 2 — How it works (3 steps).**
+
+| Step | Illustration | Headline | Body |
+|---|---|---|---|
+| 1 | `audit_website.jpg` | Paste a URL | *"No setup. No crawler config. Just a web address."* |
+| 2 | `review_audit.png` | Read your report | *"We rank every issue by impact so you know what to fix first."* |
+| 3 | `share_illustration.png` | Share with your team | *"Send a link. Export a PDF. Assign issues to teammates."* |
+
+**Section 3 — What we check.**
+
+Four paragraphs, one per audit dimension (Accessibility, Content, Visual, SEO). Each ends with *"See a sample issue →"* that opens an inline expandable with a real example.
+
+**Footer:** minimal (logo, © 2026 Look-see, Privacy, Terms, Status, Contact). See spec 04 §1.
+
+### 4. Guest flow — unblock everything
+
+Current: guest runs 1 audit, must sign up to view PDF export, must sign up to save, must sign up to run a second.
+
+Proposed:
+- **Guest runs audits.** Per-IP/per-session limit (default: 3 audits per day) instead of "1 ever." Generous enough to sell the product.
+- **Guest sees results.** Full results UI, all issues visible.
+- **Guest gets a share link.** `/r/:token` with 30-day expiry, auto-generated on first audit completion. Copyable.
+- **Guest export preview.** Export PDF button is enabled; click opens an in-browser preview (not a download), with a subtle watermark across the page: *"Preview — sign up to download a clean copy."*
+- **Guest save.** Inline card (see §5) appears after 15s or after scrolling past the third issue. Dismissable.
+- **Guest at limit.** When they try to run a 4th audit, show a card (not a modal): *"You've used today's 3 free audits. Sign up to run 7 more this month."* Not apologetic, just factual.
+
+### 5. Inline signup card
+
+```
+┌─────────────────────────────────────────────────────────┐
+│  Save this report for later?                            │
+│                                                         │
+│  We'll keep your audit history, track your score        │
+│  over time, and unlock 7 more free audits this month.   │
+│                                                         │
+│  ┌───────────────────────┐  ┌────────────────────────┐  │
+│  │ Continue with Google  │  │ Sign up with email     │  │
+│  └───────────────────────┘  └────────────────────────┘  │
+│                                                         │
+│  Already have an account? Log in →                      │
+└─────────────────────────────────────────────────────────┘
+```
+
+**Rules:**
+- Appears inline on the results page (not modal).
+- Position: below the score header, above the issue list, once trigger fires.
+- Triggers (any of):
+  - User has been on the results page ≥ 15s.
+  - User scrolls past the 3rd issue in the list.
+  - User clicks Export PDF or Save.
+- Dismissable with subtle `×`. Dismissal persists for the session (not shown again for 24h).
+- Two auth options visible (Google + email). No stack of six social logins.
+- **Unlock copy is numeric and specific.** "7 more free audits this month" beats "more free audits."
+
+### 6. Copy rewrites
+
+| Location | Before | After |
+|---|---|---|
+| Landing hero | *"Find and fix accessibility issues in seconds"* | *"Find what's broken on your website."* |
+| Landing sub | *"Enter any URL and get a comprehensive audit of accessibility, content quality, and visual design — with AI-powered fix suggestions."* | *"In under a minute. Without opening DevTools."* |
+| Landing CTA | *"Start Audit"* | *"Audit my site"* |
+| URL helper | — | *"Free, no signup. We'll check accessibility, content, visual design, and SEO."* |
+| Guest limit dialog | *"Unfortunately we only provide 1 free audit for visitors without an account."* | *"You've used today's 3 free audits. Sign up to run 7 more this month."* |
+| Guest limit CTA | *"Log In"* | *"Sign up free"* / *"Log in"* (two buttons) |
+| URL invalid error | *"Please enter a valid URL (e.g. https://www.example.com)"* | *"That doesn't look like a valid website address."* |
+| Backend unreachable | (generic toast) | *"We couldn't reach that URL. Check the address and try again."* |
+| Landing footer | *"© 2021 Look-see Inc."* | *"© 2026 Look-see, Inc."* |
+| Empty audit list | *"Please wait while we load your audits…"* | — (skeleton rows replace this) |
+| Results empty category | *"Astounding!!!! truly exception experience"* | *"No issues found in this category."* |
+| Mobile block | *"Hey there! Look-see works best on desktop."* | *"Look-see works best on desktop. Enter your email and we'll send you a link to pick up where you left off."* + email input |
+| Abandon confirmation | *"Are you sure that you want to start a new audit? Starting a new audit will cause the currently running audit to be abandoned."* | *"This will cancel the audit in progress. Start a new one anyway?"* |
+| Beta modal | (lists specific bugs) | *"You're an early Look-see user. Thanks for the patience while we polish the rough edges — [hey@look-see.com] for feedback."* |
+
+**Voice rules** (from UX_REDESIGN.md §10, restated here for spec ownership):
+- No "Unfortunately," no "Please," no "Oops," no "Sorry" in transactional flows.
+- No `!` except in audit-complete celebration.
+- Specific numbers over vague adjectives.
+- Second person always.
+
+## Technical design
+
+### Landing URL validation
+
+- Replace the regex validator in `landing.component.ts` with the `normalizeUrl` function above.
+- Also applied in `audit-form.component.ts` and anywhere else URL input appears. Extract to a shared pure function: `src/app/utils/url.ts`.
+
+### Guest rate limiting
+
+- Client tracks guest audit count in `sessionStorage` for UX (optimistic block).
+- Backend is the source of truth: `POST /audits` returns `429` with `X-RateLimit-Remaining: 0` header when exceeded. Client handles 429 by showing the guest-limit card.
+- Rate limit key: IP + user-agent hash, 3 per 24h window. Configurable.
+
+### Inline signup card
+
+- New component `<guest-signup-card>` rendered inside results view.
+- State:
+  ```ts
+  interface GuestSignupState {
+    dismissedAt?: number;   // ms timestamp
+    trigger?: 'time' | 'scroll' | 'action';
+  }
+  ```
+- Displayed when `!authenticated && !dismissedAt` and any trigger fires.
+- Auth methods delegated to Auth0 Universal Login with `prompt=signup` for the sign-up button and default prompt for log-in.
+
+### PDF export — preview mode
+
+- `report.service.ts#exportPageReportAsPdf(...)` gains a `preview: boolean` parameter.
+- In preview mode, the returned PDF blob is rendered inline via `<iframe>` or PDF.js with a CSS overlay watermark (not in the file; in the viewer only — keeps the real file unmodified).
+- Export button label for guests: *"Preview PDF"*. Tooltip: *"Sign up to download."*
+
+### Rate limit UX on 4th audit
+
+- On `429`, don't open a modal. Render an inline card in-place of the "Audit started" success card, titled *"You've used today's audits."*
+
+## Acceptance criteria
+
+**URL input:**
+- [ ] `acme.co`, `https://acme.io`, `http://acme.dev`, `www.acme.me` all accepted.
+- [ ] `foo`, `foo.`, `localhost`, `127.0.0.1` rejected with specific messages.
+- [ ] Validation fires on blur, not on each keystroke.
+- [ ] Scheme auto-prepended when missing.
+
+**Landing page:**
+- [ ] Above-the-fold includes headline, sub, input, CTA, trust row.
+- [ ] Below-the-fold: live sample, 3-step how-it-works, what-we-check, minimal footer.
+- [ ] Footer copyright reads current year.
+- [ ] No reference to `©2021`.
+
+**Guest flow:**
+- [ ] Guest can run up to 3 audits per rolling 24h window.
+- [ ] Every guest audit generates a `/r/:token` link (30-day expiry).
+- [ ] Export PDF as guest opens in-browser preview with watermark; does not trigger signup modal.
+- [ ] Inline signup card appears at the earliest of: 15s dwell, scroll past 3rd issue, action click.
+- [ ] Card is dismissable; dismissal persists for 24h in localStorage.
+
+**Copy:**
+- [ ] All 12 strings in §6 replaced verbatim.
+- [ ] No "Unfortunately," "Oops," or "!!!!"' remain in user-facing templates (grep check).
+- [ ] Mobile block modal includes email capture input and success state.
+
+**A11y:**
+- [ ] URL input has visible label (visually-hidden is acceptable); error announced via `aria-describedby`.
+- [ ] Inline signup card is a `role="region" aria-labelledby="..."` with focusable dismiss button.
+- [ ] Landing page `<h1>` is the hero; proper heading hierarchy downstream.
+
+## Metrics
+
+- `Landing: hero-viewed`
+- `Landing: url-submitted` — top-of-funnel measure
+- `Landing: url-normalized` (properties: `scheme_added`, `reason`) — measures how often we rescue a URL
+- `Landing: url-rejected` (properties: `reason`) — should go near zero after launch
+- `Landing: sample-issue-expanded` — engagement with the "See a sample issue" affordance
+- `Guest: audit-completed`
+- `Guest: pdf-preview-opened`
+- `Guest: signup-card-shown` (properties: `trigger`)
+- `Guest: signup-card-dismissed`
+- `Guest: signup-completed` (properties: `from: guest-card|export|save|limit`)
+- `Guest: daily-limit-reached`
+
+**Success metrics:**
+- Landing-to-audit-submitted conversion ≥ 35% (baseline TBD).
+- `url-rejected` events drop to < 2% of submissions (baseline: ~8% per the current regex).
+- Guest → signup conversion within 10 minutes of first audit ≥ 25% (baseline TBD).
+- Reduction in support tickets about "URL not accepted" to zero.
+
+## Risks & open questions
+
+1. **Guest rate limit gaming.** IP+UA hashing can be bypassed with rotating proxies. Accept some leakage; monitor for abuse; add CAPTCHA only if traffic justifies.
+2. **Social proof accuracy.** "Trusted by teams at" requires permission to use customer logos. If none are available, substitute with the "X sites audited this month" count — ensure the number is real, not fabricated.
+3. **Sample audit data.** The live sample on the landing needs a canned, cached result that doesn't re-run every page view. Maintain a manually-curated set of "showcase audits" in the backend.
+4. **PDF preview rendering.** Browsers handle PDF inline rendering differently. Consider a server-generated HTML-preview fallback.
+5. **Signup card frequency.** 24h dismissal may be too aggressive or too soft — A/B test after launch.
+6. **Legal review of rate limit copy.** "3 free audits" is a commitment; check with product/legal that it matches plans in Stripe config.
+
+## Phasing
+
+**Milestone 1 (smallest, highest-leverage):**
+- URL validation fix.
+- Copy rewrites (all 12 strings).
+- Footer year update.
+- **These three changes can ship in a single day and materially improve conversion.**
+
+**Milestone 2:**
+- Inline signup card (replaces hard-wall modal).
+- Guest per-session limit increased to 3, with polite limit card.
+- PDF preview mode.
+
+**Milestone 3:**
+- Landing page rebuild (above and below the fold).
+- Live sample audit component.
+- Trust row with real logos or live counter.
+
+**Milestone 4:**
+- Mobile-block replacement with email capture.
+- Localization groundwork (extract copy to i18n files).

--- a/Look-see-UI-v3/docs/design/06-shared-components.md
+++ b/Look-see-UI-v3/docs/design/06-shared-components.md
@@ -1,0 +1,411 @@
+---
+id: 06
+title: Shared UI component library
+status: Draft
+phase: B
+addresses:
+  - Template duplication: score icon display repeated 20+ times
+  - No reusable score badge, card, empty-state, or skeleton components
+  - Component SCSS files redefine global styles
+  - No shared visual pattern for status chips
+  - Inline SVG score gauges with manual circumference math in multiple places
+owner: Design + Frontend
+related:
+  - 01-design-system.md
+  - 02-audit-status-and-progress.md
+  - 03-results-architecture.md
+  - UX_REDESIGN.md §8
+---
+
+# 06 — Shared UI component library
+
+## Problem
+
+The codebase has no shared component library — only ad-hoc patterns duplicated across templates. Specifically:
+
+- **Score icon display** (check / warning / radiation icons tied to score value) appears in ≥ 20 template locations, each with its own `*ngIf` ladder.
+- **Score gauge** (circular progress) is implemented via inline SVG with manual circumference math in `page-audit-review`, `audit-dashboard`, and `audit-list` — three different versions.
+- **Empty states** use plain `<h1>`/`<h2>` with no illustration, inconsistent CTA style.
+- **Loading states** are mostly "Please wait…" text; no skeleton loaders.
+- **Status indicators** (pending/complete/failed) don't exist at all; have to infer from score presence.
+- **Card styling** is re-declared per component; spacing, border, and shadow drift.
+
+## Goals
+
+Ship a small, well-designed component library covering **11 reusable primitives** used across all current and planned screens. Each component:
+
+- Is an Angular standalone component under `src/app/components/shared/`.
+- Consumes design tokens from spec 01 (no hex literals).
+- Has documented inputs and usage examples.
+- Has unit tests (Angular testing library or Jest-compat).
+- Ships with a Storybook entry or a single-page demo in `/docs/design/components.html`.
+
+## Non-goals
+
+- A full design system framework (Material / Ionic replacement). We're using Angular Material underneath; these components are application-layer.
+- Animation library. Motion uses Angular Animations API with tokens from spec 01.
+- A publishable npm package. These live in the app; extraction to a library happens later if ever.
+
+## User stories
+
+- *As a front-end dev*, I need a score badge, I import `<looksee-score-badge>`, pass a value, done.
+- *As a designer*, I need the status chip to look the same everywhere — so I specify once, and every instance follows.
+- *As Morgan*, I see consistent patterns across the product — which makes it feel reliable.
+
+## Design — the 11 components
+
+### 1. `<looksee-button>`
+
+Covered in spec 01 §5. Variants, sizes, loading state. Recap: `primary | accent | secondary | ghost | danger | link` × `sm | md | lg` × `[loading]`.
+
+### 2. `<looksee-status-chip>`
+
+Small pill indicating the state of an audit, a page, or an issue.
+
+**Inputs:**
+```ts
+type ChipKind =
+  | 'queued' | 'running' | 'complete' | 'failed' | 'cancelled'  // audit status
+  | 'critical' | 'major' | 'minor'                              // issue severity
+  | 'open' | 'in-progress' | 'done' | 'ignored'                 // issue status
+  | 'beta' | 'new' | 'available' | 'waitlist';                  // generic
+
+@Input() kind: ChipKind;
+@Input() size: 'sm' | 'md' = 'md';
+@Input() label?: string;   // override default label text
+@Input() showDot = false;  // leading dot (used in list rows)
+```
+
+**Visual:**
+```
+┌──────────────┐    ┌──────────────┐    ┌──────────────┐
+│ ● Auditing…  │    │ Complete     │    │ ⚠ Failed    │
+└──────────────┘    └──────────────┘    └──────────────┘
+   bg: brand.50     bg: score.good.50  bg: score.critical.50
+   text: brand.700  text: score.good   text: score.critical
+```
+
+**A11y:** chip includes a visually-hidden phrase like "Status: Auditing" so screen readers are explicit.
+
+### 3. `<looksee-score-badge>`
+
+Small, inline score representation. Replaces the duplicated icon ladders.
+
+**Inputs:**
+```ts
+@Input() value: number;                  // 0–100 or null
+@Input() size: 'sm' | 'md' | 'lg' = 'md';
+@Input() variant: 'pill' | 'circle' = 'pill';
+@Input() showLabel = true;               // show "/ 100" suffix
+@Input() muted = false;                  // for loading/placeholder
+```
+
+**Color thresholds** (from tokens):
+- `value >= 80` → good
+- `value >= 60` → warning
+- `value < 60` → critical
+- `value === null` → muted
+
+**Sizes:**
+```
+sm (h-6, text-xs):   [ 72 / 100 ]
+md (h-8, text-sm):   [  72  ]
+lg (h-12, text-lg):  [  72  ]
+```
+
+**Circle variant:** small circular chip with just the number; used in tight spaces (audit list rows, hotspots).
+
+### 4. `<looksee-score-gauge>`
+
+Large circular progress gauge, used on result headers and dashboard cards.
+
+**Inputs:**
+```ts
+@Input() value: number;                      // 0–100
+@Input() size: 'sm' | 'md' | 'lg' | 'xl' = 'lg';
+@Input() label?: string;                     // centered below value
+@Input() trend?: number;                     // +/- delta from previous
+@Input() projected?: number;                 // projected score (after fixes)
+```
+
+**Visual (lg, 120px):**
+```
+   ╭─────────────╮
+  ╱   72         ╲      ← center: score, display type
+ │    /100       │      ← subtext
+  ╲   ↑ 4        ╱      ← trend arrow in good/critical
+   ╰─────────────╯
+```
+
+**Implementation:** SVG with a single CSS-animated arc. Replace the three hand-math versions with this one component.
+
+**A11y:** `role="img"` with `aria-label` like "UX Health score 72 out of 100, up 4 from previous audit."
+
+### 5. `<looksee-score-delta-arrow>`
+
+Tiny composable used inside other components, but exposed for any "score went up/down" display.
+
+```
+↑ 4    up, good (score went up)
+↓ 2    down, critical
+—      no change, muted
+```
+
+### 6. `<looksee-data-card>`
+
+Generic card wrapper. Replaces every component's hand-rolled card.
+
+**Inputs:**
+```ts
+@Input() title?: string;
+@Input() subtitle?: string;
+@Input() padding: 'none' | 'sm' | 'md' | 'lg' = 'md';
+@Input() elevation: 'flat' | 'raised' | 'floating' = 'raised';
+@Input() interactive = false;              // adds hover lift + pointer cursor
+@Input() href?: string;                    // if set, renders as <a>
+```
+
+**Slots** (Angular content projection):
+- default content
+- `[card-actions]` — top-right action bar
+- `[card-footer]` — bottom border-separated footer
+
+**Visual variants:**
+```
+flat:      white bg, 1px border subtle, no shadow
+raised:    white bg, shadow-sm (default)
+floating:  white bg, shadow-md, lifts to shadow-lg on hover if interactive
+```
+
+### 7. `<looksee-empty-state>`
+
+Friendly empty state with illustration + headline + body + primary/secondary actions.
+
+**Inputs:**
+```ts
+@Input() illustration: 'audits' | 'sites' | 'issues' | 'search' | 'generic';
+@Input() title: string;
+@Input() body?: string;
+@Input() primaryAction?: { label: string; href?: string; onClick?: () => void };
+@Input() secondaryAction?: { label: string; href?: string; onClick?: () => void };
+@Input() compact = false;     // reduces padding and illustration size
+```
+
+**Illustrations** pulled from `src/assets/illustrations/` (many already exist — `audit_website.jpg`, `review_audit.png`, `look-see_target_check.png`).
+
+**Layout:**
+```
+        [illustration, 160px]
+
+        Title — heading-lg, centered
+
+        Body — body, max-w-md, muted
+
+        [ Primary action ]   Secondary action →
+```
+
+### 8. `<looksee-skeleton>`
+
+Animated loading placeholder. Used in lists, cards, and headers while data loads.
+
+**Inputs:**
+```ts
+@Input() variant: 'text' | 'title' | 'circle' | 'rect' | 'row';
+@Input() width?: string;    // e.g., '60%', '120px'
+@Input() height?: string;
+@Input() rows?: number;     // for 'row' variant; renders a list
+```
+
+**Behavior:** subtle shimmer animation; respects `prefers-reduced-motion` by switching to static muted-gray.
+
+**Usage patterns:**
+```html
+<looksee-skeleton variant="title" width="240px"></looksee-skeleton>
+<looksee-skeleton variant="text" [rows]="3"></looksee-skeleton>
+
+<!-- Typical audit-list loading state: -->
+<looksee-skeleton variant="row" [rows]="5"></looksee-skeleton>
+```
+
+### 9. `<looksee-site-card>`
+
+Card used on `/home` and `/sites` to represent a site at a glance.
+
+**Inputs:**
+```ts
+@Input() site: Site;    // includes url, score, trend, issuesCount, lastAuditAt, favicon
+```
+
+**Visual:**
+```
+┌────────────────────────────────┐
+│  [favicon] acme.com           ⋯│
+│                                │
+│    ╭────╮                      │
+│    │ 82 │   ↑ 3 since last     │
+│    ╰────╯                      │
+│                                │
+│  3 new issues · audited 2h ago │
+└────────────────────────────────┘
+```
+
+Interactive card; click routes to `/sites/:id`. Includes a trailing `⋯` menu for per-site actions (run audit, settings, remove).
+
+### 10. `<looksee-kbd>`
+
+Tiny keyboard-key display for shortcut hints.
+
+**Inputs:**
+```ts
+@Input() keys: string[];    // e.g., ['j'], ['Ctrl', 'K']
+```
+
+**Visual:**
+```
+[ j ]        [ Ctrl ] + [ K ]
+```
+
+Uses `<kbd>` element with tokenized styling: `ink.100` bg, `ink.300` border-bottom 2px (tactile feel), `mono` type, 11–13px.
+
+### 11. `<looksee-toast>` / ToastService
+
+Replace the current `message.service` single-method approach with a typed toast service driving a single `<looksee-toast-host>` in the app shell.
+
+**API:**
+```ts
+toast.success('Audit saved.');
+toast.error('We couldn\'t save your audit. Try again.');
+toast.info('Running the audit now.', { duration: 6000 });
+toast.promise(promise, {
+  loading: 'Saving…',
+  success: 'Saved.',
+  error: 'Something went wrong.',
+});
+```
+
+**Visual:**
+- Bottom-right stack, slide-in from right.
+- Auto-dismiss in 5s (success), 8s (error), 4s (info). Hover pauses auto-dismiss.
+- Each toast is a `<div role="status" aria-live="polite">` (or `assertive` for errors).
+- Max 3 visible at once; overflow queued.
+
+---
+
+## Component dependencies
+
+```
+looksee-button            ← (standalone)
+looksee-kbd               ← (standalone)
+looksee-status-chip       ← (standalone)
+looksee-score-delta-arrow ← (standalone)
+looksee-skeleton          ← (standalone)
+
+looksee-score-badge       ← looksee-skeleton (when value is null)
+looksee-score-gauge       ← looksee-score-delta-arrow
+looksee-data-card         ← (standalone)
+looksee-empty-state       ← looksee-button
+looksee-site-card         ← looksee-data-card, looksee-score-badge, looksee-score-delta-arrow
+looksee-toast             ← (service + host)
+```
+
+All are **standalone Angular components** (Angular 17 pattern). No shared NgModule.
+
+## Technical design
+
+### File layout
+
+```
+src/app/components/shared/
+├── button/
+│   ├── button.component.ts
+│   ├── button.component.html
+│   ├── button.component.scss
+│   └── button.component.spec.ts
+├── status-chip/
+├── score-badge/
+├── score-gauge/
+├── score-delta-arrow/
+├── data-card/
+├── empty-state/
+├── skeleton/
+├── site-card/
+├── kbd/
+├── toast/
+│   ├── toast.service.ts
+│   ├── toast-host.component.ts
+│   └── toast.component.ts
+└── index.ts    // barrel re-export for convenience
+```
+
+### Storybook-lite docs
+
+If Storybook adds too much build complexity, ship a static `/docs/design/components.html` page that imports the built components and shows examples. This is enough for internal handoff at this stage.
+
+### Testing
+
+Each component: unit tests for rendering + inputs; a11y test using axe-core via `@testing-library/angular`. Target 80% coverage on the shared library (higher than the app average because these are reused).
+
+### Tokens used by each component
+
+| Component | Tokens |
+|---|---|
+| button | `--text-primary`, `--text-on-accent`, `brand.*`, `ink.*`, radius.md |
+| status-chip | `--score-*`, `brand.*`, radius.full |
+| score-badge | `--score-*`, typography body-sm/body |
+| score-gauge | `--score-*`, typography display |
+| score-delta-arrow | `--score-good`, `--score-critical` |
+| data-card | `--surface-raised`, `--border-subtle`, shadow.sm/md |
+| empty-state | `--text-primary`, `--text-secondary`, typography heading-lg/body |
+| skeleton | `ink.100` → `ink.200` shimmer gradient |
+| site-card | all card + score tokens |
+| kbd | `ink.100`, `ink.300`, typography mono |
+| toast | `--surface-raised`, `--score-good/critical`, shadow.lg |
+
+## Acceptance criteria
+
+- [ ] All 11 components exist under `src/app/components/shared/`, with the file layout in §Technical design.
+- [ ] Every component is standalone (no NgModule).
+- [ ] No hex literals in any shared component (ESLint rule from spec 01 passes).
+- [ ] All components accept `--data-theme='dark'` tokens (verified in a dark-mode preview page).
+- [ ] All components have at least one unit test; axe-core passes for each.
+- [ ] `index.ts` barrel exports every component.
+- [ ] Documentation page (Storybook or `/docs/design/components.html`) exists with:
+  - Usage code snippet per component.
+  - Visual examples at all defined variants/sizes.
+- [ ] At least three existing pages migrated to use the new components as a proof of adoption:
+  - `audit-list` → `status-chip`, `score-badge`, `skeleton`, `empty-state`
+  - `page-audit-review` (or its replacement) → `score-gauge`, `kbd`, `empty-state`
+  - `landing` → `button`, `empty-state` (for the "what we check" section)
+
+## Metrics
+
+Not directly user-facing. Track as engineering-health KPIs:
+- Count of hand-rolled card patterns in `src/app/components/*/` (baseline → target: 0).
+- Lines of SCSS in `src/app/components/*/` (expected to *drop* as shared styles consolidate).
+- Frequency of component reuse (grep for `<looksee-*>` — trend should rise monthly).
+
+## Risks & open questions
+
+1. **Angular Material overlap.** Material already provides `MatChip`, `MatCard`, `MatProgressSpinner`. Decision: wrap Material where we can for keyboard / a11y compliance (e.g., `looksee-button` wraps `matButton`), but bring the brand layer on top. Revisit per-component.
+2. **Illustration assets.** Empty state needs 5+ illustration variants. Audit what's in `src/assets/illustrations/` already; commission or source the rest. Product decision.
+3. **Storybook vs static docs.** Storybook adds ~2–3 days of setup + ongoing maintenance. For a small team, static docs may be enough. Recommend: static for now, Storybook when the library exceeds 20 components.
+4. **Dark-mode contrast validation.** Every token pair needs manual verification in both themes. Build a tiny contrast-check script.
+5. **Toast API ergonomics.** `toast.promise(...)` is nice but couples toasts to promises, not observables. Consider adding an RxJS-friendly variant: `toast.observable(obs$, messages)`.
+6. **Kbd on mobile.** Keyboard hints are useless on touch; components consuming `<looksee-kbd>` should conditionally hide it at `< md` breakpoint, or behind a "desktop-only help" expander.
+
+## Phasing
+
+**Milestone 1 (parallel with spec 01 Milestone 2):**
+- `button`, `status-chip`, `score-badge`, `skeleton`.
+- These four unblock spec 02 (status chips in audit list) and spec 05 (signup card).
+
+**Milestone 2:**
+- `score-gauge`, `score-delta-arrow`, `empty-state`, `data-card`.
+- Unblocks spec 03 and the `/home` page.
+
+**Milestone 3:**
+- `site-card`, `kbd`, `toast`.
+
+**Milestone 4:**
+- Storybook (if we commit to it), or static docs polish.
+- Consumer migrations across the app opportunistically.

--- a/Look-see-UI-v3/docs/design/IMPLEMENTATION_LOG.md
+++ b/Look-see-UI-v3/docs/design/IMPLEMENTATION_LOG.md
@@ -1,0 +1,270 @@
+# Implementation log — Phase A foundation
+
+Record of what was actually shipped vs. what each spec calls for. Treat each
+"Shipped" item as done; "Follow-up" items are the remaining scope from that
+spec.
+
+---
+
+## Spec 01 — Design system & tokens
+
+**Shipped (M1 + M2):**
+
+- `src/theme/tokens.scss` — 40+ semantic CSS custom properties (surfaces,
+  text, borders, score, brand chips, focus ring, elevation, radius, motion)
+  with full `[data-theme='dark']` overrides.
+- `src/theme/typography.scss` — @font-face + 12 named typography utilities
+  (`text-display-xl`, `text-display`, `text-heading-lg`, `text-heading`,
+  `text-subheading`, `text-body-lg`, `text-body-token`, `text-body-sm-token`,
+  `text-caption`, `text-overline`, `text-mono`).
+- `src/theme/material-overrides.scss` — Angular Material's buttons, dialogs,
+  progress, tooltip, snackbar, form-fields rebound to Look-see tokens.
+- `tailwind.config.js` — added `ink` palette (alongside legacy `charcoal`),
+  extended score palette with semantic `bg`/`text` variants, added
+  `surface.*` semantic color references, added radius/shadow/motion tokens,
+  enabled `darkMode: ['class', '[data-theme="dark"]']`.
+- `src/styles.scss` — imports new theme files; adds global
+  `prefers-reduced-motion` opt-out; retired duplicate @font-face and
+  inline Material overrides.
+- `src/app/components/shared/button/` — `LookseeButtonComponent` (standalone):
+  6 variants × 3 sizes × loading state, token-driven, focus-visible ring.
+  Registered in AppModule imports.
+
+**Follow-up (out of scope for this pass):**
+
+- ESLint rule `no-hex-in-components` — deferred. Existing code has hundreds of
+  hex literals; enforcing would fail lint immediately. Recommended approach:
+  add as `warn` first, baseline the current count, ratchet to `error` as
+  components migrate.
+- Base `h1`-`h6` remap to new typography utilities — left as-is to avoid
+  visual churn in this milestone. Migrate per-component as touched.
+- Storybook / `/docs/design/components.html` demo page — not built.
+- Dark-mode toggle UI — groundwork in tokens only; no toggle shipped.
+- Full Material theme rebuild via `mat.define-theme()` — shipped as overrides
+  instead (lower risk).
+
+---
+
+## Spec 02 — Audit status & live progress
+
+**Shipped (M1 client-only slice):**
+
+- `src/app/models/audit-status.ts` — `AuditStatus` enum (QUEUED / RUNNING /
+  COMPLETE / FAILED / CANCELLED), `auditStatusChipKind()` mapper, terminal-
+  status predicate, and `normaliseAuditStatus()` that maps raw backend status
+  strings (including lowercase / legacy variants) into the enum. Fallback
+  resolves from score-presence when unknown.
+- `audit-list.component.ts` — imports the enum; adds `statusFor()` that reads
+  `record.status` and presence of scores to derive the correct chip kind.
+- `audit-list.component.html` — renders `<looksee-status-chip>` per row;
+  skeleton rows via `<looksee-skeleton variant="row">`; empty state via
+  `<looksee-empty-state>` (also fixed a pre-existing bug where the empty
+  state guard `!audit_records` was always falsy).
+
+**Follow-up:**
+
+- Full `AuditProgressScene` component (screenshot + streaming feed + ETA +
+  cancel + notify-me) — not built. This requires backend `auditUpdate` payload
+  changes (progressPercent, findingsPreview, latestFindingLabel,
+  screenshotUrl) which are out of scope for a front-end-only pass.
+- `cancelAudit()` / `retryAudit()` / `subscribeToCompletion()` service
+  methods — not added.
+- Retiring `audit-onboarding.component` — kept intact; flip once progress
+  scene ships.
+- WebSocket merge-on-reconnect replay — not implemented.
+
+---
+
+## Spec 03 — Results architecture refactor
+
+**Deferred entirely.** Full implementation (6 new components + store + data-
+model additions + keyboard shortcuts + mark-done + projected score) is too
+large for a single session and depends on backend data-contract decisions
+listed in the spec's Risks section.
+
+**Recommended next steps:** ship behind `results_v2` feature flag as the spec
+outlines. Start with the component tree skeleton (`AuditResultsShell`,
+`IssueNavPanel`, `ScreenshotCanvas`, `IssueDetailPanel`) rendering today's
+data shape, then iterate.
+
+---
+
+## Spec 04 — Navigation & IA
+
+**Shipped (M1 slice):**
+
+- `src/app/app-routing.module.ts` — added redirect aliases for forward-
+  compatible paths (`/home`, `/sites`, `/audits`, `/audits/:id`, `/settings`,
+  `/integrations`, `/help`) that map to existing components; redirected the
+  orphaned `/dashboard` → `/audit`; added wildcard 404 route.
+- `src/app/components/not-found/` — `NotFoundComponent` with friendly 404
+  page pointing back to home / audits / how-it-works.
+- `src/app/services/breadcrumb/breadcrumb.service.ts` — `BreadcrumbService`
+  with `set()` / `clear()` / `snapshot()` and `crumbs$` observable.
+- `src/app/components/shared/breadcrumb-bar/` —
+  `LookseeBreadcrumbBarComponent` (standalone), renders nothing when no
+  crumbs; proper `nav aria-label="Breadcrumb"` + `aria-current="page"` on
+  trailing segment.
+
+**Follow-up:**
+
+- Full canonical rename — Domain → Site, `/audit` → `/audits`, etc. requires
+  updating 19 `router.navigate` / `routerLink` call-sites + all UI copy. Not
+  attempted to avoid regressions without tests.
+- `/home` component — redirects to `/audit` for now.
+- Sidebar redesign with Workspace / Learn sections.
+- Public `/r/:shareToken` route — needs backend share-token endpoint.
+- Wiring `<looksee-breadcrumb-bar>` into route components — need to place in
+  `AppComponent` layout shell; not added yet.
+
+---
+
+## Spec 05 — Landing & onboarding friction fixes
+
+**Shipped (M1 — the three one-day wins):**
+
+- `src/app/utils/url.ts` — `normaliseUrl()` permissive URL parser. Auto-
+  prepends `https://` when scheme is missing; accepts any TLD the URL
+  constructor accepts; rejects only truly invalid hostnames and polite
+  rejections for local / private ranges.
+- `landing.component.ts` — replaced hardcoded-TLD regex with `normaliseUrl()`;
+  rewrote error copy ("We couldn't reach that URL…" instead of "our servers
+  decided to take a coffee break…").
+- `audit-form.component.ts` — same URL validator swap; rewrote error copy.
+- Copy rewrites:
+  - `start-audit-login-required-dialog.html` — removed "Unfortunately";
+    reframed as unlock-message: *"Save this audit for later?"* + *"unlock up
+    to 10 audits per month."*
+  - `start-audit-confirm-dialog.html` — *"Cancel the audit in progress?"* +
+    *"Findings collected so far won't be saved."* (replaces "Are you sure
+    that you want to start a new audit?…")
+- Footer year — already dynamic via `new Date().getFullYear()`; no change
+  needed.
+
+**Follow-up:**
+
+- Inline signup card component (triggers on 15s dwell / scroll past 3rd
+  issue) — not built.
+- Guest per-day rate limit (client-side backoff + friendly 429 card) —
+  not built.
+- PDF preview mode with watermark — not built.
+- Landing page above-/below-the-fold rebuild (trust row, live sample,
+  three-step how-it-works) — not built.
+- Mobile-block modal email-capture replacement — not built.
+
+---
+
+## Spec 06 — Shared UI components
+
+**Shipped:**
+
+- `LookseeButtonComponent` (part of Spec 01).
+- `LookseeStatusChipComponent` — 16 `kind` values covering audit status,
+  issue severity, issue status, and generic (beta/new/available/waitlist);
+  `sm`/`md` sizes; optional leading dot; SR-only accessible status text.
+- `LookseeSkeletonComponent` — 5 variants (text/title/circle/rect/row);
+  respects `prefers-reduced-motion`.
+- `LookseeEmptyStateComponent` — illustration + title + body + primary /
+  secondary actions; `compact` size; uses existing `src/assets/` art.
+- `LookseeBreadcrumbBarComponent` (part of Spec 04).
+
+**Follow-up:**
+
+- `LookseeScoreBadgeComponent` upgrade — existing `app-score-badge` still has
+  hardcoded hex. Migration left for the next pass.
+- `LookseeScoreGaugeComponent` upgrade — same situation; current component
+  uses hand-math SVG.
+- `LookseeScoreDeltaArrowComponent` — not built.
+- `LookseeDataCardComponent` — not built.
+- `LookseeSiteCardComponent` — not built.
+- `LookseeKbdComponent` — not built.
+- `LookseeToastComponent` + `ToastService` — not built.
+- Unit tests for each component — not written.
+- Storybook / demo page — not built.
+
+---
+
+## Summary — what to validate on first `ng build`
+
+Because this environment does not have `node_modules` installed, no compile /
+tsc / ng-build was run. On first run after `npm install`:
+
+1. **Expect no breaking change to existing behaviour.** All new components
+   are standalone and imported via AppModule's `imports` array — no existing
+   declarations were removed.
+2. **Watch for template selector resolution:** `<looksee-status-chip>`,
+   `<looksee-skeleton>`, `<looksee-empty-state>`, `<looksee-button>`, and
+   `<looksee-breadcrumb-bar>` are now usable from any template declared in
+   AppModule.
+3. **Route redirects may shift behaviour** for any internal test that hits
+   `/dashboard` (now redirects to `/audit`) or bookmarked URLs like
+   `/integration` (still works; `/integrations` plural also works via
+   redirect).
+4. **Material Deep Purple theme still loads** (pre-built CSS). The overrides
+   layer on top. If visual regressions appear, the culprit is likely the
+   `--mdc-*` CSS variable overrides in `material-overrides.scss`.
+5. **ESLint may warn** on the deprecated `isValidURL()` shims in `landing`
+   and `audit-form`. Remove these once any remaining callers are migrated
+   (grep shows no non-self callers — safe to delete after one release).
+
+## Files created
+
+```
+src/theme/
+  tokens.scss
+  typography.scss
+  material-overrides.scss
+
+src/app/utils/
+  url.ts
+
+src/app/models/
+  audit-status.ts
+
+src/app/services/breadcrumb/
+  breadcrumb.service.ts
+
+src/app/components/
+  not-found/
+    not-found.component.ts
+    not-found.component.html
+    not-found.component.scss
+  shared/
+    button/
+      button.component.ts
+      button.component.html
+      button.component.scss
+    status-chip/
+      status-chip.component.ts
+      status-chip.component.html
+      status-chip.component.scss
+    skeleton/
+      skeleton.component.ts
+      skeleton.component.html
+      skeleton.component.scss
+    empty-state/
+      empty-state.component.ts
+      empty-state.component.html
+      empty-state.component.scss
+    breadcrumb-bar/
+      breadcrumb-bar.component.ts
+      breadcrumb-bar.component.html
+      breadcrumb-bar.component.scss
+```
+
+## Files modified
+
+```
+tailwind.config.js
+src/styles.scss
+src/app/app.module.ts
+src/app/app-routing.module.ts
+src/app/components/landing/landing.component.ts
+src/app/components/audit-form/audit-form.component.ts
+src/app/components/audit-list/audit-list.component.ts
+src/app/components/audit-list/audit-list.component.html
+src/app/components/start-audit-login-required-dialog/start-audit-login-required-dialog.html
+src/app/components/start-audit-confirm-dialog/start-audit-confirm-dialog.html
+```
+
+No existing files were deleted.

--- a/Look-see-UI-v3/src/app/app-routing.module.ts
+++ b/Look-see-UI-v3/src/app/app-routing.module.ts
@@ -6,27 +6,54 @@ import { AuditListComponent } from './components/audit-list/audit-list.component
 import { DomainsComponent } from './components/domains/domains.component';
 import { HowItWorksComponent } from './components/how-it-works/how-it-works.component';
 import { LandingComponent } from './components/landing/landing.component';
+import { NotFoundComponent } from './components/not-found/not-found.component';
 import { PageAuditReviewComponent } from './components/page-audit-review/page-audit-review.component';
 
 import { IntegrationsPanelComponent } from './integrations-panel/integrations-panel.component';
 import { UserProfileComponent } from './user-profile/user-profile.component';
 
+/**
+ * Route table.
+ *
+ * Canonical routes retained. Redirects (marked below) accept the new spec-04
+ * route names (`/home`, `/sites`, `/audits`, `/audits/:id`, `/settings`,
+ * `/integrations`) and forward them to existing components without requiring
+ * every internal call-site to migrate at once.
+ *
+ * See docs/design/04-navigation-ia.md.
+ */
 const routes: Routes = [
+  // ----- Canonical public / authed routes -----
   { path: '', component: LandingComponent },
-  { path: 'dashboard', component: AuditDashboardComponent },
-  { path: 'account', component: UserProfileComponent, canActivate: [AuthGuard]},
+  { path: 'dashboard', redirectTo: 'audit', pathMatch: 'full' },
+  { path: 'account', component: UserProfileComponent, canActivate: [AuthGuard] },
 
-  { path: 'domains', component: DomainsComponent, canActivate: [AuthGuard]},
-  { path: 'audit', component: AuditListComponent, canActivate: [AuthGuard]},
-  { path: 'audit/:id/page', component: PageAuditReviewComponent, canActivate: [AuthGuard]},
+  { path: 'domains', component: DomainsComponent, canActivate: [AuthGuard] },
+  { path: 'audit', component: AuditListComponent, canActivate: [AuthGuard] },
+  { path: 'audit/:id/page', component: PageAuditReviewComponent, canActivate: [AuthGuard] },
   { path: 'audit/:id/review', component: PageAuditReviewComponent },
-  { path: 'audit/:id/domain', component: AuditDashboardComponent, canActivate: [AuthGuard]},
-  { path: 'how-it-works', component: HowItWorksComponent},
-  { path: 'integration', component: IntegrationsPanelComponent}
+  { path: 'audit/:id/domain', component: AuditDashboardComponent, canActivate: [AuthGuard] },
+
+  { path: 'how-it-works', component: HowItWorksComponent },
+  { path: 'integration', component: IntegrationsPanelComponent },
+
+  // ----- Spec-04 forward-compatible aliases -----
+  // Once /home, /sites, /audits, /settings components exist, flip these to
+  // their own routes and redirect the old paths instead.
+  { path: 'home', redirectTo: 'audit', pathMatch: 'full' },
+  { path: 'sites', redirectTo: 'domains', pathMatch: 'full' },
+  { path: 'audits', redirectTo: 'audit', pathMatch: 'full' },
+  { path: 'audits/:id', redirectTo: 'audit/:id/review', pathMatch: 'full' },
+  { path: 'settings', redirectTo: 'account', pathMatch: 'full' },
+  { path: 'integrations', redirectTo: 'integration', pathMatch: 'full' },
+  { path: 'help', redirectTo: 'how-it-works', pathMatch: 'full' },
+
+  // ----- 404 -----
+  { path: '**', component: NotFoundComponent },
 ];
 
 @NgModule({
   imports: [RouterModule.forRoot(routes)],
-  exports: [RouterModule]
+  exports: [RouterModule],
 })
-export class AppRoutingModule { }
+export class AppRoutingModule {}

--- a/Look-see-UI-v3/src/app/app.module.ts
+++ b/Look-see-UI-v3/src/app/app.module.ts
@@ -43,10 +43,16 @@ import { HowItWorksComponent } from './components/how-it-works/how-it-works.comp
 import { LandingComponent } from './components/landing/landing.component';
 import { LoadingComponent } from './components/loading/loading.component';
 import { NavBarComponent } from './components/nav-bar/nav-bar.component';
+import { NotFoundComponent } from './components/not-found/not-found.component';
 import { PageAuditReviewComponent } from './components/page-audit-review/page-audit-review.component';
 
 import { StartSinglePageAuditLoginRequired } from './components/start-audit-login-required-dialog/start-audit-login-required-dialog';
 
+import { LookseeBreadcrumbBarComponent } from './components/shared/breadcrumb-bar/breadcrumb-bar.component';
+import { LookseeButtonComponent } from './components/shared/button/button.component';
+import { LookseeEmptyStateComponent } from './components/shared/empty-state/empty-state.component';
+import { LookseeSkeletonComponent } from './components/shared/skeleton/skeleton.component';
+import { LookseeStatusChipComponent } from './components/shared/status-chip/status-chip.component';
 import { ScoreBadgeComponent } from './components/shared/score-badge/score-badge.component';
 import { ScoreGaugeComponent } from './components/shared/score-gauge/score-gauge.component';
 import { IntegrationsPanelComponent } from './integrations-panel/integrations-panel.component';
@@ -88,7 +94,8 @@ import { UserProfileComponent } from './user-profile/user-profile.component';
     FilterByCategoryPipe,
     FilterSeverityPipe,
     ScoreBadgeComponent,
-    ScoreGaugeComponent
+    ScoreGaugeComponent,
+    NotFoundComponent
   ],
   imports: [
     HttpClientModule,
@@ -101,7 +108,12 @@ import { UserProfileComponent } from './user-profile/user-profile.component';
     CommonModule,
     FormsModule,
     ReactiveFormsModule,
-    MatTooltipModule
+    MatTooltipModule,
+    LookseeButtonComponent,
+    LookseeStatusChipComponent,
+    LookseeSkeletonComponent,
+    LookseeEmptyStateComponent,
+    LookseeBreadcrumbBarComponent
   ],
   providers: [
     AccountService,

--- a/Look-see-UI-v3/src/app/components/audit-form/audit-form.component.ts
+++ b/Look-see-UI-v3/src/app/components/audit-form/audit-form.component.ts
@@ -9,6 +9,7 @@ import { AuditRecord } from '../../models/auditRecord';
 import { DomainService } from '../../models/domain/domain.service';
 import { AuditorService } from '../../services/auditor.service';
 import { SegmentIOService } from '../../services/segmentio.service';
+import { normaliseUrl } from '../../utils/url';
 
 @Component({
   selector: 'app-audit-form',
@@ -74,41 +75,35 @@ export class AuditFormComponent {
    * @param domain 
    */
   initiateAudit(url: string, type: string): void {
-    // sessionStorage.setItem("host", domain.replace("https://", "").replace("http://", ""));
-    if(!url || !url.length) {
-      this.domain_error = true
-      this.isLoading = false
-      this.error = "URL cannot be blank"
+    const normalised = normaliseUrl(url);
+    if (!normalised.ok) {
+      this.domain_error = true;
+      this.isLoading = false;
+      this.error = normalised.error;
+      return;
     }
-    else if(!this.isValidURL(url)) {
-      this.domain_error = true
-      this.isLoading = false
-      this.error = "URL must be valid. Please be sure to follow the format https://www.example.com"
-    }
-    else {
-      this.isLoading = true
-      sessionStorage.setItem("url", url.replace("https://", "").replace("http://", ""));
-      this.auditorService.startAudit(url, type).subscribe(
-        (data) => {
-          this.segmentio.sendUxAuditStartedMessage(url)
-          console.log("starting " + type + " audit for url "+url)
-          this.isLoading = false
-          //this.audit_records.push(data)
-          this.auditRecordData.emit(data)
 
-          //send data to audit list
-        },
-        () => {
-          this.error = "uh oh...it looks like our servers decided to take a coffee break. Please wait a minute then try again.";
-          this.isLoading = false
-        }
-      );
-    }
+    const cleanUrl = normalised.url;
+    this.isLoading = true;
+    sessionStorage.setItem('url', cleanUrl.replace(/^https?:\/\//, ''));
+    this.auditorService.startAudit(cleanUrl, type).subscribe(
+      (data) => {
+        this.segmentio.sendUxAuditStartedMessage(cleanUrl);
+        this.isLoading = false;
+        this.auditRecordData.emit(data);
+      },
+      () => {
+        this.error = "Something went wrong. Try again in a moment.";
+        this.isLoading = false;
+      }
+    );
   }
 
+  /**
+   * @deprecated use `normaliseUrl()` from utils/url.
+   */
   isValidURL(domain_url: string): boolean {
-    const urlregex = /^((https?|ftp):\/\/)?([a-zA-Z0-9.-]+(:[a-zA-Z0-9.&%$-]+)*@)*((25[0-5]|2[0-4][0-9]|1[0-9]{2}|[1-9][0-9]?)(\.(25[0-5]|2[0-4][0-9]|1[0-9]{2}|[1-9]?[0-9])){3}|([a-zA-Z0-9-]+\.)*[a-zA-Z0-9-]+\.(com|app|edu|gov|int|mil|net|org|biz|arpa|info|name|pro|aero|coop|museum|website|space|[a-zA-Z]{2}))(:[0-9]+)*(\/($|[a-zA-Z0-9.,?'\\+&%$#=~_-]+))*$/;
-    return urlregex.test(domain_url);
+    return normaliseUrl(domain_url).ok;
   }
 
   /* ERROR HANDLING METHODS */

--- a/Look-see-UI-v3/src/app/components/audit-list/audit-list.component.html
+++ b/Look-see-UI-v3/src/app/components/audit-list/audit-list.component.html
@@ -1,43 +1,32 @@
-<!-- Empty state -->
-<div class="flex flex-col items-center justify-center py-16 px-6" *ngIf="!audit_records && !is_loading_audits">
-    <div class="w-16 h-16 rounded-2xl bg-brand-50 flex items-center justify-center mb-4">
-        <fa-icon [icon]="faMagnifyingGlass" class="text-brand-500 text-2xl"></fa-icon>
-    </div>
-    <h1 class="text-xl font-semibold text-gray-900 mb-2">
-        No audits yet
-    </h1>
-    <p class="text-sm text-gray-500 text-center max-w-md">
-        Enter a website URL above to run your first UX audit. We'll analyze accessibility, content quality, and visual design.
-    </p>
-</div>
-
 <!-- Audit form -->
 <app-audit-form (auditRecordData)="addItem($event)"></app-audit-form>
 
 <!-- Audit table -->
 <div class="px-6 pb-6">
+    <!-- Loading state (skeleton rows) -->
+    <div *ngIf="is_loading_audits" class="mt-4">
+        <looksee-skeleton variant="row" [rows]="4"></looksee-skeleton>
+    </div>
+
+    <!-- Empty state (no records, not loading) -->
+    <looksee-empty-state
+        *ngIf="!is_loading_audits && audit_records.length === 0"
+        illustration="audits"
+        title="Run your first audit."
+        body="Paste a URL above — we'll check accessibility, content quality, and visual design, and rank every issue by impact."
+        [compact]="true">
+    </looksee-empty-state>
+
     <!-- Table header -->
-    <div class="grid grid-cols-12 gap-4 px-5 py-3 text-xs font-semibold text-gray-500 uppercase tracking-wider">
+    <div *ngIf="!is_loading_audits && audit_records.length > 0"
+         class="grid grid-cols-12 gap-4 px-5 py-3 text-xs font-semibold text-gray-500 uppercase tracking-wider">
         <div class="col-span-4">URL</div>
-        <div class="col-span-2 text-center">Type</div>
+        <div class="col-span-1 text-center">Status</div>
+        <div class="col-span-1 text-center">Type</div>
         <div class="col-span-2 text-center">Content</div>
         <div class="col-span-2 text-center">Info Architecture</div>
         <div class="col-span-1 text-center">Aesthetic</div>
         <div class="col-span-1"></div>
-    </div>
-
-    <!-- Loading state -->
-    <div *ngIf="is_loading_audits" class="space-y-3 mt-2">
-        <div class="card px-5 py-4 animate-pulse" *ngFor="let i of [1,2,3]">
-            <div class="grid grid-cols-12 gap-4 items-center">
-                <div class="col-span-4"><div class="h-4 bg-gray-200 rounded w-3/4"></div></div>
-                <div class="col-span-2"><div class="h-4 bg-gray-200 rounded w-1/2 mx-auto"></div></div>
-                <div class="col-span-2"><div class="h-4 bg-gray-200 rounded w-1/3 mx-auto"></div></div>
-                <div class="col-span-2"><div class="h-4 bg-gray-200 rounded w-1/3 mx-auto"></div></div>
-                <div class="col-span-1"><div class="h-4 bg-gray-200 rounded w-1/3 mx-auto"></div></div>
-                <div class="col-span-1"><div class="h-4 bg-gray-200 rounded-full w-6 h-6 mx-auto"></div></div>
-            </div>
-        </div>
     </div>
 
     <!-- Audit rows -->
@@ -58,8 +47,16 @@
                     </p>
                 </div>
 
+                <!-- Status -->
+                <div class="col-span-1 flex justify-center">
+                    <looksee-status-chip
+                        [kind]="statusFor(audit_record)"
+                        size="sm">
+                    </looksee-status-chip>
+                </div>
+
                 <!-- Type -->
-                <div class="col-span-2 flex justify-center">
+                <div class="col-span-1 flex justify-center">
                     <span class="badge"
                           [ngClass]="{
                               'bg-blue-50 text-blue-700': audit_record.level === 'PAGE',

--- a/Look-see-UI-v3/src/app/components/audit-list/audit-list.component.html
+++ b/Look-see-UI-v3/src/app/components/audit-list/audit-list.component.html
@@ -5,17 +5,17 @@
 <div class="px-6 pb-6">
     <!-- Loading state (skeleton rows) -->
     <div *ngIf="is_loading_audits" class="mt-4">
-        <looksee-skeleton variant="row" [rows]="4"></looksee-skeleton>
+        <app-looksee-skeleton variant="row" [rows]="4"></app-looksee-skeleton>
     </div>
 
     <!-- Empty state (no records, not loading) -->
-    <looksee-empty-state
+    <app-looksee-empty-state
         *ngIf="!is_loading_audits && audit_records.length === 0"
         illustration="audits"
         title="Run your first audit."
         body="Paste a URL above — we'll check accessibility, content quality, and visual design, and rank every issue by impact."
         [compact]="true">
-    </looksee-empty-state>
+    </app-looksee-empty-state>
 
     <!-- Table header -->
     <div *ngIf="!is_loading_audits && audit_records.length > 0"
@@ -49,10 +49,10 @@
 
                 <!-- Status -->
                 <div class="col-span-1 flex justify-center">
-                    <looksee-status-chip
+                    <app-looksee-status-chip
                         [kind]="statusFor(audit_record)"
                         size="sm">
-                    </looksee-status-chip>
+                    </app-looksee-status-chip>
                 </div>
 
                 <!-- Type -->

--- a/Look-see-UI-v3/src/app/components/audit-list/audit-list.component.ts
+++ b/Look-see-UI-v3/src/app/components/audit-list/audit-list.component.ts
@@ -110,7 +110,7 @@ export class AuditListComponent implements OnInit {
 
   /**
    * Derive the canonical AuditStatus for a given record. Used by the template
-   * to pass a typed `kind` into <looksee-status-chip>.
+   * to pass a typed `kind` into <app-looksee-status-chip>.
    *
    * See docs/design/02-audit-status-and-progress.md §1.
    */

--- a/Look-see-UI-v3/src/app/components/audit-list/audit-list.component.ts
+++ b/Look-see-UI-v3/src/app/components/audit-list/audit-list.component.ts
@@ -7,6 +7,7 @@ import { AuthService } from '@auth0/auth0-angular';
 import { faCircleCheck } from '@fortawesome/free-regular-svg-icons';
 import { faChevronRight, faCircleRadiation, faExclamationCircle, faFrown, faMagnifyingGlass, faMeh, faPencil, faSmileBeam, faSpinner, faTriangleExclamation } from '@fortawesome/free-solid-svg-icons';
 import { AuditRecord } from '../../models/auditRecord';
+import { AuditStatus, auditStatusChipKind, normaliseAuditStatus } from '../../models/audit-status';
 import { Domain } from '../../models/domain/domain';
 import { AuditService } from '../../services/audit.service';
 import { SegmentIOService } from '../../services/segmentio.service';
@@ -107,4 +108,17 @@ export class AuditListComponent implements OnInit {
     alert("It looks like this feature isn't done yet. If you have opinions or ideas on what should be included in domain settings, please email our founder at bkindred@look-see.com.")
   }
 
+  /**
+   * Derive the canonical AuditStatus for a given record. Used by the template
+   * to pass a typed `kind` into <looksee-status-chip>.
+   *
+   * See docs/design/02-audit-status-and-progress.md §1.
+   */
+  statusFor(record: AuditRecord): ReturnType<typeof auditStatusChipKind> {
+    const hasScores = (record.contentAuditScore ?? 0) > 0
+      || (record.infoArchScore ?? 0) > 0
+      || (record.aestheticScore ?? 0) > 0;
+    const status: AuditStatus = normaliseAuditStatus(record.status, { hasScores });
+    return auditStatusChipKind(status);
+  }
 }

--- a/Look-see-UI-v3/src/app/components/landing/landing.component.ts
+++ b/Look-see-UI-v3/src/app/components/landing/landing.component.ts
@@ -4,6 +4,7 @@ import { Router } from '@angular/router';
 import { AuthService } from '@auth0/auth0-angular';
 import { AuditorService } from '../../services/auditor.service';
 import { SegmentIOService } from '../../services/segmentio.service';
+import { normaliseUrl } from '../../utils/url';
 
 @Component({
   selector: 'app-landing',
@@ -24,18 +25,15 @@ export class LandingComponent {
   segmentio = inject(SegmentIOService);
 
   startAudit(): void {
-    const url = this.form.value.url?.trim() || '';
+    const rawUrl = this.form.value.url || '';
+    const normalised = normaliseUrl(rawUrl);
 
-    if (!url.length) {
-      this.error = 'Please enter a URL to audit.';
+    if (!normalised.ok) {
+      this.error = normalised.error;
       return;
     }
 
-    if (!this.isValidURL(url)) {
-      this.error = 'Please enter a valid URL (e.g. https://www.example.com)';
-      return;
-    }
-
+    const url = normalised.url;
     this.error = '';
     this.isLoading = true;
     this.segmentio.sendUxAuditStartedMessage(url);
@@ -46,19 +44,22 @@ export class LandingComponent {
         if (data && data.id) {
           sessionStorage.setItem('audit_record_id', data.id.toString());
           sessionStorage.setItem('is_audit_started', 'true');
-          sessionStorage.setItem('url', url.replace('https://', '').replace('http://', ''));
+          sessionStorage.setItem('url', url.replace(/^https?:\/\//, ''));
           this.router.navigate(['/audit', data.id, 'review']);
         }
       },
       () => {
-        this.error = 'Something went wrong starting the audit. Please try again.';
+        this.error = "We couldn't reach that URL. Check the address and try again.";
         this.isLoading = false;
       }
     );
   }
 
+  /**
+   * @deprecated kept as a compatibility shim; call `normaliseUrl()` directly.
+   * Remove once no callers remain (no production callers remain in this file).
+   */
   isValidURL(domain_url: string): boolean {
-    const urlregex = /^((https?|ftp):\/\/)?([a-zA-Z0-9.-]+(:[a-zA-Z0-9.&%$-]+)*@)*((25[0-5]|2[0-4][0-9]|1[0-9]{2}|[1-9][0-9]?)(\.(25[0-5]|2[0-4][0-9]|1[0-9]{2}|[1-9]?[0-9])){3}|([a-zA-Z0-9-]+\.)*[a-zA-Z0-9-]+\.(com|app|edu|gov|int|mil|net|org|biz|arpa|info|name|pro|aero|coop|museum|website|space|[a-zA-Z]{2}))(:[0-9]+)*(\/($|[a-zA-Z0-9.,?'\\+&%$#=~_-]+))*$/;
-    return urlregex.test(domain_url);
+    return normaliseUrl(domain_url).ok;
   }
 }

--- a/Look-see-UI-v3/src/app/components/not-found/not-found.component.html
+++ b/Look-see-UI-v3/src/app/components/not-found/not-found.component.html
@@ -1,0 +1,16 @@
+<div class="not-found">
+  <div class="not-found__content">
+    <p class="text-overline text-token-muted">404</p>
+    <h1 class="text-display">We can't find that page.</h1>
+    <p class="text-body-token text-token-secondary">
+      The link may be broken or the page may have moved.
+    </p>
+    <div class="not-found__actions">
+      <a routerLink="/" class="looksee-link">Go home</a>
+      <span class="not-found__sep" aria-hidden="true">·</span>
+      <a routerLink="/audit" class="looksee-link">View your audits</a>
+      <span class="not-found__sep" aria-hidden="true">·</span>
+      <a routerLink="/how-it-works" class="looksee-link">How it works</a>
+    </div>
+  </div>
+</div>

--- a/Look-see-UI-v3/src/app/components/not-found/not-found.component.scss
+++ b/Look-see-UI-v3/src/app/components/not-found/not-found.component.scss
@@ -1,0 +1,37 @@
+.not-found {
+  min-height: 60vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 48px 24px;
+  background-color: var(--surface-base);
+}
+
+.not-found__content {
+  max-width: 520px;
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.not-found__actions {
+  margin-top: 16px;
+  display: flex;
+  gap: 12px;
+  justify-content: center;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.not-found__sep {
+  color: var(--text-muted);
+}
+
+.looksee-link {
+  color: var(--text-link);
+  text-decoration: none;
+  font-weight: 500;
+  &:hover { color: var(--text-link-hover); text-decoration: underline; }
+  &:focus-visible { outline: none; box-shadow: var(--focus-ring); border-radius: var(--radius-sm); }
+}

--- a/Look-see-UI-v3/src/app/components/not-found/not-found.component.ts
+++ b/Look-see-UI-v3/src/app/components/not-found/not-found.component.ts
@@ -1,0 +1,12 @@
+import { Component } from '@angular/core';
+
+/**
+ * 404 page. Friendly message + links back into the app.
+ * See docs/design/04-navigation-ia.md §1 (wildcard route).
+ */
+@Component({
+  selector: 'app-not-found',
+  templateUrl: './not-found.component.html',
+  styleUrls: ['./not-found.component.scss'],
+})
+export class NotFoundComponent {}

--- a/Look-see-UI-v3/src/app/components/shared/breadcrumb-bar/breadcrumb-bar.component.html
+++ b/Look-see-UI-v3/src/app/components/shared/breadcrumb-bar/breadcrumb-bar.component.html
@@ -1,0 +1,30 @@
+<nav
+  *ngIf="(crumbs$ | async) as crumbs"
+  class="looksee-breadcrumbs"
+  aria-label="Breadcrumb"
+  [attr.hidden]="crumbs.length === 0 ? true : null"
+>
+  <ol class="looksee-breadcrumbs__list" *ngIf="crumbs.length > 0">
+    <li
+      *ngFor="let crumb of crumbs; let last = last"
+      class="looksee-breadcrumbs__item"
+    >
+      <a
+        *ngIf="crumb.href && !last; else plain"
+        [routerLink]="crumb.href"
+        class="looksee-breadcrumbs__link"
+      >{{ crumb.label }}</a>
+      <ng-template #plain>
+        <span
+          class="looksee-breadcrumbs__current"
+          [attr.aria-current]="last ? 'page' : null"
+        >{{ crumb.label }}</span>
+      </ng-template>
+      <span
+        *ngIf="!last"
+        class="looksee-breadcrumbs__separator"
+        aria-hidden="true"
+      >/</span>
+    </li>
+  </ol>
+</nav>

--- a/Look-see-UI-v3/src/app/components/shared/breadcrumb-bar/breadcrumb-bar.component.scss
+++ b/Look-see-UI-v3/src/app/components/shared/breadcrumb-bar/breadcrumb-bar.component.scss
@@ -1,0 +1,52 @@
+.looksee-breadcrumbs {
+  padding: 12px 0;
+}
+
+.looksee-breadcrumbs__list {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  font-family: 'Inter', system-ui, sans-serif;
+  font-size: 13px;
+  line-height: 1.4;
+  color: var(--text-secondary);
+}
+
+.looksee-breadcrumbs__item {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  &::marker { content: ''; }
+}
+
+.looksee-breadcrumbs__separator {
+  margin: 0 8px;
+  color: var(--text-muted);
+  font-weight: 300;
+}
+
+.looksee-breadcrumbs__link {
+  color: var(--text-secondary);
+  text-decoration: none;
+  border-radius: var(--radius-sm);
+  padding: 2px 4px;
+  margin: -2px -4px;
+  transition: color var(--duration-fast) var(--ease-out-soft);
+  &:hover {
+    color: var(--text-primary);
+    text-decoration: underline;
+  }
+  &:focus-visible {
+    outline: none;
+    box-shadow: var(--focus-ring);
+  }
+}
+
+.looksee-breadcrumbs__current {
+  color: var(--text-primary);
+  font-weight: 500;
+}

--- a/Look-see-UI-v3/src/app/components/shared/breadcrumb-bar/breadcrumb-bar.component.ts
+++ b/Look-see-UI-v3/src/app/components/shared/breadcrumb-bar/breadcrumb-bar.component.ts
@@ -1,0 +1,22 @@
+import { CommonModule } from '@angular/common';
+import { Component, inject } from '@angular/core';
+import { RouterModule } from '@angular/router';
+import { Observable } from 'rxjs';
+import { Breadcrumb, BreadcrumbService } from '../../../services/breadcrumb/breadcrumb.service';
+
+/**
+ * Breadcrumb bar. Subscribes to BreadcrumbService; renders nothing when empty.
+ *
+ * See docs/design/04-navigation-ia.md §3.
+ */
+@Component({
+  standalone: true,
+  imports: [CommonModule, RouterModule],
+  selector: 'looksee-breadcrumb-bar',
+  templateUrl: './breadcrumb-bar.component.html',
+  styleUrls: ['./breadcrumb-bar.component.scss'],
+})
+export class LookseeBreadcrumbBarComponent {
+  private readonly service = inject(BreadcrumbService);
+  readonly crumbs$: Observable<Breadcrumb[]> = this.service.crumbs$;
+}

--- a/Look-see-UI-v3/src/app/components/shared/breadcrumb-bar/breadcrumb-bar.component.ts
+++ b/Look-see-UI-v3/src/app/components/shared/breadcrumb-bar/breadcrumb-bar.component.ts
@@ -12,7 +12,7 @@ import { Breadcrumb, BreadcrumbService } from '../../../services/breadcrumb/brea
 @Component({
   standalone: true,
   imports: [CommonModule, RouterModule],
-  selector: 'looksee-breadcrumb-bar',
+  selector: 'app-looksee-breadcrumb-bar',
   templateUrl: './breadcrumb-bar.component.html',
   styleUrls: ['./breadcrumb-bar.component.scss'],
 })

--- a/Look-see-UI-v3/src/app/components/shared/button/button.component.html
+++ b/Look-see-UI-v3/src/app/components/shared/button/button.component.html
@@ -1,0 +1,27 @@
+<button
+  [type]="type"
+  [class]="rootClasses.join(' ')"
+  [disabled]="disabled || loading"
+  [attr.aria-label]="ariaLabel || null"
+  [attr.aria-busy]="loading ? 'true' : null"
+  (click)="onClick($event)"
+>
+  <span class="looksee-btn__inner" [class.is-hidden]="loading">
+    <fa-icon
+      *ngIf="leadingIcon && !loading"
+      [icon]="leadingIcon"
+      class="looksee-btn__icon looksee-btn__icon--leading"
+      aria-hidden="true"
+    ></fa-icon>
+    <span class="looksee-btn__label"><ng-content></ng-content></span>
+    <fa-icon
+      *ngIf="trailingIcon && !loading"
+      [icon]="trailingIcon"
+      class="looksee-btn__icon looksee-btn__icon--trailing"
+      aria-hidden="true"
+    ></fa-icon>
+  </span>
+  <span class="looksee-btn__spinner" *ngIf="loading" aria-hidden="true">
+    <fa-icon [icon]="faSpinner" [spin]="true"></fa-icon>
+  </span>
+</button>

--- a/Look-see-UI-v3/src/app/components/shared/button/button.component.scss
+++ b/Look-see-UI-v3/src/app/components/shared/button/button.component.scss
@@ -1,0 +1,159 @@
+/* =============================================================================
+ * Look-see button — design system
+ * docs/design/01-design-system.md §5
+ * ============================================================================= */
+
+.looksee-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  position: relative;
+  border-radius: var(--radius-md);
+  font-family: 'Inter', system-ui, sans-serif;
+  font-weight: 600;
+  line-height: 1;
+  white-space: nowrap;
+  border: 1px solid transparent;
+  cursor: pointer;
+  user-select: none;
+  transition:
+    background-color var(--duration-base) var(--ease-out-soft),
+    border-color     var(--duration-base) var(--ease-out-soft),
+    color            var(--duration-base) var(--ease-out-soft),
+    box-shadow       var(--duration-base) var(--ease-out-soft),
+    transform        var(--duration-fast) var(--ease-out-soft);
+
+  &:focus-visible {
+    outline: none;
+    box-shadow: var(--focus-ring);
+  }
+
+  &:active:not(:disabled):not(.looksee-btn--loading) {
+    transform: translateY(1px);
+  }
+
+  &:disabled,
+  &.looksee-btn--loading {
+    cursor: not-allowed;
+    opacity: 0.5;
+  }
+}
+
+/* ----- Sizes ----- */
+.looksee-btn--sm {
+  height: 32px;
+  padding: 0 12px;
+  font-size: 13px;
+}
+.looksee-btn--md {
+  height: 40px;
+  padding: 0 16px;
+  font-size: 15px;
+}
+.looksee-btn--lg {
+  height: 48px;
+  padding: 0 20px;
+  font-size: 17px;
+}
+
+/* ----- Full width ----- */
+.looksee-btn--full {
+  width: 100%;
+}
+
+/* ----- Variants ----- */
+.looksee-btn--primary {
+  background-color: var(--text-primary);
+  color: var(--text-inverse);
+  border-color: var(--text-primary);
+
+  &:hover:not(:disabled):not(.looksee-btn--loading) {
+    background-color: #3d3b3c; /* ink.900 */
+    border-color: #3d3b3c;
+  }
+  &:active:not(:disabled):not(.looksee-btn--loading) {
+    background-color: #231f20; /* ink.950 */
+  }
+}
+
+.looksee-btn--accent {
+  background-color: var(--text-accent);
+  color: var(--text-on-accent);
+  border-color: var(--text-accent);
+
+  &:hover:not(:disabled):not(.looksee-btn--loading) {
+    background-color: var(--text-accent-hover);
+    border-color: var(--text-accent-hover);
+  }
+}
+
+.looksee-btn--secondary {
+  background-color: var(--surface-raised);
+  color: var(--text-primary);
+  border-color: var(--border-default);
+
+  &:hover:not(:disabled):not(.looksee-btn--loading) {
+    background-color: var(--surface-sunken);
+    border-color: var(--border-strong);
+  }
+}
+
+.looksee-btn--ghost {
+  background-color: transparent;
+  color: var(--text-secondary);
+  border-color: transparent;
+
+  &:hover:not(:disabled):not(.looksee-btn--loading) {
+    background-color: var(--surface-sunken);
+    color: var(--text-primary);
+  }
+}
+
+.looksee-btn--danger {
+  background-color: var(--surface-raised);
+  color: var(--score-critical);
+  border-color: var(--score-critical);
+
+  &:hover:not(:disabled):not(.looksee-btn--loading) {
+    background-color: var(--score-critical-bg);
+  }
+}
+
+.looksee-btn--link {
+  background-color: transparent;
+  color: var(--text-link);
+  border-color: transparent;
+  padding-left: 0.25rem;
+  padding-right: 0.25rem;
+  text-decoration: none;
+
+  &:hover:not(:disabled):not(.looksee-btn--loading) {
+    color: var(--text-link-hover);
+    text-decoration: underline;
+  }
+}
+
+/* ----- Inner composition ----- */
+.looksee-btn__inner {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  line-height: 1;
+
+  &.is-hidden {
+    visibility: hidden;
+  }
+}
+
+.looksee-btn__spinner {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.looksee-btn__icon {
+  font-size: 0.9em;
+}

--- a/Look-see-UI-v3/src/app/components/shared/button/button.component.ts
+++ b/Look-see-UI-v3/src/app/components/shared/button/button.component.ts
@@ -26,7 +26,7 @@ export type LookseeButtonType = 'button' | 'submit' | 'reset';
 @Component({
   standalone: true,
   imports: [CommonModule, FontAwesomeModule],
-  selector: 'looksee-button',
+  selector: 'app-looksee-button',
   templateUrl: './button.component.html',
   styleUrls: ['./button.component.scss'],
 })

--- a/Look-see-UI-v3/src/app/components/shared/button/button.component.ts
+++ b/Look-see-UI-v3/src/app/components/shared/button/button.component.ts
@@ -1,0 +1,70 @@
+import { CommonModule } from '@angular/common';
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
+import { faSpinner, IconDefinition } from '@fortawesome/free-solid-svg-icons';
+
+export type LookseeButtonVariant =
+  | 'primary'
+  | 'accent'
+  | 'secondary'
+  | 'ghost'
+  | 'danger'
+  | 'link';
+
+export type LookseeButtonSize = 'sm' | 'md' | 'lg';
+
+export type LookseeButtonType = 'button' | 'submit' | 'reset';
+
+/**
+ * Look-see design-system button. One component, six variants, three sizes.
+ *
+ * Tokens: references CSS custom properties from src/theme/tokens.scss so light
+ * and dark modes both work automatically.
+ *
+ * See docs/design/01-design-system.md §5 for the full spec.
+ */
+@Component({
+  standalone: true,
+  imports: [CommonModule, FontAwesomeModule],
+  selector: 'looksee-button',
+  templateUrl: './button.component.html',
+  styleUrls: ['./button.component.scss'],
+})
+export class LookseeButtonComponent {
+  @Input() variant: LookseeButtonVariant = 'primary';
+  @Input() size: LookseeButtonSize = 'md';
+  @Input() type: LookseeButtonType = 'button';
+  @Input() disabled = false;
+  @Input() loading = false;
+  @Input() fullWidth = false;
+  @Input() ariaLabel?: string;
+  @Input() leadingIcon?: IconDefinition;
+  @Input() trailingIcon?: IconDefinition;
+
+  @Output() pressed = new EventEmitter<MouseEvent>();
+
+  readonly faSpinner = faSpinner;
+
+  get isInteractive(): boolean {
+    return !this.disabled && !this.loading;
+  }
+
+  get rootClasses(): string[] {
+    return [
+      'looksee-btn',
+      `looksee-btn--${this.variant}`,
+      `looksee-btn--${this.size}`,
+      this.fullWidth ? 'looksee-btn--full' : '',
+      this.loading ? 'looksee-btn--loading' : '',
+    ].filter(Boolean);
+  }
+
+  onClick(event: MouseEvent): void {
+    if (!this.isInteractive) {
+      event.preventDefault();
+      event.stopPropagation();
+      return;
+    }
+    this.pressed.emit(event);
+  }
+}

--- a/Look-see-UI-v3/src/app/components/shared/empty-state/empty-state.component.html
+++ b/Look-see-UI-v3/src/app/components/shared/empty-state/empty-state.component.html
@@ -1,0 +1,33 @@
+<div class="looksee-empty" [class.looksee-empty--compact]="compact" role="region" [attr.aria-labelledby]="'empty-title'">
+  <img
+    *ngIf="illustrationSrc"
+    [src]="illustrationSrc"
+    class="looksee-empty__illustration"
+    alt=""
+    aria-hidden="true"
+  />
+
+  <h2 id="empty-title" class="looksee-empty__title text-heading-lg">{{ title }}</h2>
+
+  <p *ngIf="body" class="looksee-empty__body text-body-token">{{ body }}</p>
+
+  <div class="looksee-empty__actions" *ngIf="primaryAction || secondaryAction">
+    <looksee-button
+      *ngIf="primaryAction"
+      [variant]="primaryAction.variant || 'accent'"
+      size="md"
+      (pressed)="onPrimary()"
+    >
+      {{ primaryAction.label }}
+    </looksee-button>
+
+    <looksee-button
+      *ngIf="secondaryAction"
+      [variant]="secondaryAction.variant || 'ghost'"
+      size="md"
+      (pressed)="onSecondary()"
+    >
+      {{ secondaryAction.label }}
+    </looksee-button>
+  </div>
+</div>

--- a/Look-see-UI-v3/src/app/components/shared/empty-state/empty-state.component.html
+++ b/Look-see-UI-v3/src/app/components/shared/empty-state/empty-state.component.html
@@ -12,22 +12,22 @@
   <p *ngIf="body" class="looksee-empty__body text-body-token">{{ body }}</p>
 
   <div class="looksee-empty__actions" *ngIf="primaryAction || secondaryAction">
-    <looksee-button
+    <app-looksee-button
       *ngIf="primaryAction"
       [variant]="primaryAction.variant || 'accent'"
       size="md"
       (pressed)="onPrimary()"
     >
       {{ primaryAction.label }}
-    </looksee-button>
+    </app-looksee-button>
 
-    <looksee-button
+    <app-looksee-button
       *ngIf="secondaryAction"
       [variant]="secondaryAction.variant || 'ghost'"
       size="md"
       (pressed)="onSecondary()"
     >
       {{ secondaryAction.label }}
-    </looksee-button>
+    </app-looksee-button>
   </div>
 </div>

--- a/Look-see-UI-v3/src/app/components/shared/empty-state/empty-state.component.scss
+++ b/Look-see-UI-v3/src/app/components/shared/empty-state/empty-state.component.scss
@@ -1,0 +1,51 @@
+/* =============================================================================
+ * Empty state — docs/design/06-shared-components.md §7
+ * ============================================================================= */
+
+.looksee-empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  padding: 48px 24px;
+  text-align: center;
+  color: var(--text-primary);
+
+  &--compact {
+    padding: 24px 16px;
+    gap: 0.75rem;
+  }
+}
+
+.looksee-empty__illustration {
+  width: 160px;
+  height: auto;
+  max-height: 160px;
+  object-fit: contain;
+  margin-bottom: 8px;
+
+  .looksee-empty--compact & {
+    width: 96px;
+    max-height: 96px;
+  }
+}
+
+.looksee-empty__title {
+  margin: 0;
+  color: var(--text-primary);
+}
+
+.looksee-empty__body {
+  margin: 0;
+  max-width: 480px;
+  color: var(--text-secondary);
+}
+
+.looksee-empty__actions {
+  display: flex;
+  gap: 0.75rem;
+  margin-top: 8px;
+  flex-wrap: wrap;
+  justify-content: center;
+}

--- a/Look-see-UI-v3/src/app/components/shared/empty-state/empty-state.component.ts
+++ b/Look-see-UI-v3/src/app/components/shared/empty-state/empty-state.component.ts
@@ -23,7 +23,7 @@ export interface EmptyStateAction {
 @Component({
   standalone: true,
   imports: [CommonModule, LookseeButtonComponent],
-  selector: 'looksee-empty-state',
+  selector: 'app-looksee-empty-state',
   templateUrl: './empty-state.component.html',
   styleUrls: ['./empty-state.component.scss'],
 })

--- a/Look-see-UI-v3/src/app/components/shared/empty-state/empty-state.component.ts
+++ b/Look-see-UI-v3/src/app/components/shared/empty-state/empty-state.component.ts
@@ -1,0 +1,61 @@
+import { CommonModule } from '@angular/common';
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { LookseeButtonComponent } from '../button/button.component';
+
+export type EmptyStateIllustration =
+  | 'audits'
+  | 'sites'
+  | 'issues'
+  | 'search'
+  | 'generic';
+
+export interface EmptyStateAction {
+  label: string;
+  href?: string;
+  variant?: 'primary' | 'accent' | 'secondary' | 'ghost' | 'link';
+}
+
+/**
+ * Empty state — illustration + headline + body + actions.
+ *
+ * See docs/design/06-shared-components.md §7.
+ */
+@Component({
+  standalone: true,
+  imports: [CommonModule, LookseeButtonComponent],
+  selector: 'looksee-empty-state',
+  templateUrl: './empty-state.component.html',
+  styleUrls: ['./empty-state.component.scss'],
+})
+export class LookseeEmptyStateComponent {
+  @Input() illustration: EmptyStateIllustration = 'generic';
+  @Input() title = '';
+  @Input() body?: string;
+  @Input() primaryAction?: EmptyStateAction;
+  @Input() secondaryAction?: EmptyStateAction;
+  @Input() compact = false;
+
+  @Output() primaryActivated = new EventEmitter<void>();
+  @Output() secondaryActivated = new EventEmitter<void>();
+
+  /** Illustration paths map to existing assets in src/assets/. */
+  get illustrationSrc(): string {
+    const base = 'assets/';
+    switch (this.illustration) {
+      case 'audits':  return `${base}audit_website.jpg`;
+      case 'sites':   return `${base}look-see_target_check.png`;
+      case 'issues':  return `${base}review_audit.png`;
+      case 'search':  return `${base}look-see_target_check.png`;
+      case 'generic': default:
+        return `${base}look-see_target_check.png`;
+    }
+  }
+
+  onPrimary(): void {
+    this.primaryActivated.emit();
+  }
+
+  onSecondary(): void {
+    this.secondaryActivated.emit();
+  }
+}

--- a/Look-see-UI-v3/src/app/components/shared/empty-state/empty-state.component.ts
+++ b/Look-see-UI-v3/src/app/components/shared/empty-state/empty-state.component.ts
@@ -38,11 +38,11 @@ export class LookseeEmptyStateComponent {
   @Output() primaryActivated = new EventEmitter<void>();
   @Output() secondaryActivated = new EventEmitter<void>();
 
-  /** Illustration paths map to existing assets in src/assets/. */
+  /** Illustration paths map to existing assets in src/assets/illustrations/. */
   get illustrationSrc(): string {
-    const base = 'assets/';
+    const base = 'assets/illustrations/';
     switch (this.illustration) {
-      case 'audits':  return `${base}audit_website.jpg`;
+      case 'audits':  return `${base}Audit_website.jpg`;
       case 'sites':   return `${base}look-see_target_check.png`;
       case 'issues':  return `${base}review_audit.png`;
       case 'search':  return `${base}look-see_target_check.png`;

--- a/Look-see-UI-v3/src/app/components/shared/skeleton/skeleton.component.html
+++ b/Look-see-UI-v3/src/app/components/shared/skeleton/skeleton.component.html
@@ -1,0 +1,24 @@
+<ng-container [ngSwitch]="variant">
+  <div *ngSwitchCase="'row'" class="looksee-skeleton-rows" role="status" aria-live="polite" aria-label="Loading">
+    <div *ngFor="let i of rowArray" class="looksee-skeleton-row">
+      <span class="looksee-skeleton looksee-skeleton--circle"></span>
+      <span class="looksee-skeleton-row__lines">
+        <span class="looksee-skeleton looksee-skeleton--text" style="width: 40%"></span>
+        <span class="looksee-skeleton looksee-skeleton--text" style="width: 70%"></span>
+      </span>
+    </div>
+  </div>
+
+  <span
+    *ngSwitchDefault
+    class="looksee-skeleton"
+    [class.looksee-skeleton--text]="variant === 'text'"
+    [class.looksee-skeleton--title]="variant === 'title'"
+    [class.looksee-skeleton--circle]="variant === 'circle'"
+    [class.looksee-skeleton--rect]="variant === 'rect'"
+    [ngStyle]="customStyle"
+    role="status"
+    aria-live="polite"
+    aria-label="Loading"
+  ></span>
+</ng-container>

--- a/Look-see-UI-v3/src/app/components/shared/skeleton/skeleton.component.scss
+++ b/Look-see-UI-v3/src/app/components/shared/skeleton/skeleton.component.scss
@@ -1,0 +1,91 @@
+/* =============================================================================
+ * Skeleton — docs/design/06-shared-components.md §8
+ * ============================================================================= */
+
+.looksee-skeleton {
+  display: inline-block;
+  background: linear-gradient(
+    90deg,
+    rgba(0, 0, 0, 0.04) 25%,
+    rgba(0, 0, 0, 0.08) 37%,
+    rgba(0, 0, 0, 0.04) 63%
+  );
+  background-size: 400% 100%;
+  background-color: var(--border-subtle);
+  border-radius: var(--radius-sm);
+  animation: skeleton-shimmer 1.4s ease-in-out infinite;
+}
+
+[data-theme='dark'] .looksee-skeleton {
+  background: linear-gradient(
+    90deg,
+    rgba(255, 255, 255, 0.04) 25%,
+    rgba(255, 255, 255, 0.08) 37%,
+    rgba(255, 255, 255, 0.04) 63%
+  );
+  background-color: var(--border-subtle);
+}
+
+.looksee-skeleton--text {
+  display: block;
+  height: 12px;
+  width: 100%;
+  border-radius: var(--radius-sm);
+}
+
+.looksee-skeleton--title {
+  display: block;
+  height: 20px;
+  width: 60%;
+  border-radius: var(--radius-sm);
+}
+
+.looksee-skeleton--circle {
+  display: inline-block;
+  width: 40px;
+  height: 40px;
+  border-radius: var(--radius-full);
+  flex-shrink: 0;
+}
+
+.looksee-skeleton--rect {
+  display: block;
+  width: 100%;
+  height: 80px;
+  border-radius: var(--radius-md);
+}
+
+.looksee-skeleton-rows {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.looksee-skeleton-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px;
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-lg);
+  background-color: var(--surface-raised);
+}
+
+.looksee-skeleton-row__lines {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  gap: 8px;
+}
+
+@keyframes skeleton-shimmer {
+  0%   { background-position: 100% 50%; }
+  100% { background-position: 0% 50%; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .looksee-skeleton {
+    animation: none;
+    background: var(--border-subtle);
+  }
+}

--- a/Look-see-UI-v3/src/app/components/shared/skeleton/skeleton.component.ts
+++ b/Look-see-UI-v3/src/app/components/shared/skeleton/skeleton.component.ts
@@ -11,7 +11,7 @@ export type SkeletonVariant = 'text' | 'title' | 'circle' | 'rect' | 'row';
 @Component({
   standalone: true,
   imports: [CommonModule],
-  selector: 'looksee-skeleton',
+  selector: 'app-looksee-skeleton',
   templateUrl: './skeleton.component.html',
   styleUrls: ['./skeleton.component.scss'],
 })

--- a/Look-see-UI-v3/src/app/components/shared/skeleton/skeleton.component.ts
+++ b/Look-see-UI-v3/src/app/components/shared/skeleton/skeleton.component.ts
@@ -1,0 +1,34 @@
+import { CommonModule } from '@angular/common';
+import { Component, Input } from '@angular/core';
+
+export type SkeletonVariant = 'text' | 'title' | 'circle' | 'rect' | 'row';
+
+/**
+ * Animated loading placeholder. Respects prefers-reduced-motion.
+ *
+ * See docs/design/06-shared-components.md §8.
+ */
+@Component({
+  standalone: true,
+  imports: [CommonModule],
+  selector: 'looksee-skeleton',
+  templateUrl: './skeleton.component.html',
+  styleUrls: ['./skeleton.component.scss'],
+})
+export class LookseeSkeletonComponent {
+  @Input() variant: SkeletonVariant = 'text';
+  @Input() width?: string;
+  @Input() height?: string;
+  @Input() rows = 1;
+
+  get rowArray(): number[] {
+    return Array.from({ length: this.rows }, (_, i) => i);
+  }
+
+  get customStyle(): Record<string, string> {
+    const style: Record<string, string> = {};
+    if (this.width) style['width'] = this.width;
+    if (this.height) style['height'] = this.height;
+    return style;
+  }
+}

--- a/Look-see-UI-v3/src/app/components/shared/status-chip/status-chip.component.html
+++ b/Look-see-UI-v3/src/app/components/shared/status-chip/status-chip.component.html
@@ -1,0 +1,17 @@
+<span [class]="rootClasses.join(' ')" role="status">
+  <span class="looksee-chip__sr sr-only">{{ a11yLabel }}</span>
+  <fa-icon
+    *ngIf="showDot"
+    [icon]="faCircle"
+    class="looksee-chip__dot"
+    aria-hidden="true"
+  ></fa-icon>
+  <fa-icon
+    *ngIf="style.icon"
+    [icon]="style.icon"
+    [spin]="!!style.spin"
+    class="looksee-chip__icon"
+    aria-hidden="true"
+  ></fa-icon>
+  <span class="looksee-chip__label" aria-hidden="true">{{ displayLabel }}</span>
+</span>

--- a/Look-see-UI-v3/src/app/components/shared/status-chip/status-chip.component.scss
+++ b/Look-see-UI-v3/src/app/components/shared/status-chip/status-chip.component.scss
@@ -1,0 +1,92 @@
+/* =============================================================================
+ * Status chip — docs/design/06-shared-components.md §2
+ * ============================================================================= */
+
+.looksee-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.375rem;
+  border-radius: var(--radius-full);
+  font-family: 'Inter', system-ui, sans-serif;
+  font-weight: 600;
+  line-height: 1;
+  white-space: nowrap;
+  border: 1px solid transparent;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+/* ----- Sizes ----- */
+.looksee-chip--sm {
+  height: 20px;
+  padding: 0 8px;
+  font-size: 11px;
+}
+
+.looksee-chip--md {
+  height: 24px;
+  padding: 0 10px;
+  font-size: 12px;
+}
+
+.looksee-chip__icon,
+.looksee-chip__dot {
+  font-size: 0.85em;
+}
+
+.looksee-chip__dot {
+  font-size: 0.5em;
+}
+
+/* ----- Kinds ----- */
+
+/* Audit status */
+.looksee-chip--queued,
+.looksee-chip--cancelled,
+.looksee-chip--ignored,
+.looksee-chip--open {
+  background-color: var(--chip-neutral-bg);
+  color: var(--chip-neutral-text);
+}
+
+.looksee-chip--running,
+.looksee-chip--in-progress,
+.looksee-chip--beta,
+.looksee-chip--new {
+  background-color: var(--chip-brand-bg);
+  color: var(--chip-brand-text);
+}
+
+.looksee-chip--complete,
+.looksee-chip--done,
+.looksee-chip--available {
+  background-color: var(--score-good-bg);
+  color: var(--score-good-text);
+}
+
+.looksee-chip--failed,
+.looksee-chip--critical {
+  background-color: var(--score-critical-bg);
+  color: var(--score-critical-text);
+}
+
+.looksee-chip--major,
+.looksee-chip--waitlist {
+  background-color: var(--score-warning-bg);
+  color: var(--score-warning-text);
+}
+
+.looksee-chip--minor {
+  background-color: var(--chip-neutral-bg);
+  color: var(--chip-neutral-text);
+}

--- a/Look-see-UI-v3/src/app/components/shared/status-chip/status-chip.component.ts
+++ b/Look-see-UI-v3/src/app/components/shared/status-chip/status-chip.component.ts
@@ -1,0 +1,102 @@
+import { CommonModule } from '@angular/common';
+import { Component, Input } from '@angular/core';
+import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
+import {
+  faCheck,
+  faCircle,
+  faSpinner,
+  faTriangleExclamation,
+  faXmark,
+  IconDefinition,
+} from '@fortawesome/free-solid-svg-icons';
+
+export type StatusChipKind =
+  // Audit status
+  | 'queued'
+  | 'running'
+  | 'complete'
+  | 'failed'
+  | 'cancelled'
+  // Issue severity
+  | 'critical'
+  | 'major'
+  | 'minor'
+  // Issue status
+  | 'open'
+  | 'in-progress'
+  | 'done'
+  | 'ignored'
+  // Generic
+  | 'beta'
+  | 'new'
+  | 'available'
+  | 'waitlist';
+
+export type StatusChipSize = 'sm' | 'md';
+
+interface ChipStyle {
+  label: string;
+  icon?: IconDefinition;
+  spin?: boolean;
+}
+
+const CHIP_STYLES: Record<StatusChipKind, ChipStyle> = {
+  queued:        { label: 'Queued' },
+  running:       { label: 'Auditing…', icon: faSpinner, spin: true },
+  complete:      { label: 'Complete', icon: faCheck },
+  failed:        { label: 'Failed', icon: faTriangleExclamation },
+  cancelled:     { label: 'Cancelled', icon: faXmark },
+  critical:      { label: 'Critical' },
+  major:         { label: 'Major' },
+  minor:         { label: 'Minor' },
+  open:          { label: 'Open' },
+  'in-progress': { label: 'In progress' },
+  done:          { label: 'Done', icon: faCheck },
+  ignored:       { label: 'Ignored' },
+  beta:          { label: 'Beta' },
+  new:           { label: 'New' },
+  available:     { label: 'Available' },
+  waitlist:      { label: 'Waitlist' },
+};
+
+/**
+ * Status / severity / generic chip. Visuals driven by semantic tokens from
+ * src/theme/tokens.scss so both light and dark modes work automatically.
+ *
+ * See docs/design/06-shared-components.md §2.
+ */
+@Component({
+  standalone: true,
+  imports: [CommonModule, FontAwesomeModule],
+  selector: 'looksee-status-chip',
+  templateUrl: './status-chip.component.html',
+  styleUrls: ['./status-chip.component.scss'],
+})
+export class LookseeStatusChipComponent {
+  @Input() kind!: StatusChipKind;
+  @Input() size: StatusChipSize = 'md';
+  @Input() label?: string;
+  @Input() showDot = false;
+
+  get style(): ChipStyle {
+    return CHIP_STYLES[this.kind];
+  }
+
+  get displayLabel(): string {
+    return this.label ?? this.style.label;
+  }
+
+  get a11yLabel(): string {
+    return `Status: ${this.displayLabel}`;
+  }
+
+  get rootClasses(): string[] {
+    return [
+      'looksee-chip',
+      `looksee-chip--${this.kind}`,
+      `looksee-chip--${this.size}`,
+    ];
+  }
+
+  readonly faCircle = faCircle;
+}

--- a/Look-see-UI-v3/src/app/components/shared/status-chip/status-chip.component.ts
+++ b/Look-see-UI-v3/src/app/components/shared/status-chip/status-chip.component.ts
@@ -68,7 +68,7 @@ const CHIP_STYLES: Record<StatusChipKind, ChipStyle> = {
 @Component({
   standalone: true,
   imports: [CommonModule, FontAwesomeModule],
-  selector: 'looksee-status-chip',
+  selector: 'app-looksee-status-chip',
   templateUrl: './status-chip.component.html',
   styleUrls: ['./status-chip.component.scss'],
 })

--- a/Look-see-UI-v3/src/app/components/start-audit-confirm-dialog/start-audit-confirm-dialog.html
+++ b/Look-see-UI-v3/src/app/components/start-audit-confirm-dialog/start-audit-confirm-dialog.html
@@ -1,10 +1,10 @@
-<h1 mat-dialog-title>Are you sure that you want to start a new audit?</h1>
+<h1 mat-dialog-title>Cancel the audit in progress?</h1>
 <div mat-dialog-content>
-  <p>Starting a new audit will cause the currently running audit to be abandoned.</p>
+  <p>Starting a new audit will stop the one currently running. Findings collected so far won't be saved.</p>
 </div>
 <div mat-dialog-actions class="flex items-center justify-end">
     <button (click)="onNoClick()" class="p-4 rounded-lg border-2 mr-6">
-        Cancel
+        Keep auditing
     </button>
     <button class="bg-primary-color text-white rounded-lg p-4"
             (click)="startSinglePageAudit()"
@@ -12,4 +12,3 @@
         Start new audit
     </button>
 </div>
-

--- a/Look-see-UI-v3/src/app/components/start-audit-login-required-dialog/start-audit-login-required-dialog.html
+++ b/Look-see-UI-v3/src/app/components/start-audit-login-required-dialog/start-audit-login-required-dialog.html
@@ -1,17 +1,13 @@
-<h1 mat-dialog-title>Are you sure that you want to start a new audit?</h1>
+<h1 mat-dialog-title>Save this audit for later?</h1>
 <div mat-dialog-content>
   <p>
-      It looks like you haven't logged in yet. Unfortunately we only provide 1 free audit for visitors without an account. 
-      <br/><br/>
-      On the bright side, we allow up to 10 free audits to users that create a FREE account. 
-      <br/><br/>
-      You can create a FREE account by clicking the login button in the top right of the screen to create a new account.
+    Create a free account to save your report, track your score over time, and
+    unlock up to 10 audits per month.
   </p>
 </div>
 <div mat-dialog-actions class="flex items-center justify-end">
     <button (click)="onNoClick()" class="p-4 rounded-lg border-2 mr-6">
-        Cancel
+        Not now
     </button>
     <app-auth-button></app-auth-button>
 </div>
-

--- a/Look-see-UI-v3/src/app/models/audit-status.ts
+++ b/Look-see-UI-v3/src/app/models/audit-status.ts
@@ -1,0 +1,86 @@
+/**
+ * Canonical audit lifecycle states.
+ *
+ * See docs/design/02-audit-status-and-progress.md §1.
+ *
+ * Backend today returns `status: string` on AuditRecord with varying tokens.
+ * Until backend contract converges, use `normaliseAuditStatus()` to map any
+ * legacy value into this enum.
+ */
+export enum AuditStatus {
+  QUEUED = 'QUEUED',
+  RUNNING = 'RUNNING',
+  COMPLETE = 'COMPLETE',
+  FAILED = 'FAILED',
+  CANCELLED = 'CANCELLED',
+}
+
+const TERMINAL_STATUSES: ReadonlySet<AuditStatus> = new Set([
+  AuditStatus.COMPLETE,
+  AuditStatus.FAILED,
+  AuditStatus.CANCELLED,
+]);
+
+/** Chip `kind` value for a given status — passed to `<looksee-status-chip>`. */
+export function auditStatusChipKind(status: AuditStatus):
+  'queued' | 'running' | 'complete' | 'failed' | 'cancelled' {
+  switch (status) {
+    case AuditStatus.QUEUED:    return 'queued';
+    case AuditStatus.RUNNING:   return 'running';
+    case AuditStatus.COMPLETE:  return 'complete';
+    case AuditStatus.FAILED:    return 'failed';
+    case AuditStatus.CANCELLED: return 'cancelled';
+  }
+}
+
+export function isTerminalStatus(status: AuditStatus): boolean {
+  return TERMINAL_STATUSES.has(status);
+}
+
+/**
+ * Map a raw backend `status` string into AuditStatus.
+ *
+ * Current backend emits values like 'COMPLETE', 'RUNNING', 'IN_PROGRESS',
+ * 'ERROR', 'DONE', 'PENDING', lowercase variants, etc. Unknown values default
+ * to RUNNING when scores are absent and COMPLETE when scores are present —
+ * this is a bridge until the backend contract formalises (see spec §Risks #1).
+ */
+export function normaliseAuditStatus(
+  raw: string | null | undefined,
+  opts?: { hasScores?: boolean }
+): AuditStatus {
+  const v = (raw ?? '').toString().trim().toUpperCase();
+
+  switch (v) {
+    case 'QUEUED':
+    case 'PENDING':
+    case 'SCHEDULED':
+      return AuditStatus.QUEUED;
+
+    case 'RUNNING':
+    case 'IN_PROGRESS':
+    case 'PROCESSING':
+    case 'STARTED':
+      return AuditStatus.RUNNING;
+
+    case 'COMPLETE':
+    case 'COMPLETED':
+    case 'DONE':
+    case 'SUCCESS':
+    case 'FINISHED':
+      return AuditStatus.COMPLETE;
+
+    case 'FAILED':
+    case 'ERROR':
+    case 'ERRORED':
+      return AuditStatus.FAILED;
+
+    case 'CANCELLED':
+    case 'CANCELED':
+    case 'ABORTED':
+      return AuditStatus.CANCELLED;
+  }
+
+  // Unknown / empty — fall back based on data shape
+  return opts?.hasScores ? AuditStatus.COMPLETE : AuditStatus.RUNNING;
+}

--- a/Look-see-UI-v3/src/app/models/audit-status.ts
+++ b/Look-see-UI-v3/src/app/models/audit-status.ts
@@ -21,7 +21,7 @@ const TERMINAL_STATUSES: ReadonlySet<AuditStatus> = new Set([
   AuditStatus.CANCELLED,
 ]);
 
-/** Chip `kind` value for a given status — passed to `<looksee-status-chip>`. */
+/** Chip `kind` value for a given status — passed to `<app-looksee-status-chip>`. */
 export function auditStatusChipKind(status: AuditStatus):
   'queued' | 'running' | 'complete' | 'failed' | 'cancelled' {
   switch (status) {

--- a/Look-see-UI-v3/src/app/services/breadcrumb/breadcrumb.service.ts
+++ b/Look-see-UI-v3/src/app/services/breadcrumb/breadcrumb.service.ts
@@ -1,0 +1,36 @@
+import { Injectable } from '@angular/core';
+import { BehaviorSubject, Observable } from 'rxjs';
+
+/**
+ * A single breadcrumb entry. `href` absent = current page (rendered plain).
+ * See docs/design/04-navigation-ia.md §3.
+ */
+export interface Breadcrumb {
+  label: string;
+  href?: string;
+}
+
+/**
+ * App-wide breadcrumb state. Route components set breadcrumbs in ngOnInit;
+ * `<app-breadcrumb-bar>` reads `crumbs$` and renders.
+ *
+ * For async data loads, components should push twice: once with placeholder
+ * labels ("Loading…"), then again when resolved.
+ */
+@Injectable({ providedIn: 'root' })
+export class BreadcrumbService {
+  private readonly _crumbs$ = new BehaviorSubject<Breadcrumb[]>([]);
+  readonly crumbs$: Observable<Breadcrumb[]> = this._crumbs$.asObservable();
+
+  set(crumbs: Breadcrumb[]): void {
+    this._crumbs$.next(crumbs);
+  }
+
+  clear(): void {
+    this._crumbs$.next([]);
+  }
+
+  snapshot(): Breadcrumb[] {
+    return this._crumbs$.value;
+  }
+}

--- a/Look-see-UI-v3/src/app/utils/url.ts
+++ b/Look-see-UI-v3/src/app/utils/url.ts
@@ -1,0 +1,58 @@
+/**
+ * Permissive URL parsing — accepts anything the URL constructor can parse,
+ * auto-prepends https:// when scheme is missing, and only rejects obviously-
+ * invalid hostnames.
+ *
+ * See docs/design/05-landing-and-onboarding.md §1.
+ *
+ * Replaces the legacy hardcoded-TLD regex (which rejected valid URLs like
+ * `.tech`, `.design`, `.store`, etc.).
+ */
+
+export type NormaliseUrlSuccess = { ok: true; url: string; schemeAdded: boolean };
+export type NormaliseUrlError = { ok: false; error: string };
+export type NormaliseUrlResult = NormaliseUrlSuccess | NormaliseUrlError;
+
+export function normaliseUrl(input: string | null | undefined): NormaliseUrlResult {
+  const trimmed = (input ?? '').trim();
+  if (!trimmed) {
+    return { ok: false, error: 'Enter a website URL.' };
+  }
+
+  const hasScheme = /^https?:\/\//i.test(trimmed);
+  const withScheme = hasScheme ? trimmed : `https://${trimmed}`;
+
+  let parsed: URL;
+  try {
+    parsed = new URL(withScheme);
+  } catch {
+    return { ok: false, error: "That doesn't look like a valid website address." };
+  }
+
+  const host = parsed.hostname;
+
+  if (!host || !host.includes('.') || host.endsWith('.') || host.startsWith('.')) {
+    return { ok: false, error: "That doesn't look like a valid website address." };
+  }
+
+  // Reject local / private ranges politely — we can't audit what we can't reach.
+  const lowerHost = host.toLowerCase();
+  if (
+    lowerHost === 'localhost' ||
+    /^127\./.test(host) ||
+    /^10\./.test(host) ||
+    /^192\.168\./.test(host) ||
+    /^172\.(1[6-9]|2\d|3[01])\./.test(host) ||
+    lowerHost.endsWith('.local') ||
+    lowerHost.endsWith('.internal')
+  ) {
+    return { ok: false, error: "We can't audit local addresses. Try a public URL." };
+  }
+
+  return { ok: true, url: parsed.toString(), schemeAdded: !hasScheme };
+}
+
+/** Lightweight predicate for quick field validation. */
+export function isValidWebsiteUrl(input: string | null | undefined): boolean {
+  return normaliseUrl(input).ok;
+}

--- a/Look-see-UI-v3/src/styles.scss
+++ b/Look-see-UI-v3/src/styles.scss
@@ -3,22 +3,29 @@
 @import 'tailwindcss/utilities';
 @import '@angular/material/prebuilt-themes/deeppurple-amber.css';
 
-/* ===== FONTS ===== */
-@font-face {
-    font-family: 'Cera Pro';
-    font-style: normal;
-    font-weight: 400;
-    src: local('Cera Pro Black'), local('Cera-Pro-Black'),
-         url('/assets/fonts/cera-pro/CeraProBlack.otf') format('opentype'),
-         url('/assets/fonts/cera-pro/CeraProBlack.ttf') format('truetype'),
-}
+/* =============================================================================
+ * Look-see theme imports
+ *
+ * Design tokens and typography utilities. Every new component should reference
+ * tokens (CSS custom properties) instead of raw hex. See docs/design/01-design-system.md.
+ * ============================================================================= */
+@import './theme/tokens.scss';
+@import './theme/typography.scss';
+@import './theme/material-overrides.scss';
 
-@font-face {
-    font-family: 'Open Sans';
-    font-style: normal;
-    font-weight: 400;
-    src: local('Open Sans Regular'), local('Open-Sans-Regular'),
-         url('/assets/fonts/open-sans/OpenSans-Regular.ttf') format('truetype'),
+/* ===== REDUCED MOTION ===== */
+/* Global opt-out: if the user prefers reduced motion, neutralise nearly all
+ * animations and transitions. Components SHOULD also check
+ * prefers-reduced-motion in their own rules for fine-grained behaviour. */
+@media (prefers-reduced-motion: reduce) {
+    *,
+    *::before,
+    *::after {
+        animation-duration: 0.01ms !important;
+        animation-iteration-count: 1 !important;
+        transition-duration: 0.01ms !important;
+        scroll-behavior: auto !important;
+    }
 }
 
 /* ===== BASE RESET ===== */
@@ -228,11 +235,4 @@ select {
     @apply animate-pulse bg-gray-200 rounded;
 }
 
-/* ===== ANGULAR MATERIAL OVERRIDES ===== */
-.mat-mdc-progress-spinner circle {
-    stroke: #FF0050 !important;
-}
-
-.mat-mdc-dialog-container {
-    border-radius: 1rem !important;
-}
+/* Material overrides moved to src/theme/material-overrides.scss */

--- a/Look-see-UI-v3/src/theme/material-overrides.scss
+++ b/Look-see-UI-v3/src/theme/material-overrides.scss
@@ -1,0 +1,100 @@
+/* =============================================================================
+ * Angular Material overrides — bind Material's component colors to Look-see tokens.
+ *
+ * Material's pre-built Deep Purple/Amber theme is loaded via styles.scss; these
+ * rules layer on top to correct primary/accent usage and radii so Material
+ * components blend with the rest of the UI.
+ *
+ * For a full theme rebuild using mat.define-theme(), see docs/design/01-design-system.md §6.
+ * Shipping as overrides first to avoid risking a big SCSS build change.
+ * ============================================================================= */
+
+/* ----- Buttons ----- */
+.mat-mdc-button,
+.mat-mdc-raised-button,
+.mat-mdc-stroked-button,
+.mat-mdc-flat-button {
+  --mdc-text-button-label-text-color: var(--text-primary);
+  --mdc-filled-button-container-color: var(--text-accent);
+  --mdc-filled-button-label-text-color: var(--text-on-accent);
+  --mdc-outlined-button-label-text-color: var(--text-primary);
+  --mdc-outlined-button-outline-color: var(--border-default);
+  border-radius: var(--radius-md) !important;
+  font-family: 'Inter', system-ui, sans-serif !important;
+  letter-spacing: 0 !important;
+}
+
+.mat-mdc-raised-button.mat-primary {
+  --mdc-protected-button-container-color: var(--text-primary);
+  --mdc-protected-button-label-text-color: var(--text-inverse);
+}
+
+.mat-mdc-raised-button.mat-accent,
+.mat-mdc-flat-button.mat-accent {
+  --mdc-protected-button-container-color: var(--text-accent);
+  --mdc-protected-button-label-text-color: var(--text-on-accent);
+  --mdc-filled-button-container-color: var(--text-accent);
+  --mdc-filled-button-label-text-color: var(--text-on-accent);
+}
+
+.mat-mdc-raised-button.mat-warn,
+.mat-mdc-flat-button.mat-warn {
+  --mdc-protected-button-container-color: var(--score-critical);
+  --mdc-protected-button-label-text-color: #ffffff;
+  --mdc-filled-button-container-color: var(--score-critical);
+  --mdc-filled-button-label-text-color: #ffffff;
+}
+
+/* ----- Dialogs ----- */
+.mat-mdc-dialog-container {
+  --mdc-dialog-container-color: var(--surface-raised);
+  --mdc-dialog-subhead-color: var(--text-primary);
+  --mdc-dialog-supporting-text-color: var(--text-secondary);
+  border-radius: var(--radius-xl) !important;
+  box-shadow: var(--shadow-xl) !important;
+}
+
+.cdk-overlay-dark-backdrop {
+  background-color: var(--surface-overlay);
+}
+
+/* ----- Progress spinner / bar ----- */
+.mat-mdc-progress-spinner {
+  --mdc-circular-progress-active-indicator-color: var(--text-accent);
+}
+
+.mat-mdc-progress-spinner circle {
+  stroke: var(--text-accent) !important;
+}
+
+.mat-mdc-progress-bar {
+  --mdc-linear-progress-active-indicator-color: var(--text-accent);
+  --mdc-linear-progress-track-color: var(--surface-sunken);
+  border-radius: var(--radius-full);
+  overflow: hidden;
+}
+
+/* ----- Tooltips ----- */
+.mat-mdc-tooltip {
+  --mdc-plain-tooltip-container-color: var(--surface-inverse);
+  --mdc-plain-tooltip-supporting-text-color: var(--text-inverse);
+  --mdc-plain-tooltip-supporting-text-font: 'Inter', system-ui, sans-serif;
+  border-radius: var(--radius-sm) !important;
+}
+
+/* ----- Snackbar ----- */
+.mat-mdc-snack-bar-container {
+  --mdc-snackbar-container-color: var(--surface-inverse);
+  --mdc-snackbar-supporting-text-color: var(--text-inverse);
+  border-radius: var(--radius-md) !important;
+}
+
+/* ----- Form fields ----- */
+.mat-mdc-form-field {
+  --mdc-filled-text-field-caret-color: var(--text-accent);
+  --mdc-filled-text-field-focus-active-indicator-color: var(--text-accent);
+  --mdc-filled-text-field-focus-label-text-color: var(--text-accent);
+  --mdc-outlined-text-field-caret-color: var(--text-accent);
+  --mdc-outlined-text-field-focus-outline-color: var(--text-accent);
+  --mdc-outlined-text-field-focus-label-text-color: var(--text-accent);
+}

--- a/Look-see-UI-v3/src/theme/tokens.scss
+++ b/Look-see-UI-v3/src/theme/tokens.scss
@@ -1,0 +1,154 @@
+/* =============================================================================
+ * Look-see design tokens
+ *
+ * Semantic CSS custom properties. Components MUST reference these tokens, not
+ * raw palette colors. Raw palette values live in tailwind.config.js and in the
+ * light/dark definitions below — and nowhere else.
+ *
+ * See: docs/design/01-design-system.md
+ * ============================================================================= */
+
+:root,
+[data-theme='light'] {
+  /* ----- Surfaces ----- */
+  --surface-base:      #ffffff;   /* page background */
+  --surface-raised:    #ffffff;   /* cards */
+  --surface-sunken:    #f6f5f5;   /* subtle contained areas (ink.50) */
+  --surface-inverse:   #231f20;   /* dark bars in light mode (ink.950) */
+  --surface-overlay:   rgba(35, 31, 32, 0.55); /* modal backdrop */
+
+  /* ----- Text ----- */
+  --text-primary:      #231f20;   /* ink.950 */
+  --text-secondary:    #5f5d5e;   /* ink.600 */
+  --text-muted:        #8a8889;   /* ink.400 */
+  --text-inverse:      #ffffff;
+  --text-accent:       #c2003e;   /* brand.700 — AA on white (4.78:1) */
+  --text-accent-hover: #a10039;   /* brand.800 */
+  --text-on-accent:    #ffffff;
+  --text-link:         #c2003e;
+  --text-link-hover:   #a10039;
+
+  /* ----- Borders ----- */
+  --border-subtle:     #e7e6e6;   /* ink.100 */
+  --border-default:    #d1d0d0;   /* ink.200 */
+  --border-strong:     #b1afb0;   /* ink.300 */
+  --border-focus:      #FF0050;   /* brand.500 */
+  --border-inverse:    #504e4f;   /* ink.700 */
+
+  /* ----- Score semantic ----- */
+  --score-good:        #10b981;   /* emerald-500 */
+  --score-good-bg:     #d1fae5;
+  --score-good-text:   #065f46;
+  --score-warning:     #f59e0b;
+  --score-warning-bg:  #fef3c7;
+  --score-warning-text:#92400e;
+  --score-critical:    #ef4444;
+  --score-critical-bg: #fee2e2;
+  --score-critical-text:#991b1b;
+
+  /* ----- Brand chip (used for in-progress, beta, etc.) ----- */
+  --chip-brand-bg:     #fee2e8;   /* brand.100 */
+  --chip-brand-text:   #870035;   /* brand.900 */
+  --chip-neutral-bg:   #e7e6e6;   /* ink.100 */
+  --chip-neutral-text: #464445;   /* ink.800 */
+
+  /* ----- Focus ring ----- */
+  --focus-ring:        0 0 0 3px rgba(255, 0, 80, 0.35);
+  --focus-ring-inset:  inset 0 0 0 2px #FF0050;
+
+  /* ----- Elevation ----- */
+  --shadow-xs:   0 1px 2px 0 rgb(0 0 0 / 0.04);
+  --shadow-sm:   0 1px 3px 0 rgb(0 0 0 / 0.06), 0 1px 2px -1px rgb(0 0 0 / 0.04);
+  --shadow-md:   0 4px 6px -1px rgb(0 0 0 / 0.08), 0 2px 4px -2px rgb(0 0 0 / 0.04);
+  --shadow-lg:   0 10px 15px -3px rgb(0 0 0 / 0.10), 0 4px 6px -4px rgb(0 0 0 / 0.06);
+  --shadow-xl:   0 20px 25px -5px rgb(0 0 0 / 0.10), 0 8px 10px -6px rgb(0 0 0 / 0.04);
+
+  /* ----- Radius ----- */
+  --radius-xs:   2px;
+  --radius-sm:   4px;
+  --radius-md:   6px;
+  --radius-lg:   8px;
+  --radius-xl:   12px;
+  --radius-2xl:  16px;
+  --radius-full: 9999px;
+
+  /* ----- Motion ----- */
+  --duration-fast: 120ms;
+  --duration-base: 180ms;
+  --duration-slow: 280ms;
+  --ease-out-soft:     cubic-bezier(0.22, 1, 0.36, 1);
+  --ease-in-out-soft:  cubic-bezier(0.65, 0, 0.35, 1);
+}
+
+[data-theme='dark'] {
+  --surface-base:      #151313;   /* ink.950 */
+  --surface-raised:    #231f20;   /* ink.900 */
+  --surface-sunken:    #151313;
+  --surface-inverse:   #ffffff;
+  --surface-overlay:   rgba(0, 0, 0, 0.72);
+
+  --text-primary:      #f6f5f5;   /* ink.50 */
+  --text-secondary:    #b1afb0;   /* ink.300 */
+  --text-muted:        #8a8889;
+  --text-inverse:      #231f20;
+  --text-accent:       #ff6690;   /* brand.400 — brighter for dark surfaces */
+  --text-accent-hover: #ff9db5;
+  --text-on-accent:    #ffffff;
+  --text-link:         #ff6690;
+  --text-link-hover:   #ff9db5;
+
+  --border-subtle:     #3d3b3c;   /* ink.900 */
+  --border-default:    #504e4f;   /* ink.700 */
+  --border-strong:     #6f6d6e;   /* ink.500 */
+  --border-focus:      #ff6690;
+  --border-inverse:    #d1d0d0;
+
+  --score-good:        #34d399;
+  --score-good-bg:     rgba(16, 185, 129, 0.18);
+  --score-good-text:   #6ee7b7;
+  --score-warning:     #fbbf24;
+  --score-warning-bg:  rgba(245, 158, 11, 0.18);
+  --score-warning-text:#fcd34d;
+  --score-critical:    #f87171;
+  --score-critical-bg: rgba(239, 68, 68, 0.18);
+  --score-critical-text:#fca5a5;
+
+  --chip-brand-bg:     rgba(255, 0, 80, 0.18);
+  --chip-brand-text:   #ff9db5;
+  --chip-neutral-bg:   #3d3b3c;
+  --chip-neutral-text: #d1d0d0;
+
+  --focus-ring:        0 0 0 3px rgba(255, 102, 144, 0.45);
+  --focus-ring-inset:  inset 0 0 0 2px #ff6690;
+
+  /* Shadows darker / softer on dark surfaces */
+  --shadow-xs:   0 1px 2px 0 rgb(0 0 0 / 0.35);
+  --shadow-sm:   0 1px 3px 0 rgb(0 0 0 / 0.45), 0 1px 2px -1px rgb(0 0 0 / 0.30);
+  --shadow-md:   0 4px 6px -1px rgb(0 0 0 / 0.50), 0 2px 4px -2px rgb(0 0 0 / 0.35);
+  --shadow-lg:   0 10px 15px -3px rgb(0 0 0 / 0.55), 0 4px 6px -4px rgb(0 0 0 / 0.40);
+  --shadow-xl:   0 20px 25px -5px rgb(0 0 0 / 0.60), 0 8px 10px -6px rgb(0 0 0 / 0.45);
+}
+
+/* ---- Aliased Tailwind helpers (opt-in; classes can be used in templates) ---- */
+
+.bg-surface-base   { background-color: var(--surface-base); }
+.bg-surface-raised { background-color: var(--surface-raised); }
+.bg-surface-sunken { background-color: var(--surface-sunken); }
+
+.text-token-primary   { color: var(--text-primary); }
+.text-token-secondary { color: var(--text-secondary); }
+.text-token-muted     { color: var(--text-muted); }
+.text-token-accent    { color: var(--text-accent); }
+
+.border-token-subtle  { border-color: var(--border-subtle); }
+.border-token-default { border-color: var(--border-default); }
+.border-token-strong  { border-color: var(--border-strong); }
+
+.shadow-token-sm { box-shadow: var(--shadow-sm); }
+.shadow-token-md { box-shadow: var(--shadow-md); }
+.shadow-token-lg { box-shadow: var(--shadow-lg); }
+
+.focus-ring:focus-visible {
+  outline: none;
+  box-shadow: var(--focus-ring);
+}

--- a/Look-see-UI-v3/src/theme/typography.scss
+++ b/Look-see-UI-v3/src/theme/typography.scss
@@ -1,0 +1,113 @@
+/* =============================================================================
+ * Look-see typography
+ *
+ * @font-face loading + named typography utilities. Maps headings (h1–h6) to the
+ * canonical scale. See docs/design/01-design-system.md §2.
+ * ============================================================================= */
+
+/* ----- Fonts ----- */
+@font-face {
+  font-family: 'Cera Pro';
+  font-style: normal;
+  font-weight: 700;
+  font-display: swap;
+  src: local('Cera Pro Black'), local('Cera-Pro-Black'),
+       url('/assets/fonts/cera-pro/CeraProBlack.otf') format('opentype'),
+       url('/assets/fonts/cera-pro/CeraProBlack.ttf') format('truetype');
+}
+
+/* Open Sans kept for one release while components migrate to Inter. */
+@font-face {
+  font-family: 'Open Sans';
+  font-style: normal;
+  font-weight: 400;
+  font-display: swap;
+  src: local('Open Sans Regular'), local('Open-Sans-Regular'),
+       url('/assets/fonts/open-sans/OpenSans-Regular.ttf') format('truetype');
+}
+
+/* ----- Named scale ----- */
+.text-display-xl {
+  font-family: 'Cera Pro', 'Inter', system-ui, sans-serif;
+  font-size: 48px;
+  line-height: 1.1;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+}
+
+.text-display {
+  font-family: 'Cera Pro', 'Inter', system-ui, sans-serif;
+  font-size: 36px;
+  line-height: 1.15;
+  font-weight: 700;
+  letter-spacing: -0.015em;
+}
+
+.text-heading-lg {
+  font-family: 'Inter', system-ui, sans-serif;
+  font-size: 28px;
+  line-height: 1.25;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+}
+
+.text-heading {
+  font-family: 'Inter', system-ui, sans-serif;
+  font-size: 22px;
+  line-height: 1.3;
+  font-weight: 600;
+  letter-spacing: -0.005em;
+}
+
+.text-subheading {
+  font-family: 'Inter', system-ui, sans-serif;
+  font-size: 18px;
+  line-height: 1.4;
+  font-weight: 600;
+}
+
+.text-body-lg {
+  font-family: 'Inter', system-ui, sans-serif;
+  font-size: 17px;
+  line-height: 1.55;
+  font-weight: 400;
+}
+
+.text-body-token {
+  /* Named "-token" to avoid collision with existing .text-body class */
+  font-family: 'Inter', system-ui, sans-serif;
+  font-size: 15px;
+  line-height: 1.55;
+  font-weight: 400;
+}
+
+.text-body-sm-token {
+  font-family: 'Inter', system-ui, sans-serif;
+  font-size: 13px;
+  line-height: 1.5;
+  font-weight: 400;
+}
+
+.text-caption {
+  font-family: 'Inter', system-ui, sans-serif;
+  font-size: 12px;
+  line-height: 1.4;
+  font-weight: 500;
+  letter-spacing: 0.01em;
+}
+
+.text-overline {
+  font-family: 'Inter', system-ui, sans-serif;
+  font-size: 11px;
+  line-height: 1.2;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.text-mono {
+  font-family: 'JetBrains Mono', 'SF Mono', 'Menlo', monospace;
+  font-size: 13px;
+  line-height: 1.5;
+  font-weight: 400;
+}

--- a/Look-see-UI-v3/tailwind.config.js
+++ b/Look-see-UI-v3/tailwind.config.js
@@ -1,5 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
+  darkMode: ['class', '[data-theme="dark"]'],
   content: [
     "./src/**/*.{html,ts}",
     "./node_modules/flowbite/**/*.js"
@@ -18,6 +19,22 @@ module.exports = {
           700: '#c2003e',
           800: '#a10039',
           900: '#870035',
+          950: '#4d0018',
+        },
+        // `ink` is the canonical neutral palette. `charcoal` is kept as an
+        // alias for legacy templates; new code should use `ink`.
+        ink: {
+          50: '#f6f5f5',
+          100: '#e7e6e6',
+          200: '#d1d0d0',
+          300: '#b1afb0',
+          400: '#8a8889',
+          500: '#6f6d6e',
+          600: '#5f5d5e',
+          700: '#504e4f',
+          800: '#464445',
+          900: '#3d3b3c',
+          950: '#231f20',
         },
         charcoal: {
           50: '#f6f5f5',
@@ -38,8 +55,22 @@ module.exports = {
         },
         score: {
           good: '#10b981',
+          'good-bg': '#d1fae5',
+          'good-text': '#065f46',
           warning: '#f59e0b',
+          'warning-bg': '#fef3c7',
+          'warning-text': '#92400e',
           critical: '#ef4444',
+          'critical-bg': '#fee2e2',
+          'critical-text': '#991b1b',
+        },
+        // Semantic aliases reading from CSS custom properties so components
+        // automatically theme (light/dark) when the variable flips.
+        surface: {
+          base: 'var(--surface-base)',
+          raised: 'var(--surface-raised)',
+          sunken: 'var(--surface-sunken)',
+          inverse: 'var(--surface-inverse)',
         },
       },
       fontFamily: {
@@ -55,15 +86,36 @@ module.exports = {
         '128': '32rem',
       },
       borderRadius: {
-        'xl': '0.75rem',
-        '2xl': '1rem',
+        'xs': '2px',
+        'sm': '4px',
+        'md': '6px',
+        'lg': '8px',
+        'xl': '12px',
+        '2xl': '16px',
         '3xl': '1.5rem',
       },
       boxShadow: {
-        'card': '0 1px 3px 0 rgb(0 0 0 / 0.06), 0 1px 2px -1px rgb(0 0 0 / 0.06)',
+        // Named tokens matching tokens.scss
+        'token-xs': 'var(--shadow-xs)',
+        'token-sm': 'var(--shadow-sm)',
+        'token-md': 'var(--shadow-md)',
+        'token-lg': 'var(--shadow-lg)',
+        'token-xl': 'var(--shadow-xl)',
+        'focus':    'var(--focus-ring)',
+        // Legacy aliases (kept so existing templates keep working)
+        'card':       '0 1px 3px 0 rgb(0 0 0 / 0.06), 0 1px 2px -1px rgb(0 0 0 / 0.06)',
         'card-hover': '0 4px 6px -1px rgb(0 0 0 / 0.08), 0 2px 4px -2px rgb(0 0 0 / 0.05)',
-        'panel': '0 1px 2px 0 rgb(0 0 0 / 0.05)',
-        'elevated': '0 10px 15px -3px rgb(0 0 0 / 0.08), 0 4px 6px -4px rgb(0 0 0 / 0.04)',
+        'panel':      '0 1px 2px 0 rgb(0 0 0 / 0.05)',
+        'elevated':   '0 10px 15px -3px rgb(0 0 0 / 0.08), 0 4px 6px -4px rgb(0 0 0 / 0.04)',
+      },
+      transitionDuration: {
+        fast: '120ms',
+        base: '180ms',
+        slow: '280ms',
+      },
+      transitionTimingFunction: {
+        'out-soft':    'cubic-bezier(0.22, 1, 0.36, 1)',
+        'in-out-soft': 'cubic-bezier(0.65, 0, 0.35, 1)',
       },
       animation: {
         'fade-in': 'fadeIn 0.3s ease-out',


### PR DESCRIPTION
## Summary

Adds a principal-designer-level UX redesign of the Look-see UI plus the first phase of implementation. Two commits: docs-only, then a non-breaking implementation that lays the design system foundation and ships several foundational components / copy fixes.

## What's in here

**1. Docs ([`32efc69`](../commit/32efc69))** — strategy and specs
- [`UX_REDESIGN.md`](Look-see-UI-v3/UX_REDESIGN.md) — end-to-end redesign: product thesis, personas, IA, user flows, screen-by-screen wireframes (ASCII), copy rewrites, metrics, 4-phase sequence
- [`docs/design/`](Look-see-UI-v3/docs/design/) — 6 per-area specs + index + implementation log. Each spec follows the same structure (problem → goals → user stories → design → technical design → acceptance criteria → metrics → risks → phasing).

**2. Implementation ([`f12f834`](../commit/f12f834))** — Phase A foundation

| Spec | Status | What shipped |
|---|---|---|
| 01 — Design system | ✅ M1 + M2 | Tokens (40+ CSS custom properties, full dark-mode overrides), 12 typography utilities, Material theme overrides, reduced-motion opt-out, `LookseeButtonComponent` (6 variants × 3 sizes) |
| 02 — Audit status | ✅ M1 (client) | `AuditStatus` enum + `normaliseAuditStatus()` (handles legacy/lowercase/unknown backend values); audit-list shows per-row status chips |
| 03 — Results refactor | ⏸ Deferred | Depends on backend contract decisions |
| 04 — Navigation / IA | ✅ M1 | Forward-compatible route redirects (`/home`, `/sites`, `/audits`, `/audits/:id`, `/settings`, `/integrations`, `/help`); 404 fallback; `BreadcrumbService` + `<looksee-breadcrumb-bar>` |
| 05 — Landing & onboarding | ✅ M1 | Permissive `normaliseUrl()` replacing hardcoded-TLD regex; 3 dialog copy rewrites |
| 06 — Shared components | ✅ 4 of 11 | Button, StatusChip, Skeleton, EmptyState, BreadcrumbBar |

Full shipped-vs-follow-up breakdown per spec in [`docs/design/IMPLEMENTATION_LOG.md`](Look-see-UI-v3/docs/design/IMPLEMENTATION_LOG.md).

## Why

The current UI has specific, measurable friction points that leak conversion and erode trust:
- URL regex rejects `.tech`, `.design`, `.store` etc. — first interaction fails for many users
- "Unfortunately we only provide 1 free audit" is pessimistic tone at the conversion moment
- In-progress audits are invisible after navigation
- `page-audit-review.ts` is 1,293 LOC and unmaintainable
- Hardcoded hex across 20+ templates; brand inconsistency grows linearly

The docs frame the redesign; the implementation lands the non-breaking foundation every later change depends on.

## Non-breaking guarantees

- No existing component is deleted. All new components are standalone, added to AppModule's `imports` array.
- All existing routes still work. New spec-04 paths are added as redirects to existing components — no `router.navigate` call-site updates needed.
- Material Deep Purple theme still loads; overrides layer on top via `--mdc-*` variables.
- Legacy tokens retained (`charcoal`, legacy shadows, score-* colors) so no current template breaks.

## What to check in review

1. **Build on first `ng build` after `npm install`.** This environment didn't have `node_modules`; no compile was possible here. Syntax-level review of the diff is the best proxy.
2. **Dark-mode readiness.** `[data-theme='dark']` is wired in `tokens.scss` and `tailwind.config.js` but no toggle UI ships — expected.
3. **Pre-existing audit-list empty-state bug.** Was `*ngIf="!audit_records && !is_loading_audits"` — always false because `[]` is truthy. Fixed to `audit_records.length === 0`.
4. **Deprecated shims.** `isValidURL()` kept on `landing` and `audit-form` as delegators to `normaliseUrl()` — remove after one release (no non-self callers).
5. **Material theme.** The Deep Purple pre-built theme still loads. Full `mat.define-theme()` rebuild is called out as follow-up in spec 01.

## Test plan

- [ ] `npm install && ng build` succeeds with no new errors
- [ ] Landing page: pasting `acme.io`, `acme.co`, `acme.tech` all accepted (previously rejected)
- [ ] Landing page: pasting invalid input shows friendlier error copy
- [ ] Audit list: loading shows skeleton rows (not "Please wait…")
- [ ] Audit list: empty state shows when no audits exist (not hidden by `[]` truthy bug)
- [ ] Audit list: each row shows a `<looksee-status-chip>` matching its status
- [ ] Navigating to `/home`, `/sites`, `/audits`, `/audits/:id`, `/settings`, `/integrations`, `/help` all redirect correctly
- [ ] Navigating to a bogus URL shows the 404 page with working back-links
- [ ] "Cancel the audit in progress?" dialog copy displays correctly
- [ ] "Save this audit for later?" login-required dialog copy displays correctly
- [ ] Material dialogs and tooltips still render with proper styling
- [ ] Visual regression: existing pages look substantively the same (tokens added non-breakingly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)