### PR TITLE
feat(persistence): atomic IdempotencyService.claim via Cypher MERGE (#81)

### DIFF
--- a/LookseeCore/looksee-messaging/src/main/java/com/looksee/messaging/idempotency/IdempotencyGuard.java
+++ b/LookseeCore/looksee-messaging/src/main/java/com/looksee/messaging/idempotency/IdempotencyGuard.java
@@ -31,4 +31,33 @@ public interface IdempotencyGuard {
      * must not throw on persistence failures (de-duplication is best-effort).
      */
     void markProcessed(String pubsubMessageId, String serviceName);
+
+    /**
+     * Atomically claims the given Pub/Sub messageId for the named service.
+     *
+     * <p>Returns {@code true} iff this caller is the first to claim it; subsequent
+     * calls with the same {@code (pubsubMessageId, serviceName)} pair return
+     * {@code false}. This collapses the legacy
+     * {@link #isAlreadyProcessed}/{@link #markProcessed} pair into a single
+     * operation, eliminating the TOCTOU window where two concurrent deliveries
+     * both see "not processed" and both proceed.
+     *
+     * <p>Implementations that cannot dedupe (e.g. repository unavailable, or
+     * null/empty messageId) must return {@code true} so the caller falls
+     * through to normal processing — same fail-open semantics as the legacy
+     * pair, just expressed in the opposite direction.
+     *
+     * <p>The default implementation here delegates to the legacy pair so any
+     * existing {@link IdempotencyGuard} implementor keeps compiling. The
+     * production implementation in {@code IdempotencyService} overrides this
+     * with a single Cypher {@code MERGE} backed by the Neo4j uniqueness
+     * constraint on {@code (pubsubMessageId, serviceName)}.
+     */
+    default boolean claim(String pubsubMessageId, String serviceName) {
+        if (isAlreadyProcessed(pubsubMessageId, serviceName)) {
+            return false;
+        }
+        markProcessed(pubsubMessageId, serviceName);
+        return true;
+    }
 }

--- a/LookseeCore/looksee-persistence/src/main/java/com/looksee/models/repository/ProcessedMessageRepository.java
+++ b/LookseeCore/looksee-persistence/src/main/java/com/looksee/models/repository/ProcessedMessageRepository.java
@@ -33,4 +33,28 @@ public interface ProcessedMessageRepository extends Neo4jRepository<ProcessedMes
      */
     @Query("MATCH (pm:ProcessedMessage) WHERE pm.processedAt < datetime() - duration({days: $days}) DETACH DELETE pm")
     void deleteOlderThan(@Param("days") int days);
+
+    /**
+     * Atomically claims a {@code (pubsubMessageId, serviceName)} pair via a
+     * single Cypher {@code MERGE}. Returns {@code true} iff this call created
+     * the node; {@code false} if it already existed.
+     *
+     * <p>Backed by the {@code processed_message_unique} constraint
+     * (migration {@code V002}) so two concurrent claims for the same key are
+     * physically serialized by Neo4j — there is no TOCTOU window the way
+     * {@link #existsByPubsubMessageIdAndServiceName} + {@code save(...)} had.
+     *
+     * @param pubsubMessageId the PubSub envelope message ID
+     * @param serviceName the name of the service claiming the message
+     * @return true if this call created the record, false if it already existed
+     */
+    @Query("""
+        MERGE (pm:ProcessedMessage {pubsubMessageId: $pubsubMessageId, serviceName: $serviceName})
+        ON CREATE SET pm.processedAt = datetime(), pm.status = 'PROCESSED', pm.justCreated = true
+        ON MATCH  SET pm.justCreated = false
+        RETURN pm.justCreated AS claimed
+        """)
+    boolean claim(
+        @Param("pubsubMessageId") String pubsubMessageId,
+        @Param("serviceName") String serviceName);
 }

--- a/LookseeCore/looksee-persistence/src/main/java/com/looksee/services/IdempotencyService.java
+++ b/LookseeCore/looksee-persistence/src/main/java/com/looksee/services/IdempotencyService.java
@@ -81,6 +81,39 @@ public class IdempotencyService implements IdempotencyGuard {
     }
 
     /**
+     * Atomically claims this {@code (pubsubMessageId, serviceName)} pair for processing.
+     *
+     * <p>Backed by a single Cypher {@code MERGE} against the {@code ProcessedMessage}
+     * uniqueness constraint (migration V002). Two concurrent calls with the same key
+     * are physically serialized by Neo4j; exactly one returns {@code true}.
+     *
+     * <p>Returns {@code true} when the caller should proceed with processing.
+     * In the fail-open paths (null repository, null/empty messageId) returns
+     * {@code true} as well so callers behave like before — same effect as the
+     * legacy {@link #isAlreadyProcessed} returning {@code false}.
+     */
+    @Override
+    public boolean claim(String pubsubMessageId, String serviceName) {
+        if (processedMessageRepository == null || pubsubMessageId == null || pubsubMessageId.isEmpty()) {
+            return true;
+        }
+
+        try {
+            boolean firstClaim = processedMessageRepository.claim(pubsubMessageId, serviceName);
+            if (!firstClaim) {
+                log.info("Duplicate message detected via claim(): pubsubMessageId={} service={}", pubsubMessageId, serviceName);
+            } else {
+                log.debug("Claimed message: pubsubMessageId={} service={}", pubsubMessageId, serviceName);
+            }
+            return firstClaim;
+        } catch (Exception e) {
+            log.warn("claim() failed; falling back to allow processing (at-least-once): pubsubMessageId={} service={}",
+                    pubsubMessageId, serviceName, e);
+            return true;
+        }
+    }
+
+    /**
      * Cleans up old processed message records. Runs daily at 3 AM.
      */
     @Scheduled(cron = "0 0 3 * * ?")

--- a/LookseeCore/looksee-persistence/src/test/java/com/looksee/models/repository/ProcessedMessageRepositoryTest.java
+++ b/LookseeCore/looksee-persistence/src/test/java/com/looksee/models/repository/ProcessedMessageRepositoryTest.java
@@ -125,6 +125,32 @@ class ProcessedMessageRepositoryTest {
     }
 
     @Test
+    @DisplayName("claim returns true on first call and false on subsequent calls")
+    void claim_returnsTrueThenFalse() {
+        when(repository.claim(MSG_ID, SERVICE_NAME))
+                .thenReturn(true)
+                .thenReturn(false);
+
+        assertTrue(repository.claim(MSG_ID, SERVICE_NAME),
+                "First claim must return true (just created)");
+        assertFalse(repository.claim(MSG_ID, SERVICE_NAME),
+                "Second claim must return false (already exists)");
+        verify(repository, times(2)).claim(MSG_ID, SERVICE_NAME);
+    }
+
+    @Test
+    @DisplayName("claim differentiates by service name")
+    void claim_differentiatesByServiceName() {
+        when(repository.claim(MSG_ID, "page-builder")).thenReturn(true);
+        when(repository.claim(MSG_ID, SERVICE_NAME)).thenReturn(true);
+
+        assertTrue(repository.claim(MSG_ID, "page-builder"),
+                "Same messageId for a different service should still claim");
+        assertTrue(repository.claim(MSG_ID, SERVICE_NAME),
+                "Same messageId for this service first time should claim");
+    }
+
+    @Test
     @DisplayName("ProcessedMessage constructor sets fields correctly")
     void processedMessageConstructor_setsFieldsCorrectly() {
         LocalDateTime before = LocalDateTime.now();

--- a/LookseeCore/looksee-persistence/src/test/java/com/looksee/services/IdempotencyServiceTest.java
+++ b/LookseeCore/looksee-persistence/src/test/java/com/looksee/services/IdempotencyServiceTest.java
@@ -115,4 +115,48 @@ class IdempotencyServiceTest {
         idempotencyService.markProcessed("", "svc-j");
         verifyNoInteractions(processedMessageRepository);
     }
+
+    @Test
+    void claim_returnsTrueOnFirstCall() {
+        when(processedMessageRepository.claim("msg-claim-1", "svc-k")).thenReturn(true);
+
+        assertTrue(idempotencyService.claim("msg-claim-1", "svc-k"));
+        verify(processedMessageRepository).claim("msg-claim-1", "svc-k");
+    }
+
+    @Test
+    void claim_returnsFalseOnDuplicate() {
+        when(processedMessageRepository.claim("msg-claim-2", "svc-l")).thenReturn(false);
+
+        assertFalse(idempotencyService.claim("msg-claim-2", "svc-l"));
+        verify(processedMessageRepository).claim("msg-claim-2", "svc-l");
+    }
+
+    @Test
+    void claim_returnsTrueWhenRepositoryIsNull() {
+        IdempotencyService serviceWithNullRepo = new IdempotencyService();
+        // Fail-open: cannot dedupe → caller must process
+        assertTrue(serviceWithNullRepo.claim("msg-claim-3", "svc-m"));
+    }
+
+    @Test
+    void claim_returnsTrueForNullPubsubMessageId() {
+        assertTrue(idempotencyService.claim(null, "svc-n"));
+        verifyNoInteractions(processedMessageRepository);
+    }
+
+    @Test
+    void claim_returnsTrueForEmptyPubsubMessageId() {
+        assertTrue(idempotencyService.claim("", "svc-o"));
+        verifyNoInteractions(processedMessageRepository);
+    }
+
+    @Test
+    void claim_failsOpenOnRepositoryException() {
+        when(processedMessageRepository.claim(eq("msg-claim-4"), eq("svc-p")))
+                .thenThrow(new RuntimeException("Neo4j unreachable"));
+
+        // Fail-open: at-least-once is preferable to silently dropping the message
+        assertTrue(idempotencyService.claim("msg-claim-4", "svc-p"));
+    }
 }


### PR DESCRIPTION
## Summary

Closes #81. Step 2 of the #28 atomic-idempotency rollout.

Collapses the legacy `isAlreadyProcessed` + `markProcessed` pair into a single atomic `claim(pubsubMessageId, serviceName)`, backed by a Cypher `MERGE` against the `processed_message_unique` constraint added in V002 (neo4j-migrations from #80). Two concurrent claims for the same key are now physically serialized by Neo4j; exactly one returns `true`.

## Changes

- **`IdempotencyGuard`** — `claim()` added as a `default` method that delegates to the legacy pair, so every existing implementor keeps compiling without edits.
- **`IdempotencyService`** — overrides with a single repository call. Fail-open on null repository / null/empty messageId / repo exception so the caller still processes (same effective behavior as legacy fall-through, just expressed in the opposite direction).
- **`ProcessedMessageRepository`** — `claim()` `@Query` MERGEs and returns the just-created flag via `ON CREATE SET pm.justCreated = true / ON MATCH SET pm.justCreated = false`.
- **Tests**
  - `IdempotencyServiceTest` 12 → 18 (+6): claim happy/duplicate/null-repo/null-id/empty-id/repo-exception fail-open.
  - `ProcessedMessageRepositoryTest` 7 → 9 (+2): true-then-false sequence, service-name discrimination.

Legacy `isAlreadyProcessed` / `markProcessed` are kept untouched. Migrating `PubSubAuditController` to call `claim()` is sub-issue #82; full concurrency + integration tests come in #87.

## Test plan

- [x] `mvn -pl looksee-persistence,looksee-messaging -am verify` — **BUILD SUCCESS**
- [x] No regressions: every previously-passing test still passes
- [x] `IdempotencyServiceTest` and `ProcessedMessageRepositoryTest` show the expected new test counts
- [ ] (later, in #87) 100-thread concurrency proof against a real Neo4j confirms the constraint serializes claims
- [ ] (later, in #87) two-replica integration test against Pub/Sub emulator

---
_Generated by [Claude Code](https://claude.ai/code/session_01J9N9rpoHdWxGgHvQx1252X)_