### PR TITLE
refactor(auditManager): extend PubSubAuditController; drop in-memory dedupe

### DIFF
--- a/AuditManager/pom.xml
+++ b/AuditManager/pom.xml
@@ -114,6 +114,12 @@
             <artifactId>A11yCore</artifactId>
             <version>${core.version}</version>
         </dependency>
+
+		<dependency>
+            <groupId>com.looksee</groupId>
+            <artifactId>A11yMessaging</artifactId>
+            <version>${core.version}</version>
+        </dependency>
 	</dependencies>
 
 	<build>

--- a/AuditManager/src/main/java/com/looksee/auditManager/AuditController.java
+++ b/AuditManager/src/main/java/com/looksee/auditManager/AuditController.java
@@ -1,188 +1,87 @@
 package com.looksee.auditManager;
 
-import java.nio.charset.StandardCharsets;
-import java.util.Base64;
 import java.util.HashSet;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
-import java.util.concurrent.ExecutionException;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
-import org.springframework.transaction.annotation.Transactional;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.looksee.models.config.JacksonConfig;
 import com.looksee.gcp.PubSubPageAuditPublisherImpl;
-import com.looksee.mapper.Body;
+import com.looksee.messaging.web.PubSubAuditController;
 import com.looksee.models.PageState;
 import com.looksee.models.audit.AuditRecord;
 import com.looksee.models.audit.DomainAuditRecord;
 import com.looksee.models.audit.PageAuditRecord;
+import com.looksee.models.config.JacksonConfig;
 import com.looksee.models.enums.AuditName;
 import com.looksee.models.enums.ExecutionStatus;
 import com.looksee.models.message.PageAuditMessage;
 import com.looksee.models.message.PageBuiltMessage;
 import com.looksee.services.AuditRecordService;
-import com.looksee.services.IdempotencyService;
 import com.looksee.services.PageStateService;
 
 /**
- * REST controller that receives page-built notifications from Google Cloud
- * Pub/Sub and orchestrates the creation of page audit records.
- *
- * <h3>Contract</h3>
- * <ul>
- *   <li><b>Precondition:</b> All constructor dependencies must be non-null.</li>
- *   <li><b>Postcondition:</b> Every HTTP response uses the correct status code
- *       ({@code 200}, {@code 400}, or {@code 500}) and includes a human-readable
- *       body describing the outcome.</li>
- *   <li><b>Invariant:</b> A page is never audited more than once within the
- *       same domain audit, and only landable pages with a persisted
- *       {@link PageState} are eligible for auditing.</li>
- * </ul>
+ * Pub/Sub controller that turns a {@link PageBuiltMessage} into a persisted
+ * {@link PageAuditRecord} and forwards a {@link PageAuditMessage} to the
+ * page-audit topic. Envelope validation, base64 decode, atomic idempotency
+ * claim, trace-context propagation and metrics emission are inherited from
+ * {@link PubSubAuditController}; this subclass only owns the per-service
+ * eligibility and persistence logic in {@link #handle(PageBuiltMessage)}.
  */
 @RestController
-public class AuditController {
+public class AuditController extends PubSubAuditController<PageBuiltMessage> {
+
 	private static final Logger log = LoggerFactory.getLogger(AuditController.class);
 
-	private final AuditRecordService auditRecordService;
-	private final PubSubPageAuditPublisherImpl auditRecordTopic;
-	private final PageStateService pageStateService;
-	private final IdempotencyService idempotencyService;
+	@Autowired
+	private AuditRecordService auditRecordService;
 
-	/**
-	 * Creates a new {@code AuditController}.
-	 *
-	 * @param auditRecordService service for persisting and querying audit records; must not be {@code null}
-	 * @param auditRecordTopic   Pub/Sub publisher for page-audit messages; must not be {@code null}
-	 * @param pageStateService   service for querying page state and landability; must not be {@code null}
-	 * @param idempotencyService service for deduplicating Pub/Sub messages; must not be {@code null}
-	 * @throws NullPointerException if any argument is {@code null}
-	 */
-	public AuditController(
-		AuditRecordService auditRecordService,
-		PubSubPageAuditPublisherImpl auditRecordTopic,
-		PageStateService pageStateService,
-		IdempotencyService idempotencyService) {
-		this.auditRecordService = Objects.requireNonNull(auditRecordService, "auditRecordService must not be null");
-		this.auditRecordTopic = Objects.requireNonNull(auditRecordTopic, "auditRecordTopic must not be null");
-		this.pageStateService = Objects.requireNonNull(pageStateService, "pageStateService must not be null");
-		this.idempotencyService = Objects.requireNonNull(idempotencyService, "idempotencyService must not be null");
+	@Autowired
+	private PubSubPageAuditPublisherImpl auditRecordTopic;
+
+	@Autowired
+	private PageStateService pageStateService;
+
+	@Override
+	protected String serviceName() {
+		return "audit-manager";
 	}
 
-	/**
-	 * Receives a Base64-encoded {@link PageBuiltMessage} wrapped in a Pub/Sub
-	 * {@link Body} and, when eligible, creates a {@link PageAuditRecord} and
-	 * publishes a {@link PageAuditMessage}.
-	 *
-	 * <h4>Contract</h4>
-	 * <ul>
-	 *   <li><b>Precondition:</b> {@code body} contains a non-null message with
-	 *       non-empty, valid Base64 data that deserializes to a
-	 *       {@link PageBuiltMessage}.</li>
-	 *   <li><b>Postcondition (success):</b> Returns {@code 200 OK}. If the page
-	 *       was eligible, a new audit record has been persisted and a message
-	 *       published to Pub/Sub.</li>
-	 *   <li><b>Postcondition (client error):</b> Returns {@code 400 Bad Request}
-	 *       when preconditions are violated.</li>
-	 *   <li><b>Postcondition (server error):</b> Returns {@code 500} when an
-	 *       unexpected or infrastructure error occurs.</li>
-	 * </ul>
-	 *
-	 * @param body the Pub/Sub push message envelope
-	 * @return a {@link ResponseEntity} indicating the processing outcome
-	 */
-	@RequestMapping(value = "/", method = RequestMethod.POST)
-	public ResponseEntity<String> receiveMessage(@RequestBody Body body) {
-		if (!hasValidPayload(body)) {
-			log.warn("Received invalid Pub/Sub payload: message or data is missing");
-			return ResponseEntity.ok("Acknowledged invalid Pub/Sub payload");
-		}
-
-		String pubsubMessageId = body.getMessage().getMessageId();
-		if (idempotencyService.isAlreadyProcessed(pubsubMessageId, "audit-manager")) {
-			return ResponseEntity.ok("Duplicate message, already processed");
-		}
-
-		String payload = decodePayload(body.getMessage().getData());
-		if (payload == null) {
-			return ResponseEntity.ok("Acknowledged invalid message encoding");
-		}
-
-		PageBuiltMessage pageBuiltMessage = parseMessage(payload);
-		if (pageBuiltMessage == null) {
-			return ResponseEntity.ok("Acknowledged invalid message format");
-		}
-
-		return processMessage(pageBuiltMessage, pubsubMessageId);
+	@Override
+	protected String topicName() {
+		return "page_built";
 	}
 
-	/**
-	 * Determines whether a page is eligible for auditing and, if so, creates
-	 * and publishes the audit record.
-	 *
-	 * @param pageBuiltMessage the validated message; must not be {@code null}
-	 * @return {@code 200 OK} on success, {@code 500} on infrastructure failure
-	 */
-	private ResponseEntity<String> processMessage(PageBuiltMessage pageBuiltMessage, String pubsubMessageId) {
-		assert pageBuiltMessage != null : "pageBuiltMessage must not be null at this point";
+	@Override
+	protected Class<PageBuiltMessage> payloadType() {
+		return PageBuiltMessage.class;
+	}
 
-		try {
-			Set<AuditName> auditNames = buildAuditNames(pageBuiltMessage.getAuditRecordId());
+	@Override
+	protected void handle(PageBuiltMessage pageBuiltMessage) throws Exception {
+		Set<AuditName> auditNames = buildAuditNames(pageBuiltMessage.getAuditRecordId());
 
-			boolean alreadyAudited = auditRecordService.wasPageAlreadyAudited(pageBuiltMessage.getAuditRecordId(), pageBuiltMessage.getPageId());
-			boolean isLandable = pageStateService.isPageLandable(pageBuiltMessage.getPageId());
-			Optional<PageState> pageState = pageStateService.findById(pageBuiltMessage.getPageId());
+		boolean alreadyAudited = auditRecordService.wasPageAlreadyAudited(
+			pageBuiltMessage.getAuditRecordId(), pageBuiltMessage.getPageId());
+		boolean isLandable = pageStateService.isPageLandable(pageBuiltMessage.getPageId());
+		Optional<PageState> pageState = pageStateService.findById(pageBuiltMessage.getPageId());
 
-			if (!alreadyAudited && isLandable && pageState.isPresent()) {
-				return createAndPublishAudit(pageBuiltMessage, pageState.get(), auditNames, pubsubMessageId);
-			}
-
+		if (alreadyAudited || !isLandable || pageState.isEmpty()) {
 			log.info("Skipping pageId={} (alreadyAudited={}, landable={}, pageStatePresent={})",
 				pageBuiltMessage.getPageId(), alreadyAudited, isLandable, pageState.isPresent());
-			idempotencyService.markProcessed(pubsubMessageId, "audit-manager");
-			return ResponseEntity.ok("Successfully processed message");
-		} catch (InterruptedException e) {
-			Thread.currentThread().interrupt();
-			log.error("Audit processing interrupted", e);
-			return new ResponseEntity<>("Audit processing interrupted", HttpStatus.INTERNAL_SERVER_ERROR);
-		} catch (ExecutionException e) {
-			log.error("Error publishing audit message", e);
-			return new ResponseEntity<>("Failed to process message", HttpStatus.INTERNAL_SERVER_ERROR);
-		} catch (Exception e) {
-			log.error("Unexpected error while handling PageBuiltMessage", e);
-			return new ResponseEntity<>("Failed to process message", HttpStatus.INTERNAL_SERVER_ERROR);
+			return;
 		}
+
+		createAndPublishAudit(pageBuiltMessage, pageState.get(), auditNames);
 	}
 
-	/**
-	 * Creates a {@link PageAuditRecord}, persists it, links it to the parent
-	 * domain audit, and publishes a {@link PageAuditMessage} to Pub/Sub.
-	 *
-	 * @param pageBuiltMessage the source message; must not be {@code null}
-	 * @param pageState        the page to audit; must not be {@code null}
-	 * @param auditNames       audit types to run; must not be {@code null} or empty
-	 * @return {@code 200 OK} after successful persistence and publishing
-	 * @throws JsonProcessingException if the audit message cannot be serialized
-	 * @throws ExecutionException      if the Pub/Sub publish future fails
-	 * @throws InterruptedException    if the current thread is interrupted while publishing
-	 */
-	@Transactional
-	private ResponseEntity<String> createAndPublishAudit(PageBuiltMessage pageBuiltMessage, PageState pageState, Set<AuditName> auditNames, String pubsubMessageId)
-		throws JsonProcessingException, ExecutionException, InterruptedException {
-		assert pageBuiltMessage != null : "pageBuiltMessage must not be null";
-		assert pageState != null : "pageState must not be null";
-		assert auditNames != null && !auditNames.isEmpty() : "auditNames must not be null or empty";
-
-		log.info("Received page for auditing, pageId={}, url={}", pageBuiltMessage.getPageId(), pageState.getUrl());
+	private void createAndPublishAudit(PageBuiltMessage pageBuiltMessage, PageState pageState,
+	                                   Set<AuditName> auditNames) throws Exception {
+		log.info("Received page for auditing, pageId={}, url={}",
+			pageBuiltMessage.getPageId(), pageState.getUrl());
 
 		AuditRecord auditRecord = new PageAuditRecord(
 			ExecutionStatus.BUILDING_PAGE,
@@ -192,27 +91,16 @@ public class AuditController {
 			auditNames);
 
 		auditRecord = auditRecordService.save(auditRecord);
-		assert auditRecord != null : "auditRecordService.save() must return a non-null record";
-
 		auditRecordService.addPageAuditToDomainAudit(pageBuiltMessage.getAuditRecordId(), auditRecord.getId());
 		auditRecordService.addPageToAuditRecord(auditRecord.getId(), pageBuiltMessage.getPageId());
 
-		PageAuditMessage auditMessage = new PageAuditMessage(pageBuiltMessage.getAccountId(), auditRecord.getId());
+		PageAuditMessage auditMessage = new PageAuditMessage(
+			pageBuiltMessage.getAccountId(), auditRecord.getId());
 		String auditRecordJson = JacksonConfig.mapper().writeValueAsString(auditMessage);
 		log.info("Sending PageAuditMessage to Pub/Sub for pageAuditId={}", auditRecord.getId());
 		auditRecordTopic.publish(auditRecordJson);
-		idempotencyService.markProcessed(pubsubMessageId, "audit-manager");
-		return ResponseEntity.ok("Successfully processed message");
 	}
 
-	/**
-	 * Resolves the set of audit types to execute. Uses the labels from the
-	 * parent {@link DomainAuditRecord} when available, otherwise falls back to
-	 * a default set.
-	 *
-	 * @param auditRecordId the parent audit record identifier
-	 * @return a non-null, non-empty set of {@link AuditName}s
-	 */
 	private Set<AuditName> buildAuditNames(long auditRecordId) {
 		Optional<AuditRecord> optRecord = auditRecordService.findById(auditRecordId);
 		if (optRecord.isPresent() && optRecord.get() instanceof DomainAuditRecord) {
@@ -222,19 +110,10 @@ public class AuditController {
 				return labels;
 			}
 		}
-
-		Set<AuditName> defaults = buildDefaultAuditNames();
-		assert !defaults.isEmpty() : "default audit names must never be empty";
-		return defaults;
+		return defaultAuditNames();
 	}
 
-	/**
-	 * Returns the default set of audit types applied when no domain-level
-	 * configuration is available.
-	 *
-	 * @return a non-null, non-empty set of {@link AuditName}s
-	 */
-	private Set<AuditName> buildDefaultAuditNames() {
+	private Set<AuditName> defaultAuditNames() {
 		Set<AuditName> auditNames = new HashSet<>();
 		auditNames.add(AuditName.TEXT_BACKGROUND_CONTRAST);
 		auditNames.add(AuditName.NON_TEXT_BACKGROUND_CONTRAST);
@@ -248,60 +127,5 @@ public class AuditController {
 		auditNames.add(AuditName.IMAGE_COPYRIGHT);
 		auditNames.add(AuditName.IMAGE_POLICY);
 		return auditNames;
-	}
-
-	/**
-	 * Validates that the Pub/Sub envelope contains a message with non-empty data.
-	 *
-	 * @param body the request body to validate; may be {@code null}
-	 * @return {@code true} if the payload is structurally valid
-	 */
-	private boolean hasValidPayload(Body body) {
-		return body != null
-			&& body.getMessage() != null
-			&& body.getMessage().getData() != null
-			&& !body.getMessage().getData().isEmpty();
-	}
-
-	/**
-	 * Decodes a Base64-encoded string to UTF-8 text.
-	 *
-	 * @param encodedData the Base64 string; must not be {@code null}
-	 * @return the decoded payload, or {@code null} if decoding fails
-	 */
-	private String decodePayload(String encodedData) {
-		assert encodedData != null : "encodedData must not be null when called";
-		try {
-			return new String(Base64.getDecoder().decode(encodedData), StandardCharsets.UTF_8);
-		} catch (IllegalArgumentException e) {
-			log.warn("Received invalid Base64 data from Pub/Sub message", e);
-			return null;
-		}
-	}
-
-	/**
-	 * Deserializes a JSON string into a {@link PageBuiltMessage}.
-	 *
-	 * @param payload the JSON payload; must not be {@code null}
-	 * @return the parsed message, or {@code null} if parsing fails
-	 */
-	private PageBuiltMessage parseMessage(String payload) {
-		assert payload != null : "payload must not be null when called";
-		try {
-			return JacksonConfig.mapper().readValue(payload, PageBuiltMessage.class);
-		} catch (JsonProcessingException e) {
-			log.error("Error occurred while mapping payload to PageBuiltMessage", e);
-			return null;
-		}
-	}
-
-	/**
-	 * Convenience factory for {@code 400 Bad Request} responses.
-	 *
-	 * @param msg the response body; must not be {@code null}
-	 * @return a {@link ResponseEntity} with status {@code 400}
-	 */
-	private ResponseEntity<String> badRequest(String msg) {
-		return new ResponseEntity<>(msg, HttpStatus.BAD_REQUEST);
 	}
 }

--- a/AuditManager/src/test/java/com/looksee/auditManager/AuditControllerIdempotencyTest.java
+++ b/AuditManager/src/test/java/com/looksee/auditManager/AuditControllerIdempotencyTest.java
@@ -1,9 +1,14 @@
 package com.looksee.auditManager;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
@@ -14,209 +19,118 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.test.util.ReflectionTestUtils;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.looksee.gcp.PubSubPageAuditPublisherImpl;
 import com.looksee.mapper.Body;
+import com.looksee.messaging.idempotency.IdempotencyGuard;
+import com.looksee.messaging.observability.PubSubMetrics;
 import com.looksee.models.PageState;
 import com.looksee.models.audit.AuditRecord;
 import com.looksee.models.audit.DomainAuditRecord;
 import com.looksee.models.audit.PageAuditRecord;
 import com.looksee.models.enums.AuditName;
-import com.looksee.models.enums.ExecutionStatus;
 import com.looksee.services.AuditRecordService;
-import com.looksee.services.IdempotencyService;
 import com.looksee.services.PageStateService;
 
 /**
- * Unit tests for {@link AuditController} focusing on idempotency,
- * error handling, and message processing.
+ * Idempotency-focused tests for {@link AuditController}. The atomic
+ * {@code claim()} call lives in the {@link com.looksee.messaging.web.PubSubAuditController}
+ * base class, so these cases assert the contract from the audit-manager side:
+ * a duplicate claim returns 200 without doing any work, and the success path
+ * does not hit {@code release()}.
  */
 class AuditControllerIdempotencyTest {
 
-    private AuditController controller;
+	private static final String SERVICE = "audit-manager";
 
-    private AuditRecordService auditRecordService;
-    private PubSubPageAuditPublisherImpl auditRecordTopic;
-    private PageStateService pageStateService;
-    private IdempotencyService idempotencyService;
+	private AuditController controller;
+	private AuditRecordService auditRecordService;
+	private PubSubPageAuditPublisherImpl auditRecordTopic;
+	private PageStateService pageStateService;
+	private IdempotencyGuard idempotencyService;
+	private PubSubMetrics pubSubMetrics;
 
-    @BeforeEach
-    void setUp() {
-        auditRecordService = mock(AuditRecordService.class);
-        auditRecordTopic = mock(PubSubPageAuditPublisherImpl.class);
-        pageStateService = mock(PageStateService.class);
-        idempotencyService = mock(IdempotencyService.class);
+	@BeforeEach
+	void setUp() {
+		controller = new AuditController();
+		auditRecordService = mock(AuditRecordService.class);
+		auditRecordTopic = mock(PubSubPageAuditPublisherImpl.class);
+		pageStateService = mock(PageStateService.class);
+		idempotencyService = mock(IdempotencyGuard.class);
+		pubSubMetrics = mock(PubSubMetrics.class);
 
-        // Constructor injection
-        controller = new AuditController(
-            auditRecordService,
-            auditRecordTopic,
-            pageStateService,
-            idempotencyService
-        );
-    }
+		ReflectionTestUtils.setField(controller, "auditRecordService", auditRecordService);
+		ReflectionTestUtils.setField(controller, "auditRecordTopic", auditRecordTopic);
+		ReflectionTestUtils.setField(controller, "pageStateService", pageStateService);
+		ReflectionTestUtils.setField(controller, "idempotencyService", idempotencyService);
+		ReflectionTestUtils.setField(controller, "objectMapper", new ObjectMapper());
+		ReflectionTestUtils.setField(controller, "pubSubMetrics", pubSubMetrics);
+	}
 
-    // --- Idempotency tests ---
+	@Test
+	void duplicateClaim_shortCircuits_returns200() throws Exception {
+		when(idempotencyService.claim("dup-msg", SERVICE)).thenReturn(false);
 
-    @Test
-    void shouldReturnOkForDuplicateMessage() throws Exception {
-        String validPayload = "{\"accountId\":1,\"pageId\":10,\"auditRecordId\":100}";
-        Body body = createValidBody("test-msg-id", validPayload);
-        when(idempotencyService.isAlreadyProcessed("test-msg-id", "audit-manager")).thenReturn(true);
+		ResponseEntity<String> response = controller.receiveMessage(
+			buildBody("dup-msg", "{\"accountId\":1,\"pageId\":10,\"auditRecordId\":100}"));
 
-        ResponseEntity<String> response = controller.receiveMessage(body);
+		assertEquals(HttpStatus.OK, response.getStatusCode());
+		assertTrue(response.getBody().contains("Duplicate"));
+		verify(auditRecordTopic, never()).publish(anyString());
+		verify(auditRecordService, never()).save(any());
+		verify(idempotencyService, never()).release(anyString(), anyString());
+	}
 
-        assertEquals(HttpStatus.OK, response.getStatusCode());
-        assertTrue(response.getBody().contains("already processed"));
-        verify(auditRecordTopic, never()).publish(anyString());
-        verify(idempotencyService, never()).markProcessed(anyString(), anyString());
-    }
+	@Test
+	void successPath_doesNotReleaseTheClaim() throws Exception {
+		when(idempotencyService.claim("ok-msg", SERVICE)).thenReturn(true);
 
-    // --- Invalid payload tests (returns 200 not 400) ---
+		DomainAuditRecord domainRecord = mock(DomainAuditRecord.class);
+		HashSet<AuditName> labels = new HashSet<>();
+		labels.add(AuditName.ALT_TEXT);
+		when(domainRecord.getAuditLabels()).thenReturn(labels);
+		when(auditRecordService.findById(100L)).thenReturn(Optional.of(domainRecord));
+		when(auditRecordService.wasPageAlreadyAudited(100L, 10L)).thenReturn(false);
+		when(pageStateService.isPageLandable(10L)).thenReturn(true);
+		when(pageStateService.findById(10L)).thenReturn(Optional.of(new PageState()));
 
-    @Test
-    void shouldReturnOkForNullBody() throws Exception {
-        ResponseEntity<String> response = controller.receiveMessage(null);
+		PageAuditRecord savedRecord = mock(PageAuditRecord.class);
+		when(savedRecord.getId()).thenReturn(200L);
+		when(auditRecordService.save(any(AuditRecord.class))).thenReturn(savedRecord);
 
-        assertEquals(HttpStatus.OK, response.getStatusCode());
-    }
+		ResponseEntity<String> response = controller.receiveMessage(
+			buildBody("ok-msg", "{\"accountId\":1,\"pageId\":10,\"auditRecordId\":100}"));
 
-    @Test
-    void shouldReturnOkForNullMessage() throws Exception {
-        Body body = new Body();
-        body.setMessage(null);
+		assertEquals(HttpStatus.OK, response.getStatusCode());
+		verify(auditRecordTopic, times(1)).publish(anyString());
+		verify(idempotencyService, never()).release(anyString(), anyString());
+	}
 
-        ResponseEntity<String> response = controller.receiveMessage(body);
+	@Test
+	void skippedEligibility_doesNotReleaseTheClaim() throws Exception {
+		when(idempotencyService.claim("skip-msg", SERVICE)).thenReturn(true);
+		when(auditRecordService.findById(100L)).thenReturn(Optional.empty());
+		when(auditRecordService.wasPageAlreadyAudited(100L, 10L)).thenReturn(true);
+		when(pageStateService.isPageLandable(10L)).thenReturn(true);
+		when(pageStateService.findById(10L)).thenReturn(Optional.of(new PageState()));
 
-        assertEquals(HttpStatus.OK, response.getStatusCode());
-    }
+		ResponseEntity<String> response = controller.receiveMessage(
+			buildBody("skip-msg", "{\"accountId\":1,\"pageId\":10,\"auditRecordId\":100}"));
 
-    @Test
-    void shouldReturnOkForNullData() throws Exception {
-        Body body = new Body();
-        Body.Message msg = body.new Message("msg-1", "2024-01-01T00:00:00Z", "placeholder");
-        // Use reflection to set data to null since constructor asserts non-null
-        try {
-            java.lang.reflect.Field dataField = Body.Message.class.getDeclaredField("data");
-            dataField.setAccessible(true);
-            dataField.set(msg, null);
-        } catch (Exception e) {
-            fail("Failed to set data field to null via reflection");
-        }
-        body.setMessage(msg);
+		assertEquals(HttpStatus.OK, response.getStatusCode());
+		verify(auditRecordTopic, never()).publish(anyString());
+		verify(idempotencyService, never()).release(anyString(), anyString());
+	}
 
-        ResponseEntity<String> response = controller.receiveMessage(body);
-
-        assertEquals(HttpStatus.OK, response.getStatusCode());
-    }
-
-    @Test
-    void shouldReturnOkForEmptyData() throws Exception {
-        Body body = new Body();
-        Body.Message msg = body.new Message("msg-2", "2024-01-01T00:00:00Z", "");
-        body.setMessage(msg);
-
-        ResponseEntity<String> response = controller.receiveMessage(body);
-
-        assertEquals(HttpStatus.OK, response.getStatusCode());
-    }
-
-    @Test
-    void shouldReturnOkForInvalidBase64Data() throws Exception {
-        Body body = new Body();
-        Body.Message msg = body.new Message("msg-3", "2024-01-01T00:00:00Z", "not-valid-base64!!!");
-        body.setMessage(msg);
-        when(idempotencyService.isAlreadyProcessed("msg-3", "audit-manager")).thenReturn(false);
-
-        ResponseEntity<String> response = controller.receiveMessage(body);
-
-        assertEquals(HttpStatus.OK, response.getStatusCode());
-        verify(auditRecordTopic, never()).publish(anyString());
-    }
-
-    @Test
-    void shouldReturnOkForInvalidJson() throws Exception {
-        String invalidJson = "this is not json";
-        Body body = createValidBody("msg-4", invalidJson);
-        when(idempotencyService.isAlreadyProcessed("msg-4", "audit-manager")).thenReturn(false);
-
-        ResponseEntity<String> response = controller.receiveMessage(body);
-
-        assertEquals(HttpStatus.OK, response.getStatusCode());
-        verify(auditRecordTopic, never()).publish(anyString());
-    }
-
-    // --- Successful processing tests ---
-
-    @Test
-    void shouldCreateAndPublishAuditForEligiblePage() throws Exception {
-        String payload = "{\"accountId\":1,\"pageId\":10,\"auditRecordId\":100}";
-        Body body = createValidBody("msg-5", payload);
-        when(idempotencyService.isAlreadyProcessed("msg-5", "audit-manager")).thenReturn(false);
-
-        // Set up audit record with labels
-        DomainAuditRecord domainRecord = mock(DomainAuditRecord.class);
-        HashSet<AuditName> labels = new HashSet<>();
-        labels.add(AuditName.ALT_TEXT);
-        when(domainRecord.getAuditLabels()).thenReturn(labels);
-        when(auditRecordService.findById(100L)).thenReturn(Optional.of(domainRecord));
-
-        when(auditRecordService.wasPageAlreadyAudited(100L, 10L)).thenReturn(false);
-        when(pageStateService.isPageLandable(10L)).thenReturn(true);
-
-        PageState pageState = new PageState();
-        when(pageStateService.findById(10L)).thenReturn(Optional.of(pageState));
-
-        PageAuditRecord savedRecord = mock(PageAuditRecord.class);
-        when(savedRecord.getId()).thenReturn(200L);
-        when(auditRecordService.save(any(AuditRecord.class))).thenReturn(savedRecord);
-
-        ResponseEntity<String> response = controller.receiveMessage(body);
-
-        assertEquals(HttpStatus.OK, response.getStatusCode());
-        verify(auditRecordTopic).publish(anyString());
-        verify(idempotencyService).markProcessed("msg-5", "audit-manager");
-    }
-
-    @Test
-    void shouldMarkProcessedWhenPageAlreadyAudited() throws Exception {
-        String payload = "{\"accountId\":1,\"pageId\":10,\"auditRecordId\":100}";
-        Body body = createValidBody("msg-6", payload);
-        when(idempotencyService.isAlreadyProcessed("msg-6", "audit-manager")).thenReturn(false);
-
-        when(auditRecordService.findById(100L)).thenReturn(Optional.empty());
-        when(auditRecordService.wasPageAlreadyAudited(100L, 10L)).thenReturn(true);
-        when(pageStateService.isPageLandable(10L)).thenReturn(true);
-        when(pageStateService.findById(10L)).thenReturn(Optional.of(new PageState()));
-
-        ResponseEntity<String> response = controller.receiveMessage(body);
-
-        assertEquals(HttpStatus.OK, response.getStatusCode());
-        verify(auditRecordTopic, never()).publish(anyString());
-        verify(idempotencyService).markProcessed("msg-6", "audit-manager");
-    }
-
-    // --- Error handling tests ---
-
-    @Test
-    void shouldNotCallMarkProcessedOnInvalidPayload() throws Exception {
-        Body body = new Body();
-        Body.Message msg = body.new Message("msg-7", "2024-01-01T00:00:00Z", "bad-base64!!!");
-        body.setMessage(msg);
-        when(idempotencyService.isAlreadyProcessed("msg-7", "audit-manager")).thenReturn(false);
-
-        controller.receiveMessage(body);
-
-        verify(idempotencyService, never()).markProcessed(anyString(), anyString());
-    }
-
-    // --- Helper ---
-
-    private Body createValidBody(String messageId, String jsonPayload) {
-        String encoded = Base64.getEncoder().encodeToString(jsonPayload.getBytes(StandardCharsets.UTF_8));
-        Body body = new Body();
-        Body.Message msg = body.new Message(messageId, "2024-01-01T00:00:00Z", encoded);
-        body.setMessage(msg);
-        return body;
-    }
+	private static Body buildBody(String messageId, String json) {
+		String encoded = Base64.getEncoder().encodeToString(json.getBytes(StandardCharsets.UTF_8));
+		Body body = new Body();
+		Body.Message msg = body.new Message();
+		msg.setMessageId(messageId);
+		msg.setData(encoded);
+		body.setMessage(msg);
+		return body;
+	}
 }

--- a/AuditManager/src/test/java/com/looksee/auditManager/AuditControllerIntegrationTest.java
+++ b/AuditManager/src/test/java/com/looksee/auditManager/AuditControllerIntegrationTest.java
@@ -1,9 +1,15 @@
 package com.looksee.auditManager;
 
-import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.Mockito.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
@@ -16,142 +22,156 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.MediaType;
+import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.looksee.gcp.PubSubPageAuditPublisherImpl;
+import com.looksee.messaging.idempotency.IdempotencyGuard;
+import com.looksee.messaging.observability.PubSubMetrics;
 import com.looksee.models.PageState;
 import com.looksee.models.audit.AuditRecord;
 import com.looksee.models.audit.PageAuditRecord;
 import com.looksee.models.config.JacksonConfig;
 import com.looksee.models.message.PageBuiltMessage;
 import com.looksee.services.AuditRecordService;
-import com.looksee.services.IdempotencyService;
 import com.looksee.services.PageStateService;
 
 /**
- * Integration tests for {@link AuditController} using standalone MockMvc.
+ * End-to-end MockMvc tests that drive the controller through the inherited
+ * {@code @PostMapping("/")} route on
+ * {@link com.looksee.messaging.web.PubSubAuditController}. The base class is
+ * responsible for envelope handling and idempotency claim/release; these
+ * tests just confirm the wiring still produces the expected HTTP responses
+ * after the migration.
  */
 @ExtendWith(MockitoExtension.class)
 class AuditControllerIntegrationTest {
 
-    @Mock private AuditRecordService auditRecordService;
-    @Mock private PubSubPageAuditPublisherImpl auditRecordTopic;
-    @Mock private PageStateService pageStateService;
-    @Mock private IdempotencyService idempotencyService;
+	@Mock private AuditRecordService auditRecordService;
+	@Mock private PubSubPageAuditPublisherImpl auditRecordTopic;
+	@Mock private PageStateService pageStateService;
+	@Mock private IdempotencyGuard idempotencyService;
+	@Mock private PubSubMetrics pubSubMetrics;
 
-    private MockMvc mockMvc;
+	private MockMvc mockMvc;
 
-    @BeforeEach
-    void setUp() {
-        AuditController controller = new AuditController(
-                auditRecordService, auditRecordTopic, pageStateService, idempotencyService);
-        mockMvc = MockMvcBuilders.standaloneSetup(controller).build();
-    }
+	@BeforeEach
+	void setUp() {
+		AuditController controller = new AuditController();
+		ReflectionTestUtils.setField(controller, "auditRecordService", auditRecordService);
+		ReflectionTestUtils.setField(controller, "auditRecordTopic", auditRecordTopic);
+		ReflectionTestUtils.setField(controller, "pageStateService", pageStateService);
+		ReflectionTestUtils.setField(controller, "idempotencyService", idempotencyService);
+		ReflectionTestUtils.setField(controller, "objectMapper", new ObjectMapper());
+		ReflectionTestUtils.setField(controller, "pubSubMetrics", pubSubMetrics);
+		mockMvc = MockMvcBuilders.standaloneSetup(controller).build();
+	}
 
-    private String buildValidEnvelope(Object innerMessage) throws Exception {
-        String innerJson = JacksonConfig.mapper().writeValueAsString(innerMessage);
-        String base64Data = Base64.getEncoder().encodeToString(
-                innerJson.getBytes(StandardCharsets.UTF_8));
-        return String.format(
-                "{\"message\":{\"messageId\":\"test-msg-001\",\"publishTime\":\"2026-04-04T10:00:00Z\",\"data\":\"%s\"}}",
-                base64Data);
-    }
+	private String buildValidEnvelope(Object innerMessage) throws Exception {
+		String innerJson = JacksonConfig.mapper().writeValueAsString(innerMessage);
+		String base64Data = Base64.getEncoder().encodeToString(
+			innerJson.getBytes(StandardCharsets.UTF_8));
+		return String.format(
+			"{\"message\":{\"messageId\":\"test-msg-001\",\"publishTime\":\"2026-04-04T10:00:00Z\",\"data\":\"%s\"}}",
+			base64Data);
+	}
 
-    @Test
-    @DisplayName("POST / with valid PageBuiltMessage returns 200")
-    void postValidMessage_returns200() throws Exception {
-        PageBuiltMessage innerMsg = new PageBuiltMessage(1L, 100L, 200L);
-        String envelopeJson = buildValidEnvelope(innerMsg);
+	@Test
+	@DisplayName("POST / with valid PageBuiltMessage returns 200")
+	void postValidMessage_returns200() throws Exception {
+		PageBuiltMessage innerMsg = new PageBuiltMessage(1L, 100L, 200L);
+		String envelopeJson = buildValidEnvelope(innerMsg);
 
-        when(idempotencyService.isAlreadyProcessed(anyString(), eq("audit-manager")))
-                .thenReturn(false);
-        when(auditRecordService.wasPageAlreadyAudited(200L, 100L)).thenReturn(false);
-        when(pageStateService.isPageLandable(100L)).thenReturn(true);
+		when(idempotencyService.claim(anyString(), eq("audit-manager"))).thenReturn(true);
+		when(auditRecordService.wasPageAlreadyAudited(200L, 100L)).thenReturn(false);
+		when(pageStateService.isPageLandable(100L)).thenReturn(true);
 
-        PageState mockPageState = mock(PageState.class);
-        when(mockPageState.getUrl()).thenReturn("https://example.com");
-        when(pageStateService.findById(100L)).thenReturn(Optional.of(mockPageState));
+		PageState mockPageState = mock(PageState.class);
+		when(mockPageState.getUrl()).thenReturn("https://example.com");
+		when(pageStateService.findById(100L)).thenReturn(Optional.of(mockPageState));
 
-        PageAuditRecord mockAuditRecord = mock(PageAuditRecord.class);
-        when(mockAuditRecord.getId()).thenReturn(999L);
-        when(auditRecordService.findById(200L)).thenReturn(Optional.empty());
-        when(auditRecordService.save(any(AuditRecord.class))).thenReturn(mockAuditRecord);
+		PageAuditRecord mockAuditRecord = mock(PageAuditRecord.class);
+		when(mockAuditRecord.getId()).thenReturn(999L);
+		when(auditRecordService.findById(200L)).thenReturn(Optional.empty());
+		when(auditRecordService.save(any(AuditRecord.class))).thenReturn(mockAuditRecord);
 
-        mockMvc.perform(post("/")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(envelopeJson))
-                .andExpect(status().isOk());
-    }
+		mockMvc.perform(post("/")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(envelopeJson))
+			.andExpect(status().isOk());
+	}
 
-    @Test
-    @DisplayName("POST / with duplicate message returns 200 without processing")
-    void postDuplicateMessage_returns200WithoutProcessing() throws Exception {
-        PageBuiltMessage innerMsg = new PageBuiltMessage(1L, 100L, 200L);
-        String envelopeJson = buildValidEnvelope(innerMsg);
+	@Test
+	@DisplayName("POST / with duplicate claim returns 200 without processing")
+	void postDuplicateMessage_returns200WithoutProcessing() throws Exception {
+		PageBuiltMessage innerMsg = new PageBuiltMessage(1L, 100L, 200L);
+		String envelopeJson = buildValidEnvelope(innerMsg);
 
-        when(idempotencyService.isAlreadyProcessed("test-msg-001", "audit-manager"))
-                .thenReturn(true);
+		when(idempotencyService.claim("test-msg-001", "audit-manager")).thenReturn(false);
 
-        mockMvc.perform(post("/")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(envelopeJson))
-                .andExpect(status().isOk());
+		mockMvc.perform(post("/")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(envelopeJson))
+			.andExpect(status().isOk());
 
-        verify(auditRecordService, never()).wasPageAlreadyAudited(anyLong(), anyLong());
-        verify(auditRecordTopic, never()).publish(anyString());
-    }
+		verify(auditRecordService, never()).wasPageAlreadyAudited(anyLong(), anyLong());
+		verify(auditRecordTopic, never()).publish(anyString());
+	}
 
-    @Test
-    @DisplayName("POST / with invalid base64 returns 200")
-    void postInvalidBase64_returns200() throws Exception {
-        String invalidEnvelope = "{\"message\":{\"messageId\":\"test-bad\",\"publishTime\":\"2026-04-04T10:00:00Z\",\"data\":\"not-valid-base64!!!\"}}";
+	@Test
+	@DisplayName("POST / with invalid base64 returns 200 (poison)")
+	void postInvalidBase64_returns200() throws Exception {
+		String invalidEnvelope = "{\"message\":{\"messageId\":\"test-bad\",\"publishTime\":\"2026-04-04T10:00:00Z\",\"data\":\"not-valid-base64!!!\"}}";
 
-        when(idempotencyService.isAlreadyProcessed(anyString(), eq("audit-manager")))
-                .thenReturn(false);
+		when(idempotencyService.claim(anyString(), eq("audit-manager"))).thenReturn(true);
 
-        mockMvc.perform(post("/")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(invalidEnvelope))
-                .andExpect(status().isOk());
-    }
+		mockMvc.perform(post("/")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(invalidEnvelope))
+			.andExpect(status().isOk());
 
-    @Test
-    @DisplayName("POST / with empty body returns 200")
-    void postEmptyBody_returns200() throws Exception {
-        mockMvc.perform(post("/")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content("{}"))
-                .andExpect(status().isOk());
-    }
+		verify(auditRecordTopic, never()).publish(anyString());
+	}
 
-    @Test
-    @DisplayName("POST / with empty data returns 200")
-    void postEmptyData_returns200() throws Exception {
-        String emptyDataEnvelope = "{\"message\":{\"messageId\":\"test-empty\",\"publishTime\":\"2026-04-04T10:00:00Z\",\"data\":\"\"}}";
+	@Test
+	@DisplayName("POST / with empty body returns 200")
+	void postEmptyBody_returns200() throws Exception {
+		mockMvc.perform(post("/")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("{}"))
+			.andExpect(status().isOk());
+	}
 
-        mockMvc.perform(post("/")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(emptyDataEnvelope))
-                .andExpect(status().isOk());
-    }
+	@Test
+	@DisplayName("POST / with empty data returns 200")
+	void postEmptyData_returns200() throws Exception {
+		String emptyDataEnvelope = "{\"message\":{\"messageId\":\"test-empty\",\"publishTime\":\"2026-04-04T10:00:00Z\",\"data\":\"\"}}";
 
-    @Test
-    @DisplayName("POST / skips already audited page")
-    void postAlreadyAuditedPage_returns200() throws Exception {
-        PageBuiltMessage innerMsg = new PageBuiltMessage(1L, 100L, 200L);
-        String envelopeJson = buildValidEnvelope(innerMsg);
+		mockMvc.perform(post("/")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(emptyDataEnvelope))
+			.andExpect(status().isOk());
+	}
 
-        when(idempotencyService.isAlreadyProcessed(anyString(), eq("audit-manager")))
-                .thenReturn(false);
-        when(auditRecordService.wasPageAlreadyAudited(200L, 100L)).thenReturn(true);
-        when(auditRecordService.findById(200L)).thenReturn(Optional.empty());
+	@Test
+	@DisplayName("POST / skips already audited page")
+	void postAlreadyAuditedPage_returns200() throws Exception {
+		PageBuiltMessage innerMsg = new PageBuiltMessage(1L, 100L, 200L);
+		String envelopeJson = buildValidEnvelope(innerMsg);
 
-        mockMvc.perform(post("/")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(envelopeJson))
-                .andExpect(status().isOk());
+		when(idempotencyService.claim(anyString(), eq("audit-manager"))).thenReturn(true);
+		when(auditRecordService.wasPageAlreadyAudited(200L, 100L)).thenReturn(true);
+		when(pageStateService.isPageLandable(100L)).thenReturn(true);
+		when(pageStateService.findById(100L)).thenReturn(Optional.of(new PageState()));
+		when(auditRecordService.findById(200L)).thenReturn(Optional.empty());
 
-        verify(auditRecordTopic, never()).publish(anyString());
-    }
+		mockMvc.perform(post("/")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(envelopeJson))
+			.andExpect(status().isOk());
+
+		verify(auditRecordTopic, never()).publish(anyString());
+	}
 }

--- a/AuditManager/src/test/java/com/looksee/auditManager/AuditControllerTest.java
+++ b/AuditManager/src/test/java/com/looksee/auditManager/AuditControllerTest.java
@@ -3,8 +3,10 @@ package com.looksee.auditManager;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -12,165 +14,107 @@ import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.Optional;
 import java.util.Set;
-import java.util.concurrent.ExecutionException;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.test.util.ReflectionTestUtils;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.looksee.gcp.PubSubPageAuditPublisherImpl;
 import com.looksee.mapper.Body;
+import com.looksee.messaging.idempotency.IdempotencyGuard;
+import com.looksee.messaging.observability.PubSubMetrics;
 import com.looksee.models.PageState;
 import com.looksee.models.audit.AuditRecord;
 import com.looksee.models.audit.DomainAuditRecord;
+import com.looksee.models.audit.PageAuditRecord;
 import com.looksee.models.enums.AuditName;
 import com.looksee.services.AuditRecordService;
-import com.looksee.services.IdempotencyService;
 import com.looksee.services.PageStateService;
 
-@ExtendWith(MockitoExtension.class)
+/**
+ * Per-service tests for audit-manager after the migration to
+ * {@link com.looksee.messaging.web.PubSubAuditController}. Envelope
+ * validation, base64/JSON edge cases, idempotency claim/release, and metrics
+ * emission are owned by the base class and covered in
+ * {@code PubSubAuditControllerTest}; this file only exercises the
+ * eligibility + persistence business logic in {@code handle(...)}.
+ */
 class AuditControllerTest {
 
-	@Mock
-	private AuditRecordService auditRecordService;
-
-	@Mock
-	private PubSubPageAuditPublisherImpl auditRecordTopic;
-
-	@Mock
-	private PageStateService pageStateService;
-
-	@Mock
-	private IdempotencyService idempotencyService;
+	private static final String SERVICE = "audit-manager";
 
 	private AuditController controller;
+	private AuditRecordService auditRecordService;
+	private PubSubPageAuditPublisherImpl auditRecordTopic;
+	private PageStateService pageStateService;
+	private IdempotencyGuard idempotencyService;
+	private PubSubMetrics pubSubMetrics;
 
 	@BeforeEach
-	void setup() {
-		controller = new AuditController(auditRecordService, auditRecordTopic, pageStateService, idempotencyService);
-	}
+	void setUp() {
+		controller = new AuditController();
+		auditRecordService = mock(AuditRecordService.class);
+		auditRecordTopic = mock(PubSubPageAuditPublisherImpl.class);
+		pageStateService = mock(PageStateService.class);
+		idempotencyService = mock(IdempotencyGuard.class);
+		pubSubMetrics = mock(PubSubMetrics.class);
 
-	@Test
-	void shouldReturnBadRequestWhenBodyIsMissing() {
-		ResponseEntity<String> response = controller.receiveMessage(null);
+		ReflectionTestUtils.setField(controller, "auditRecordService", auditRecordService);
+		ReflectionTestUtils.setField(controller, "auditRecordTopic", auditRecordTopic);
+		ReflectionTestUtils.setField(controller, "pageStateService", pageStateService);
+		ReflectionTestUtils.setField(controller, "idempotencyService", idempotencyService);
+		ReflectionTestUtils.setField(controller, "objectMapper", new ObjectMapper());
+		ReflectionTestUtils.setField(controller, "pubSubMetrics", pubSubMetrics);
 
-		assertEquals(HttpStatus.OK, response.getStatusCode());
-		assertEquals("Acknowledged invalid Pub/Sub payload", response.getBody());
-	}
-
-	@Test
-	void shouldReturnBadRequestWhenMessageIsNull() {
-		Body body = mock(Body.class);
-		when(body.getMessage()).thenReturn(null);
-
-		ResponseEntity<String> response = controller.receiveMessage(body);
-
-		assertEquals(HttpStatus.OK, response.getStatusCode());
-		assertEquals("Acknowledged invalid Pub/Sub payload", response.getBody());
-	}
-
-	@Test
-	void shouldReturnBadRequestWhenMessageDataIsNull() {
-		Body body = mock(Body.class);
-		Body.Message message = mock(Body.Message.class);
-		when(body.getMessage()).thenReturn(message);
-		when(message.getData()).thenReturn(null);
-
-		ResponseEntity<String> response = controller.receiveMessage(body);
-
-		assertEquals(HttpStatus.OK, response.getStatusCode());
-		assertEquals("Acknowledged invalid Pub/Sub payload", response.getBody());
-	}
-
-	@Test
-	void shouldReturnBadRequestWhenMessageDataIsMissing() {
-		Body body = mock(Body.class);
-		Body.Message message = mock(Body.Message.class);
-		when(body.getMessage()).thenReturn(message);
-		when(message.getData()).thenReturn("");
-
-		ResponseEntity<String> response = controller.receiveMessage(body);
-
-		assertEquals(HttpStatus.OK, response.getStatusCode());
-		assertEquals("Acknowledged invalid Pub/Sub payload", response.getBody());
-	}
-
-	@Test
-	void shouldReturnBadRequestWhenMessageDataIsNotBase64() throws Exception {
-		Body body = mockBodyWithData("not-base64");
-
-		ResponseEntity<String> response = controller.receiveMessage(body);
-
-		assertEquals(HttpStatus.OK, response.getStatusCode());
-		assertEquals("Acknowledged invalid message encoding", response.getBody());
-		verify(auditRecordTopic, never()).publish(any());
-	}
-
-	@Test
-	void shouldReturnBadRequestWhenDecodedPayloadIsNotJson() throws Exception {
-		String encoded = Base64.getEncoder().encodeToString("invalid-json".getBytes(StandardCharsets.UTF_8));
-		Body body = mockBodyWithData(encoded);
-
-		ResponseEntity<String> response = controller.receiveMessage(body);
-
-		assertEquals(HttpStatus.OK, response.getStatusCode());
-		assertEquals("Acknowledged invalid message format", response.getBody());
-		verify(auditRecordTopic, never()).publish(any());
+		when(idempotencyService.claim(anyString(), anyString())).thenReturn(true);
 	}
 
 	@Test
 	void shouldSkipWhenPageAlreadyAudited() throws Exception {
-		Body body = createValidBody();
-
 		when(auditRecordService.wasPageAlreadyAudited(3L, 2L)).thenReturn(true);
 		when(pageStateService.isPageLandable(2L)).thenReturn(true);
 		when(pageStateService.findById(2L)).thenReturn(Optional.of(new PageState()));
 		when(auditRecordService.findById(3L)).thenReturn(Optional.empty());
 
-		ResponseEntity<String> response = controller.receiveMessage(body);
+		ResponseEntity<String> response = controller.receiveMessage(buildBody("msg-skip", validJson()));
 
 		assertEquals(HttpStatus.OK, response.getStatusCode());
-		verify(auditRecordTopic, never()).publish(any());
+		verify(auditRecordTopic, never()).publish(anyString());
+		verify(auditRecordService, never()).save(any());
 	}
 
 	@Test
 	void shouldSkipWhenPageIsNotLandable() throws Exception {
-		Body body = createValidBody();
-
 		when(auditRecordService.wasPageAlreadyAudited(3L, 2L)).thenReturn(false);
 		when(pageStateService.isPageLandable(2L)).thenReturn(false);
 		when(pageStateService.findById(2L)).thenReturn(Optional.of(new PageState()));
 		when(auditRecordService.findById(3L)).thenReturn(Optional.empty());
 
-		ResponseEntity<String> response = controller.receiveMessage(body);
+		ResponseEntity<String> response = controller.receiveMessage(buildBody("msg-nonlandable", validJson()));
 
 		assertEquals(HttpStatus.OK, response.getStatusCode());
-		verify(auditRecordTopic, never()).publish(any());
+		verify(auditRecordTopic, never()).publish(anyString());
 	}
 
 	@Test
 	void shouldSkipWhenPageStateMissing() throws Exception {
-		Body body = createValidBody();
-
 		when(auditRecordService.wasPageAlreadyAudited(3L, 2L)).thenReturn(false);
 		when(pageStateService.isPageLandable(2L)).thenReturn(true);
 		when(pageStateService.findById(2L)).thenReturn(Optional.empty());
 		when(auditRecordService.findById(3L)).thenReturn(Optional.empty());
 
-		ResponseEntity<String> response = controller.receiveMessage(body);
+		ResponseEntity<String> response = controller.receiveMessage(buildBody("msg-nostate", validJson()));
 
 		assertEquals(HttpStatus.OK, response.getStatusCode());
-		verify(auditRecordTopic, never()).publish(any());
+		verify(auditRecordTopic, never()).publish(anyString());
 	}
 
 	@Test
 	void shouldPublishAuditWhenEligible() throws Exception {
-		Body body = createValidBody();
 		PageState pageState = new PageState();
 		AuditRecord savedRecord = mock(AuditRecord.class);
 
@@ -181,7 +125,7 @@ class AuditControllerTest {
 		when(auditRecordService.save(any())).thenReturn(savedRecord);
 		when(savedRecord.getId()).thenReturn(99L);
 
-		ResponseEntity<String> response = controller.receiveMessage(body);
+		ResponseEntity<String> response = controller.receiveMessage(buildBody("msg-go", validJson()));
 
 		assertEquals(HttpStatus.OK, response.getStatusCode());
 		verify(auditRecordService).addPageAuditToDomainAudit(3L, 99L);
@@ -194,9 +138,8 @@ class AuditControllerTest {
 
 	@Test
 	void shouldUseDomainAuditLabelsWhenDomainRecordExists() throws Exception {
-		Body body = createValidBody();
 		PageState pageState = new PageState();
-		AuditRecord savedRecord = mock(AuditRecord.class);
+		PageAuditRecord savedRecord = mock(PageAuditRecord.class);
 		DomainAuditRecord domainRecord = mock(DomainAuditRecord.class);
 		Set<AuditName> labels = Set.of(AuditName.ALT_TEXT);
 
@@ -208,17 +151,15 @@ class AuditControllerTest {
 		when(auditRecordService.save(any())).thenReturn(savedRecord);
 		when(savedRecord.getId()).thenReturn(22L);
 
-		ResponseEntity<String> response = controller.receiveMessage(body);
+		ResponseEntity<String> response = controller.receiveMessage(buildBody("msg-labels", validJson()));
 
 		assertEquals(HttpStatus.OK, response.getStatusCode());
-		verify(auditRecordService).save(any());
 		verify(domainRecord).getAuditLabels();
 		verify(auditRecordService).addPageAuditToDomainAudit(3L, 22L);
 	}
 
 	@Test
 	void shouldReturnInternalServerErrorWhenPublishingFails() throws Exception {
-		Body body = createValidBody();
 		PageState pageState = new PageState();
 		AuditRecord savedRecord = mock(AuditRecord.class);
 
@@ -228,65 +169,62 @@ class AuditControllerTest {
 		when(auditRecordService.findById(3L)).thenReturn(Optional.empty());
 		when(auditRecordService.save(any())).thenReturn(savedRecord);
 		when(savedRecord.getId()).thenReturn(88L);
-		doExecutionFailure();
+		org.mockito.Mockito.doThrow(new java.util.concurrent.ExecutionException(new RuntimeException("pubsub")))
+			.when(auditRecordTopic)
+			.publish(anyString());
 
-		ResponseEntity<String> response = controller.receiveMessage(body);
+		ResponseEntity<String> response = controller.receiveMessage(buildBody("msg-pub-fail", validJson()));
 
 		assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
-		assertEquals("Failed to process message", response.getBody());
+		// Base class releases the eager claim so Pub/Sub redelivery can retry.
+		verify(idempotencyService).release("msg-pub-fail", SERVICE);
 	}
 
 	@Test
-	void shouldReturnInternalServerErrorWhenInterrupted() throws Exception {
-		Body body = createValidBody();
+	void redelivery_doesNotDoubleProcess_thePerIssue83Contract() throws Exception {
 		PageState pageState = new PageState();
 		AuditRecord savedRecord = mock(AuditRecord.class);
+
+		// Stateful claim: first call wins, every subsequent call sees the row.
+		when(idempotencyService.claim("dup-msg", SERVICE))
+			.thenReturn(true)
+			.thenReturn(false);
 
 		when(auditRecordService.wasPageAlreadyAudited(3L, 2L)).thenReturn(false);
 		when(pageStateService.isPageLandable(2L)).thenReturn(true);
 		when(pageStateService.findById(2L)).thenReturn(Optional.of(pageState));
 		when(auditRecordService.findById(3L)).thenReturn(Optional.empty());
 		when(auditRecordService.save(any())).thenReturn(savedRecord);
-		when(savedRecord.getId()).thenReturn(77L);
-		org.mockito.Mockito.doThrow(new InterruptedException("stop"))
-			.when(auditRecordTopic)
-			.publish(any(String.class));
+		when(savedRecord.getId()).thenReturn(42L);
 
-		ResponseEntity<String> response = controller.receiveMessage(body);
+		Body envelope = buildBody("dup-msg", validJson());
 
-		assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
-		assertEquals("Audit processing interrupted", response.getBody());
+		ResponseEntity<String> first = controller.receiveMessage(envelope);
+		ResponseEntity<String> second = controller.receiveMessage(envelope);
+
+		assertEquals(HttpStatus.OK, first.getStatusCode());
+		assertEquals("ok", first.getBody());
+		assertEquals(HttpStatus.OK, second.getStatusCode());
+		assertTrue(second.getBody().contains("Duplicate"),
+			"second redelivery must short-circuit on duplicate, got: " + second.getBody());
+
+		// The audit must be persisted + published exactly once across redeliveries.
+		verify(auditRecordService, times(1)).save(any());
+		verify(auditRecordTopic, times(1)).publish(anyString());
+		verify(auditRecordService, times(1)).addPageAuditToDomainAudit(3L, 42L);
 	}
 
-	@Test
-	void shouldReturnInternalServerErrorForUnexpectedException() {
-		Body body = createValidBody();
-
-		when(auditRecordService.findById(3L)).thenThrow(new RuntimeException("boom"));
-
-		ResponseEntity<String> response = controller.receiveMessage(body);
-
-		assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
-		assertEquals("Failed to process message", response.getBody());
+	private static String validJson() {
+		return "{\"accountId\":1,\"pageId\":2,\"auditRecordId\":3}";
 	}
 
-	private void doExecutionFailure() throws Exception {
-		org.mockito.Mockito.doThrow(new ExecutionException(new RuntimeException("pubsub")))
-			.when(auditRecordTopic)
-			.publish(any(String.class));
-	}
-
-	private Body createValidBody() {
-		String payload = "{\"accountId\":1,\"pageId\":2,\"auditRecordId\":3}";
-		String encoded = Base64.getEncoder().encodeToString(payload.getBytes(StandardCharsets.UTF_8));
-		return mockBodyWithData(encoded);
-	}
-
-	private Body mockBodyWithData(String data) {
-		Body body = mock(Body.class);
-		Body.Message message = mock(Body.Message.class);
-		when(body.getMessage()).thenReturn(message);
-		when(message.getData()).thenReturn(data);
+	private static Body buildBody(String messageId, String json) {
+		String encoded = Base64.getEncoder().encodeToString(json.getBytes(StandardCharsets.UTF_8));
+		Body body = new Body();
+		Body.Message msg = body.new Message();
+		msg.setMessageId(messageId);
+		msg.setData(encoded);
+		body.setMessage(msg);
 		return body;
 	}
 }


### PR DESCRIPTION
## Summary

Step 5 of #28 (atomic idempotency rollout). Migrates `AuditManager/src/main/java/com/looksee/auditManager/AuditController.java` to extend `PubSubAuditController<PageBuiltMessage>`, mirroring the pattern just landed in journeyErrors (#83 / PR #93).

The subclass now only owns the eligibility check and `PageAuditRecord` persistence in `handle()`. Envelope validation, base64 decode, atomic `claim()`, trace-context propagation, poison-vs-transient distinction, and metrics emission are all inherited.

### Changes

- `AuditController.java` shrinks from ~307 lines to ~125. The legacy `isAlreadyProcessed`/`markProcessed` pair is replaced by the base class's atomic `claim()`. Custom `decodePayload`/`parseMessage`/envelope validation are removed.
- `serviceName()` is preserved as `"audit-manager"` so existing `ProcessedMessage` rows continue to dedupe.
- `topicName()` is `"page_built"`, matching the `pubsub.page_built` env-var convention used by `LookseeIaC/GCP/modules.tf`.
- `pom.xml` adds the `A11yMessaging` 0.8.2 dependency (`PubSubAuditController` lives in `looksee-messaging`).
- The three test classes (`AuditControllerTest`, `AuditControllerIdempotencyTest`, `AuditControllerIntegrationTest`) are rewritten to use `ReflectionTestUtils` field injection (matching the journeyErrors pattern), mock `IdempotencyGuard`/`PubSubMetrics`, and include the `redelivery_doesNotDoubleProcess_thePerIssue83Contract` regression test.

### Verification

- `cd AuditManager && mvn -B clean verify` → BUILD SUCCESS, 19 tests pass, JaCoCo line coverage ≥ 0.90 satisfied.
- `grep -rn "isAlreadyProcessed\|markProcessed" AuditManager/src` → no hits.
- Per-PR redelivery test asserts that two consecutive `receiveMessage()` calls with the same envelope publish exactly once and call `addPageAuditToDomainAudit` exactly once, while the second call short-circuits with `"Duplicate"`.

### Out of scope

- Steps 6-10 (#85-#89) of umbrella #28.
- `PageBuilder` and `look-see-front-end-broadcaster` migrations belong to #29.

Closes #84.

https://claude.ai/code/session_01JPthgEoutbX1q3ehsu52MU

---
_Generated by [Claude Code](https://claude.ai/code/session_01JPthgEoutbX1q3ehsu52MU)_