### PR TITLE
feat(persistence)!: fail startup when ProcessedMessageRepository is missing

### DIFF
--- a/LookseeCore/looksee-persistence/src/main/java/com/looksee/services/IdempotencyService.java
+++ b/LookseeCore/looksee-persistence/src/main/java/com/looksee/services/IdempotencyService.java
@@ -1,5 +1,7 @@
 package com.looksee.services;
 
+import javax.annotation.PostConstruct;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -39,6 +41,15 @@ public class IdempotencyService implements IdempotencyGuard {
     @Autowired(required = false)
     private ProcessedMessageRepository processedMessageRepository;
 
+    @PostConstruct
+    void requireRepository() {
+        if (processedMessageRepository == null) {
+            throw new IllegalStateException(
+                    "IdempotencyService requires ProcessedMessageRepository on the classpath. " +
+                    "Add a dependency on looksee-persistence or remove the IdempotencyGuard wiring.");
+        }
+    }
+
     /**
      * Checks if a PubSub message has already been processed by a service.
      *
@@ -48,7 +59,7 @@ public class IdempotencyService implements IdempotencyGuard {
      */
     @Override
     public boolean isAlreadyProcessed(String pubsubMessageId, String serviceName) {
-        if (processedMessageRepository == null || pubsubMessageId == null || pubsubMessageId.isEmpty()) {
+        if (pubsubMessageId == null || pubsubMessageId.isEmpty()) {
             return false;
         }
 
@@ -67,7 +78,7 @@ public class IdempotencyService implements IdempotencyGuard {
      */
     @Override
     public void markProcessed(String pubsubMessageId, String serviceName) {
-        if (processedMessageRepository == null || pubsubMessageId == null || pubsubMessageId.isEmpty()) {
+        if (pubsubMessageId == null || pubsubMessageId.isEmpty()) {
             return;
         }
 
@@ -88,13 +99,13 @@ public class IdempotencyService implements IdempotencyGuard {
      * are physically serialized by Neo4j; exactly one returns {@code true}.
      *
      * <p>Returns {@code true} when the caller should proceed with processing.
-     * In the fail-open paths (null repository, null/empty messageId) returns
-     * {@code true} as well so callers behave like before — same effect as the
-     * legacy {@link #isAlreadyProcessed} returning {@code false}.
+     * In the fail-open path (null/empty messageId) returns {@code true} so callers
+     * behave like before — same effect as the legacy {@link #isAlreadyProcessed}
+     * returning {@code false}.
      */
     @Override
     public boolean claim(String pubsubMessageId, String serviceName) {
-        if (processedMessageRepository == null || pubsubMessageId == null || pubsubMessageId.isEmpty()) {
+        if (pubsubMessageId == null || pubsubMessageId.isEmpty()) {
             return true;
         }
 
@@ -118,14 +129,13 @@ public class IdempotencyService implements IdempotencyGuard {
      * record so a subsequent Pub/Sub redelivery is allowed to re-run
      * business logic.
      *
-     * <p>Best-effort: a missing repository, null/empty messageId, or a
-     * thrown persistence exception are all logged and swallowed. A stuck
-     * claim is preferable to bubbling a release-failure up over the
-     * original handler error.
+     * <p>Best-effort: a null/empty messageId or a thrown persistence
+     * exception are logged and swallowed. A stuck claim is preferable
+     * to bubbling a release-failure up over the original handler error.
      */
     @Override
     public void release(String pubsubMessageId, String serviceName) {
-        if (processedMessageRepository == null || pubsubMessageId == null || pubsubMessageId.isEmpty()) {
+        if (pubsubMessageId == null || pubsubMessageId.isEmpty()) {
             return;
         }
         try {
@@ -142,9 +152,6 @@ public class IdempotencyService implements IdempotencyGuard {
      */
     @Scheduled(cron = "0 0 3 * * ?")
     public void cleanupOldRecords() {
-        if (processedMessageRepository == null) {
-            return;
-        }
         try {
             processedMessageRepository.deleteOlderThan(RETENTION_DAYS);
             log.info("Cleaned up processed message records older than {} days", RETENTION_DAYS);

--- a/LookseeCore/looksee-persistence/src/test/java/com/looksee/services/IdempotencyIntegrationTest.java
+++ b/LookseeCore/looksee-persistence/src/test/java/com/looksee/services/IdempotencyIntegrationTest.java
@@ -22,8 +22,9 @@ import com.looksee.models.repository.ProcessedMessageRepository;
 
 /**
  * Integration tests for {@link IdempotencyService} validating the full
- * idempotency lifecycle, concurrency behavior, cleanup, and graceful
- * degradation when the repository is unavailable.
+ * idempotency lifecycle, concurrency behavior, and cleanup. A missing
+ * repository is now a fail-fast condition at startup (covered in
+ * {@link IdempotencyServiceTest}), not a graceful-degradation path.
  */
 @ExtendWith(MockitoExtension.class)
 class IdempotencyIntegrationTest {
@@ -157,20 +158,12 @@ class IdempotencyIntegrationTest {
     }
 
     @Test
-    @DisplayName("Graceful degradation when repository is null")
-    void testGracefulDegradation_repositoryNull() {
-        // Inject null repository
-        injectRepository(null);
-
-        // isAlreadyProcessed returns false when repo is null (allow processing)
-        assertFalse(idempotencyService.isAlreadyProcessed("any-msg", "any-service"),
-                "Should return false when repository is unavailable");
-
-        // markProcessed should not throw when repo is null
-        assertDoesNotThrow(() -> idempotencyService.markProcessed("any-msg", "any-service"));
-
-        // cleanupOldRecords should not throw when repo is null
-        assertDoesNotThrow(() -> idempotencyService.cleanupOldRecords());
+    @DisplayName("Startup fails fast when repository is null")
+    void testStartupFailsFast_repositoryNull() {
+        IdempotencyService bare = new IdempotencyService();
+        IllegalStateException ex = assertThrows(IllegalStateException.class, bare::requireRepository);
+        assertTrue(ex.getMessage().contains("ProcessedMessageRepository"),
+                "message should name the missing dependency, was: " + ex.getMessage());
     }
 
     @Test

--- a/LookseeCore/looksee-persistence/src/test/java/com/looksee/services/IdempotencyServiceTest.java
+++ b/LookseeCore/looksee-persistence/src/test/java/com/looksee/services/IdempotencyServiceTest.java
@@ -58,17 +58,17 @@ class IdempotencyServiceTest {
     }
 
     @Test
-    void isAlreadyProcessed_returnsFalseWhenRepositoryIsNull() {
+    void requireRepository_throwsWhenRepositoryIsNull() {
         IdempotencyService serviceWithNullRepo = new IdempotencyService();
-        // processedMessageRepository is null by default (not injected)
-        assertFalse(serviceWithNullRepo.isAlreadyProcessed("msg-4", "svc-d"));
+        IllegalStateException ex = assertThrows(IllegalStateException.class,
+                serviceWithNullRepo::requireRepository);
+        assertTrue(ex.getMessage().contains("ProcessedMessageRepository"),
+                "message should name the missing dependency, was: " + ex.getMessage());
     }
 
     @Test
-    void markProcessed_doesNothingWhenRepositoryIsNull() {
-        IdempotencyService serviceWithNullRepo = new IdempotencyService();
-        // Should not throw
-        assertDoesNotThrow(() -> serviceWithNullRepo.markProcessed("msg-5", "svc-e"));
+    void requireRepository_succeedsWhenRepositoryIsPresent() {
+        assertDoesNotThrow(idempotencyService::requireRepository);
     }
 
     @Test
@@ -96,12 +96,6 @@ class IdempotencyServiceTest {
     void cleanupOldRecords_callsRepositoryDeleteOlderThan3() {
         idempotencyService.cleanupOldRecords();
         verify(processedMessageRepository).deleteOlderThan(3);
-    }
-
-    @Test
-    void cleanupOldRecords_doesNothingWhenRepositoryIsNull() {
-        IdempotencyService serviceWithNullRepo = new IdempotencyService();
-        assertDoesNotThrow(serviceWithNullRepo::cleanupOldRecords);
     }
 
     @Test
@@ -133,13 +127,6 @@ class IdempotencyServiceTest {
     }
 
     @Test
-    void claim_returnsTrueWhenRepositoryIsNull() {
-        IdempotencyService serviceWithNullRepo = new IdempotencyService();
-        // Fail-open: cannot dedupe → caller must process
-        assertTrue(serviceWithNullRepo.claim("msg-claim-3", "svc-m"));
-    }
-
-    @Test
     void claim_returnsTrueForNullPubsubMessageId() {
         assertTrue(idempotencyService.claim(null, "svc-n"));
         verifyNoInteractions(processedMessageRepository);
@@ -165,12 +152,6 @@ class IdempotencyServiceTest {
         idempotencyService.release("msg-rel-1", "svc-q");
 
         verify(processedMessageRepository).release("msg-rel-1", "svc-q");
-    }
-
-    @Test
-    void release_doesNothingWhenRepositoryIsNull() {
-        IdempotencyService serviceWithNullRepo = new IdempotencyService();
-        assertDoesNotThrow(() -> serviceWithNullRepo.release("msg-rel-2", "svc-r"));
     }
 
     @Test


### PR DESCRIPTION
## Summary

Sub-issue 6 of umbrella #28 (atomic, persistent, mandatory idempotency).

`IdempotencyService` previously treated a null `ProcessedMessageRepository` as "idempotency disabled": every call became a silent no-op (`false` from `isAlreadyProcessed`, `true` from `claim`, no-op `markProcessed`/`release`/`cleanup`). The only signal was a single warn log at startup. With more services routing through this path as part of #28, a misconfigured bean would silently turn at-least-once delivery into unbounded duplicates.

Replace the silent fallback with explicit fail-fast at Spring context startup.

## Changes

- **`IdempotencyService.java`**
  - Add `@PostConstruct requireRepository()` that throws `IllegalStateException` with a clear message if `processedMessageRepository == null`.
  - Remove the now-impossible `processedMessageRepository == null` clauses from all five guards (`claim`, `isAlreadyProcessed`, `markProcessed`, `release`, `cleanupOldRecords`). Per-call `null/empty messageId` guards remain — different concern.
  - Use `javax.annotation.PostConstruct` to match Spring Boot 2.6.13 + the existing `BrowserStackConfiguration` / `AppiumConfiguration` style in this codebase.
- **`IdempotencyServiceTest.java`** — replace 5 null-fallback tests with two `requireRepository_*` tests covering the throw and pass cases.
- **`IdempotencyIntegrationTest.java`** — replace `testGracefulDegradation_repositoryNull` with `testStartupFailsFast_repositoryNull`.

## Reviewer notes — breaking change

This is a **backward-incompatible** behavior change. Any consumer that boots today with `looksee-persistence` on the classpath but no `ProcessedMessageRepository` bean will start failing the Spring context. This surfaces existing latent risk rather than introducing new — silent at-least-once with no upper bound was never a safe runtime mode.

CHANGELOG + version bump are deferred to #88's scope per plan.

## Verification

- `cd LookseeCore/looksee-persistence && mvn test` — full suite passes (85 tests).
- Targeted runs:
  - `IdempotencyServiceTest`: 20/20 ✅
  - `IdempotencyIntegrationTest`: 9/9 ✅
  - `MessageFlowEndToEndTest`: 6/6 ✅

## Test plan

- [ ] CI green on this branch.
- [ ] Spring context still boots for every consumer that wires `IdempotencyService` (PageBuilder, journeyExpander, journeyExecutor, contentAudit, visualDesignAudit, informationArchitectureAudit) — they all already depend on `looksee-persistence`, so the bean is on the classpath. Confirm via existing service-level tests in CI.
- [ ] Negative confirmation (manual, optional): temporarily exclude `looksee-persistence` from one consumer's pom and verify `IllegalStateException` at boot, then revert.

Closes #85.

https://claude.ai/code/session_01Sh6TX7KK76rSSsgYLmbJCn

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sh6TX7KK76rSSsgYLmbJCn)_