### PR TITLE
Phase 4a.5: PageBuilder staging cutover (code/config, no flip)

### DIFF
--- a/LookseeIaC/GCP/modules.tf
+++ b/LookseeIaC/GCP/modules.tf
@@ -242,6 +242,17 @@ module "page_builder_cloud_run" {
     } : {},
   )
 
+  # Phase-4 cutover env vars (plain, not from Secret Manager). Defaults keep
+  # mode=local + smoke-check off, so this block is inert until the staging
+  # tfvars flip mode=remote. See browser-service/phase-4a5-pagebuilder-staging-cutover.md.
+  plain_environment_variables = {
+    "LOOKSEE_BROWSING_MODE"                   = var.looksee_browsing_mode
+    "LOOKSEE_BROWSING_SERVICE_URL"            = var.looksee_browsing_service_url
+    "LOOKSEE_BROWSING_SMOKE_CHECK_ENABLED"    = tostring(var.page_builder_smoke_check_enabled)
+    "LOOKSEE_BROWSING_SMOKE_CHECK_INTERVAL"   = var.looksee_browsing_smoke_check_interval
+    "LOOKSEE_BROWSING_SMOKE_CHECK_TARGET_URL" = var.looksee_browsing_smoke_check_target_url
+  }
+
   vpc_connector_name = module.vpc.vpc_connector_name
   vpc_egress         = "private-ranges-only"
   selenium_urls      = local.selenium_urls

--- a/LookseeIaC/GCP/modules/cloud_run/main.tf
+++ b/LookseeIaC/GCP/modules/cloud_run/main.tf
@@ -51,6 +51,15 @@ resource "google_cloud_run_service" "service" {
           }
         }
 
+        # Plain (non-secret) environment variables
+        dynamic "env" {
+          for_each = var.plain_environment_variables
+          content {
+            name  = env.key
+            value = env.value
+          }
+        }
+
         # ----------------------------------------------------------------
         # Observability defaults (Wave 2 of architecture review)
         # Enable Stackdriver metric export and OpenTelemetry tracing for

--- a/LookseeIaC/GCP/modules/cloud_run/variables.tf
+++ b/LookseeIaC/GCP/modules/cloud_run/variables.tf
@@ -81,8 +81,14 @@ variable "cpu_limit" {
 }
 
 variable "environment_variables" {
-  description = "Map of environment variables to set"
+  description = "Map of environment variables sourced from Secret Manager. Value is [secret_name, version]."
   type        = map(list(string))
+  default     = {}
+}
+
+variable "plain_environment_variables" {
+  description = "Map of plain (non-secret) environment variables. Use environment_variables for secret references."
+  type        = map(string)
   default     = {}
 }
 

--- a/LookseeIaC/GCP/variables.tf
+++ b/LookseeIaC/GCP/variables.tf
@@ -249,6 +249,50 @@ variable "information_architecture_audit_image" {
 }
 
 #########################
+# LookseeCore browsing (phase-4 cutover to brandonkindred/browser-service)
+#########################
+# Single-source-of-truth for all browser-using consumers' mode. Rolling back
+# the phase-4 cutover is one variable edit, not a coordinated change across
+# every consumer module. See browser-service/phase-4-consumer-cutover.md.
+
+variable "looksee_browsing_mode" {
+  description = "looksee.browsing.mode for all browser-using consumers. 'local' = in-process Selenium (current default); 'remote' = route through browser-service."
+  type        = string
+  default     = "local"
+  validation {
+    condition     = contains(["local", "remote"], var.looksee_browsing_mode)
+    error_message = "looksee_browsing_mode must be 'local' or 'remote'."
+  }
+}
+
+variable "looksee_browsing_service_url" {
+  description = "Endpoint for browser-service when looksee_browsing_mode = 'remote'. Empty when mode = 'local'."
+  type        = string
+  default     = ""
+}
+
+# Smoke-check is per-consumer to allow staged rollout — each consumer's
+# 48-hour burn-in is observed independently. See phase-4a5 plan doc.
+
+variable "page_builder_smoke_check_enabled" {
+  description = "Enables the CapturePageSmokeCheck watchdog in PageBuilder."
+  type        = bool
+  default     = false
+}
+
+variable "looksee_browsing_smoke_check_interval" {
+  description = "Smoke-check probe interval (Spring Duration string, e.g. '60s', '5m')."
+  type        = string
+  default     = "60s"
+}
+
+variable "looksee_browsing_smoke_check_target_url" {
+  description = "Smoke-check target URL. The metric measures the BrowsingClient round-trip, not the page itself."
+  type        = string
+  default     = "https://example.com"
+}
+
+#########################
 # VPC
 #########################
 

--- a/PageBuilder/src/main/resources/application.yml
+++ b/PageBuilder/src/main/resources/application.yml
@@ -68,3 +68,8 @@ looksee:
         service-url: ${LOOKSEE_BROWSING_SERVICE_URL:}
         connect-timeout: ${LOOKSEE_BROWSING_CONNECT_TIMEOUT:5s}
         read-timeout: ${LOOKSEE_BROWSING_READ_TIMEOUT:120s}
+        smoke-check:
+            enabled: ${LOOKSEE_BROWSING_SMOKE_CHECK_ENABLED:false}
+            interval: ${LOOKSEE_BROWSING_SMOKE_CHECK_INTERVAL:60s}
+            target-url: ${LOOKSEE_BROWSING_SMOKE_CHECK_TARGET_URL:https://example.com}
+            browser: ${LOOKSEE_BROWSING_SMOKE_CHECK_BROWSER:CHROME}


### PR DESCRIPTION
## Summary

Implements Commits 1 and 2 of the [phase-4a.5 plan](https://github.com/brandonkindred/Look-see/blob/main/browser-service/phase-4a5-pagebuilder-staging-cutover.md). Inert until the staging tfvars flip.

- **PageBuilder** `application.yml` — bind `LOOKSEE_BROWSING_SMOKE_CHECK_*` env vars. Defaults match LookseeCore so unset = today's behavior.
- **LookseeIaC** — five new tfvars (one shared `looksee_browsing_mode` for one-edit rollback; per-consumer `page_builder_smoke_check_enabled` for independent burn-in). Wired into the page-builder Cloud Run module.
- **LookseeIaC `cloud_run` module** — extended with a new `plain_environment_variables` parameter for non-secret env vars. The existing `environment_variables` map is for Secret Manager refs (rendered via `secret_key_ref`); plain key/value vars need a different `env` block shape.

**Commit 3 (the actual staging tfvars flip) is intentionally NOT in this PR.** That's an operational step the user runs once browser-service-staging is confirmed reachable — it triggers the 48-hour burn-in and shouldn't be merged speculatively. The plan doc enumerates the three tfvars to set; once ready, set them in the staging-only override location and `terraform apply`.

After this PR merges and Commit 3 is applied, LookseeCore-side phase-4 prep is complete. Remaining 4a.6/4b/4c work is gated on burn-in success + browser-service deployment.

## Test plan

- [x] PageBuilder compiles cleanly (`mvn compile` → BUILD SUCCESS)
- [ ] `terraform plan` against any environment shows env vars added to the page-builder Cloud Run revision; non-staging environments show no behavior diff because of `local`/`false`/`""` defaults
- [ ] `terraform plan` against staging (after Commit 3) shows `LOOKSEE_BROWSING_MODE` flipping `local → remote` plus the smoke-check vars
- [ ] After Commit 3 + apply: PageBuilder Cloud Run staging revision boot log shows `CapturePageSmokeCheck started: interval=60000ms target=https://example.com`
- [ ] Dashboard renders `browser_service_smoke_checks{outcome=success,consumer=page-builder}` ticking once per 60s
- [ ] 48-hour burn-in passes the criteria in the plan doc (error rate <1%, p95 within 2× baseline, no Sentry regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)