### PR TITLE
docs: fix reasons grid so body text spans the wide column

### DIFF
--- a/docs/styles.css
+++ b/docs/styles.css
@@ -694,6 +694,7 @@ html[data-theme="night"] .theme-toggle__knob {
   line-height: 1;
 }
 .reasons h3 {
+  grid-column: 2;
   font-family: var(--font-display);
   font-variation-settings: "opsz" 60, "SOFT" 40;
   font-weight: 500;
@@ -704,8 +705,9 @@ html[data-theme="night"] .theme-toggle__knob {
   max-width: 32ch;
 }
 .reasons p {
+  grid-column: 2;
   margin: 0;
-  max-width: 60ch;
+  max-width: 72ch;
   line-height: 1.65;
 }
 @media (max-width: 640px) {
@@ -713,6 +715,8 @@ html[data-theme="night"] .theme-toggle__knob {
     grid-template-columns: 1fr;
     gap: .5rem;
   }
+  .reasons h3,
+  .reasons p { grid-column: auto; }
 }
 
 /* ============================================================


### PR DESCRIPTION
## Summary

Chapter 03 ("Why it's unusual") was rendering the reason-body paragraphs with ~1 word per line. The `.reasons li` is a 2-column grid (`6ch | 1fr`) — without explicit placement, the `<p>` auto-flowed into the narrow first column *under* the Roman numeral, so the paragraph was constrained to 6ch.

Fix: pin `<h3>` and `<p>` to column 2 on desktop; restore auto-flow on the single-column mobile layout so stacking still works below 640px. Also bumps paragraph `max-width` from `60ch` → `72ch` now that there is real room.

Before (bug): numeral | h3; numeral | (narrow p)
After: numeral | h3; (empty) | wide p

## Test plan

- [ ] Load the deployed Pages site and scroll to Chapter 03.
- [ ] Each of the three reasons (i / ii / iii) has its paragraph reading at a comfortable measure, not wrapping every word.
- [ ] Resize to < 640px; numeral, heading, and paragraph stack cleanly in a single column.
- [ ] No other sections visually shifted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)