### PR TITLE
docs: rewrite marketing copy for an authentic, nerdy voice

### DIFF
--- a/Look-see-UI-v3/README.md
+++ b/Look-see-UI-v3/README.md
@@ -1,25 +1,21 @@
 # Look-see UI
 
-Look-see is an AI-powered UX audit platform that helps businesses improve their website accessibility and user experience. The platform automatically analyzes websites for visual design, information architecture, and content quality issues while ensuring WCAG 2.1 compliance.
+The Angular web interface for [Look-see](../README.md) — an open-source accessibility audit platform that reads your website the way a user does: in HTML, in rendered pixels, and across the journeys between pages.
 
-## What is Look-see?
+## What this is
 
-LookSee is a comprehensive UX audit tool that:
+This is the user-facing web app. It's what you open in your browser to start an audit, watch it run in real time over WebSocket, and read the results. The audits themselves are run by a fleet of Spring Boot services in sibling directories; this app just talks to them and surfaces what they find.
 
-- **Automatically audits websites** for UX issues using advanced AI
-- **Ensures WCAG 2.1 compliance** for accessibility standards
-- **Provides detailed reports** with actionable recommendations
-- **Tracks usability scores** over time to measure improvements
-- **Supports both single-page and full-site audits**
+For the full platform — services, deployment, architecture — see the [top-level README](../README.md).
 
-### Key Features
+### What it shows
 
-- **Visual Design Analysis**: Color palette, typography, whitespace, and branding evaluation
-- **Information Architecture**: SEO optimization, menu analysis, and performance assessment
-- **Content Quality**: Written content readability, imagery relevance, and media accessibility
-- **Real-time Updates**: Live progress tracking via WebSocket connections
-- **Export Capabilities**: Generate detailed reports in Excel format
-- **Team Collaboration**: Share results with stakeholders and team members
+- **Visual design** — contrast, typography, whitespace, and imagery, measured from rendered pixels
+- **Information architecture** — headings, forms, tables, links, landmarks, and metadata
+- **Content** — alt text quality, readability grade, and paragraph structure
+- **Journeys** — multi-step flows driven in a real headless browser
+- **Live progress** — scores update as each audit worker finishes, pushed over WebSocket
+- **Report export** — detailed issue lists in Excel
 
 ## Third-Party Services Configuration
 

--- a/Look-see-UI-v3/src/app/components/audit-onboarding/audit-onboarding.component.ts
+++ b/Look-see-UI-v3/src/app/components/audit-onboarding/audit-onboarding.component.ts
@@ -75,8 +75,8 @@ export class AuditOnboardingComponent implements OnInit, OnDestroy, OnChanges {
       icon: 'code'
     },
     {
-      title: 'AI-Powered Fix Suggestions',
-      description: 'For each issue, get intelligent recommendations and code snippets to resolve it quickly.',
+      title: 'Fix Suggestions',
+      description: 'Every issue comes with the WCAG success criterion it fails and a code-level recommendation — not just a red flag.',
       icon: 'sparkle'
     },
     {

--- a/Look-see-UI-v3/src/app/components/how-it-works/how-it-works.component.html
+++ b/Look-see-UI-v3/src/app/components/how-it-works/how-it-works.component.html
@@ -6,7 +6,7 @@
                 Improve your UX in 4 easy steps
             </h1>
             <p class="text-lg text-gray-500 max-w-2xl mx-auto">
-                Let our AI-powered platform analyze your website and deliver actionable UX recommendations.
+                Point Look-see at your site and it walks the pages a real visitor would — then reports the issues they'd hit.
             </p>
         </div>
 
@@ -38,7 +38,7 @@
                          class="h-24 object-contain"/>
                 </div>
                 <p class="text-sm text-gray-500">
-                    Give us a publicly facing URL and our AI examines every aspect of your website for UX issues.
+                    Give us a publicly facing URL. Look-see crawls the pages, renders them, and walks the journeys between them to surface UX and accessibility issues.
                 </p>
             </div>
 
@@ -115,7 +115,7 @@
                 <div class="flex-1">
                     <h2 class="text-2xl font-bold text-gray-900 mb-4">Visual Design</h2>
                     <p class="text-gray-600 leading-relaxed">
-                        Ensure your site is compliant with WCAG 2.1 visual guidelines with our advanced AI.
+                        Contrast, typography, and whitespace are measured from rendered pixels — not from stylesheet rules — so the page is checked against what a user actually sees.
                     </p>
                     <p class="text-gray-600 leading-relaxed mt-3">
                         Review color palette, whitespace, image quality, and how everything looks together to create more accessible user experiences.

--- a/Look-see-UI-v3/src/app/components/landing/landing.component.html
+++ b/Look-see-UI-v3/src/app/components/landing/landing.component.html
@@ -20,17 +20,17 @@
         <!-- Badge -->
         <div class="inline-flex items-center gap-2 px-3 py-1.5 rounded-full bg-white/10 border border-white/10 mb-8">
             <span class="w-2 h-2 rounded-full bg-brand-500 animate-pulse"></span>
-            <span class="text-xs font-medium text-white/80">AI-Powered Accessibility Audits</span>
+            <span class="text-xs font-medium text-white/80">Open source · Engineered in public · WCAG 2.2</span>
         </div>
 
         <!-- Headline -->
         <h1 class="text-5xl md:text-6xl font-semibold text-white text-center max-w-3xl leading-tight tracking-tight">
-            Find and fix accessibility issues
-            <span class="text-brand-400">in seconds</span>
+            Audit your website the way a user
+            <span class="text-brand-400">actually reads it.</span>
         </h1>
 
         <p class="mt-5 text-lg text-white/60 text-center max-w-xl leading-relaxed">
-            Enter any URL and get a comprehensive audit of accessibility, content quality, and visual design — with AI-powered fix suggestions.
+            In HTML, in rendered pixels, and across the journeys between pages. Paste a URL — Look-see walks the site like a real visitor and tells you where it falls apart.
         </p>
 
         <!-- URL Input Form -->
@@ -81,8 +81,8 @@
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"/>
                     </svg>
                 </div>
-                <h3 class="text-sm font-semibold text-white mb-1">Visual Issues</h3>
-                <p class="text-xs text-white/50 leading-relaxed">See issues pinpointed directly on your page screenshot</p>
+                <h3 class="text-sm font-semibold text-white mb-1">Rendered pixels</h3>
+                <p class="text-xs text-white/50 leading-relaxed">Contrast, typography, and whitespace measured from what actually paints on screen — not from CSS rules that may be overridden.</p>
             </div>
             <div class="text-center">
                 <div class="w-10 h-10 rounded-xl bg-white/10 flex items-center justify-center mx-auto mb-3">
@@ -90,8 +90,8 @@
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z"/>
                     </svg>
                 </div>
-                <h3 class="text-sm font-semibold text-white mb-1">AI Fix Suggestions</h3>
-                <p class="text-xs text-white/50 leading-relaxed">Get intelligent recommendations to resolve each issue</p>
+                <h3 class="text-sm font-semibold text-white mb-1">Real user journeys</h3>
+                <p class="text-xs text-white/50 leading-relaxed">A headless browser drives login, checkout, and search — catching issues only visible mid-flow, not on the landing page.</p>
             </div>
             <div class="text-center">
                 <div class="w-10 h-10 rounded-xl bg-white/10 flex items-center justify-center mx-auto mb-3">
@@ -99,14 +99,14 @@
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 10v6m0 0l-3-3m3 3l3-3m2 8H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"/>
                     </svg>
                 </div>
-                <h3 class="text-sm font-semibold text-white mb-1">PDF Reports</h3>
-                <p class="text-xs text-white/50 leading-relaxed">Export detailed reports with issues and recommendations</p>
+                <h3 class="text-sm font-semibold text-white mb-1">Explanations that teach</h3>
+                <p class="text-xs text-white/50 leading-relaxed">Every violation comes with the WCAG success criterion it fails and a plain-English reason it matters — not just a red flag.</p>
             </div>
         </div>
     </main>
 
     <!-- Footer -->
     <footer class="px-8 py-5 text-center">
-        <p class="text-xs text-white/30">WCAG 2.1 compliant auditing for content, accessibility, and visual design</p>
+        <p class="text-xs text-white/30">Open source, engineered in public, built to be looked at.</p>
     </footer>
 </div>

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 <h1 align="center">Look-see — Automated WCAG 2.2 Accessibility Audit Platform</h1>
 
 <p align="center">
-  <strong>Find, fix, and prove every accessibility issue on your website — from color contrast to keyboard journeys — with one open-source platform.</strong>
+  <strong>Look-see reads your website the way a user does — in HTML, in rendered pixels, and across the journeys between pages. Then it tells you where it falls apart.</strong>
 </p>
 
 <p align="center">
@@ -32,7 +32,7 @@
 </p>
 
 <p align="center">
-  <img src="Look-see-UI-v3/src/assets/Banner_1.png" alt="Look-see — stay on trend, stay on brand, stay ahead. Accessibility score dashboard screenshot." />
+  <img src="Look-see-UI-v3/src/assets/Banner_1.png" alt="Look-see dashboard showing content, visual design, information architecture, and journey scores from a live audit." />
   <!-- TODO(design): replace with a bespoke a11y-superhero hero image pairing the Look-see logo with WCAG category icons. -->
 </p>
 
@@ -49,23 +49,29 @@
 
 ## What is Look-see?
 
-**Look-see is an open-source accessibility audit platform** that continuously crawls your website, drives it in a real headless browser, and grades every page against **WCAG 2.2 / 2.1 AA**, **ADA**, **Section 508**, and **EN 301 549**. Unlike one-page scanners, Look-see follows real user journeys — clicking, navigating, and validating end-to-end flows — so the issues it reports are the ones your users actually hit.
+**Look-see is an open-source accessibility audit platform.** It crawls your site, drives it in a real headless browser, and grades every page against **WCAG 2.2 / 2.1 AA**, **ADA**, **Section 508**, and **EN 301 549**. Unlike one-page scanners, it follows the journeys users actually take — clicking, navigating, and validating end-to-end flows — so the issues it reports are the ones a real visitor would hit.
 
-It ships as a monorepo of small services: a crawler API, a page builder, four specialized audit workers (content, visual design, information architecture, journeys), an Angular UI, a Chrome extension, and a VS Code extension for real-time feedback in your editor.
+Under the hood it's a monorepo of small services: a crawler API, a page builder, four specialized audit workers (content, visual design, information architecture, journeys), an Angular UI, a Chrome extension, and a VS Code extension for real-time feedback in your editor. They trade work over Google Cloud Pub/Sub and describe the site in a Neo4j graph.
 
-A hosted commercial version is coming to [**look-see.com**](https://deepthought42.github.io/Accessibility-audit-platform/) — self-host in the meantime with the instructions below.
+## Where we are
 
-## Why teams choose Look-see
+Look-see is **engineered in public** and isn't 1.0 yet. The services below are real and runnable, but the project is still being stitched together — not a polished hosted product. Expect rough edges, roadmap items that are sketched before they're wired up, and docs that occasionally describe intent before they describe reality.
 
-- 🎯 **Comprehensive WCAG 2.2 coverage** — not just a quick scan. Covers perceivable, operable, understandable, and robust success criteria across every page and journey.
-- 🧭 **Journey-aware, not page-aware** — drives multi-step flows (login, checkout, search) in a real browser and catches issues only visible mid-flow.
-- 🎨 **Dedicated visual-design audits** — color contrast (AA/AAA), typography scale, imagery quality, whitespace, and brand consistency.
-- ✍️ **Content audits** — alt text quality, readability grade, paragraph structure, and plain-language checks powered by Google Cloud NLP.
-- 🏗️ **Information architecture audits** — heading hierarchy, landmarks, table semantics, form labels, link text, and metadata.
-- ⚡ **Live audit progress** — see scores update in real time via WebSocket as workers finish.
-- 🧩 **Meet developers where they work** — Chrome extension, VS Code extension, and an Angular dashboard.
-- 🔓 **MIT-licensed and self-hostable** — your data never leaves your cloud. One `terraform apply` on GCP.
-- 🧠 **Graph-native** — built on Neo4j so relationships between pages, elements, journeys, and issues are first-class.
+For the current cadence, skim the [commits](https://github.com/deepthought42/Accessibility-audit-platform/commits/main) and [open issues](https://github.com/deepthought42/Accessibility-audit-platform/issues). A hosted version at [look-see.com](https://deepthought42.github.io/Accessibility-audit-platform/) is planned but not live; self-hosting is the supported path today.
+
+If that sounds more interesting than it sounds like a warning, you're in the right place. PRs welcome. Bug reports from real websites especially welcome.
+
+## Why it's unusual
+
+**It looks at pixels, not only at HTML.** Most accessibility tools parse the DOM and stop there. Look-see also renders the page and audits the output a user actually sees — contrast measured from the paint on screen, not from stylesheet rules that may be overridden. A page can pass every rule-based checker and still be unreadable: light grey on white, a font that computed to 10px, a button that vanishes below a sticky banner. The visual-design service sees what a user sees.
+
+**It audits journeys, not just URLs.** Modern applications are state machines. Auditing the landing page is like inspecting a theatre by its lobby. Look-see discovers interactive elements, drives a real headless browser through them, and audits the states you only reach by clicking — mid-login, mid-checkout, mid-search.
+
+**It's a graph, not a list.** The site is stored in Neo4j, so pages, elements, journeys, and issues relate the way they actually do in a product. Ask it "which heading hierarchy violations affect which user journeys?" and it has an answer, not a spreadsheet.
+
+**It meets developers where they work.** Chrome extension, VS Code extension, Angular dashboard — the same audit data, three surfaces. Live scores arrive over WebSocket as workers finish, so you watch the audit happen instead of waiting for a PDF.
+
+**It's MIT-licensed and self-hostable.** One `terraform apply` on GCP and your data never leaves your cloud. That matters for compliance teams and for anyone who's been burned by a vendor rug-pull.
 
 ## What Look-see audits
 


### PR DESCRIPTION
Align the README, Angular landing page, and supporting component copy
with the literary voice already established in docs/index.html, and
trim SaaS boilerplate from surfaces that didn't match.

- README: replace brochure hero with a line that has a point of view,
  swap "Why teams choose" emoji-bullet grid for an opinionated
  "Why it's unusual" prose section, and add a "Where we are" section
  that owns the pre-1.0 status honestly.
- Landing: retire the "AI-Powered Accessibility Audits" badge and
  "in seconds" headline; feature cards now describe what makes the
  platform unusual (rendered pixels, real journeys, teaching
  explanations) instead of generic outputs.
- how-it-works + audit-onboarding: remove "AI-powered" / "advanced AI"
  buzzwords in favor of specific descriptions of what the software
  actually does.
- Look-see-UI-v3/README: rewrite as a dev-facing intro that points to
  the top-level README, without the "AI-powered UX platform" framing.