### PR TITLE
feat(persistence): extend ProcessedMessage retention to 8 days

### DIFF
--- a/LookseeCore/CHANGELOG.md
+++ b/LookseeCore/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [Unreleased]
+
+### Changed
+- `IdempotencyService` retention extended from 3 to 8 days; cleanup keys off `ProcessedMessage.processedAt`. Pub/Sub retains undelivered messages for 7 days, so 8 days ensures a service offline for the full window still finds its dedupe record on recovery. **Operational note:** if a service is down longer than 8 days, message replays may reprocess. (Refs #86, part of #28.)
+
 ## [0.8.2] - 2026-04-26
 
 ### Added

--- a/LookseeCore/looksee-persistence/src/main/java/com/looksee/services/IdempotencyService.java
+++ b/LookseeCore/looksee-persistence/src/main/java/com/looksee/services/IdempotencyService.java
@@ -29,14 +29,15 @@ import com.looksee.models.repository.ProcessedMessageRepository;
  * idempotencyService.markProcessed(pubsubMsgId, "page-builder");
  * }</pre>
  *
- * <p>Processed message records are automatically cleaned up after 3 days
- * via a scheduled job (PubSub message retention is 7 days, so 3 days
- * provides adequate coverage with margin).
+ * <p>Processed message records are automatically cleaned up after 8 days
+ * via a scheduled job. Pub/Sub retains undelivered messages for 7 days,
+ * so 8 days ensures a service offline for the full Pub/Sub window still
+ * finds its dedupe record on recovery (with one day of margin).
  */
 @Service
 public class IdempotencyService implements IdempotencyGuard {
     private static final Logger log = LoggerFactory.getLogger(IdempotencyService.class);
-    private static final int RETENTION_DAYS = 3;
+    private static final int RETENTION_DAYS = 8;
 
     @Autowired(required = false)
     private ProcessedMessageRepository processedMessageRepository;

--- a/LookseeCore/looksee-persistence/src/test/java/com/looksee/services/IdempotencyIntegrationTest.java
+++ b/LookseeCore/looksee-persistence/src/test/java/com/looksee/services/IdempotencyIntegrationTest.java
@@ -139,22 +139,22 @@ class IdempotencyIntegrationTest {
     @Test
     @DisplayName("Cleanup removes old records via deleteOlderThan")
     void testCleanupRemovesOldRecords() {
-        doNothing().when(processedMessageRepository).deleteOlderThan(3);
+        doNothing().when(processedMessageRepository).deleteOlderThan(8);
 
         idempotencyService.cleanupOldRecords();
 
-        verify(processedMessageRepository).deleteOlderThan(3);
+        verify(processedMessageRepository).deleteOlderThan(8);
     }
 
     @Test
     @DisplayName("Cleanup handles repository exception gracefully")
     void testCleanupHandlesException() {
         doThrow(new RuntimeException("DB connection failed"))
-                .when(processedMessageRepository).deleteOlderThan(3);
+                .when(processedMessageRepository).deleteOlderThan(8);
 
         // Should not throw
         assertDoesNotThrow(() -> idempotencyService.cleanupOldRecords());
-        verify(processedMessageRepository).deleteOlderThan(3);
+        verify(processedMessageRepository).deleteOlderThan(8);
     }
 
     @Test

--- a/LookseeCore/looksee-persistence/src/test/java/com/looksee/services/IdempotencyServiceTest.java
+++ b/LookseeCore/looksee-persistence/src/test/java/com/looksee/services/IdempotencyServiceTest.java
@@ -93,9 +93,9 @@ class IdempotencyServiceTest {
     }
 
     @Test
-    void cleanupOldRecords_callsRepositoryDeleteOlderThan3() {
+    void cleanupOldRecords_callsRepositoryDeleteOlderThan8() {
         idempotencyService.cleanupOldRecords();
-        verify(processedMessageRepository).deleteOlderThan(3);
+        verify(processedMessageRepository).deleteOlderThan(8);
     }
 
     @Test


### PR DESCRIPTION
## Summary

Step 7 of umbrella #28. Bumps `ProcessedMessage` dedupe retention from **3 days** to **8 days**.

Pub/Sub retains undelivered messages for **7 days**. With the previous 3-day retention, a service offline for 3+ days (extended outage, holiday freeze) would re-receive Pub/Sub messages whose dedupe records had already been swept, defeating the atomic-claim work delivered in steps 1–6 of #28. 8 days = Pub/Sub's 7-day window + 1 day of margin.

## Changes

- `IdempotencyService.RETENTION_DAYS`: `3` → `8` + Javadoc updated.
- `IdempotencyServiceTest.cleanupOldRecords_callsRepositoryDeleteOlderThan8`: assertion updated (renamed for accuracy).
- `IdempotencyIntegrationTest.testCleanupRemovesOldRecords` / `testCleanupHandlesException`: stubs and verifies updated to `8`.
- `CHANGELOG.md`: new `## [Unreleased]` section with a one-line `### Changed` entry. Step 9 (#88) will consolidate this under the `## [1.0.0]` release header during the version bump.

## DoD checklist (from #86)

- [x] `RETENTION_DAYS = 8`.
- [x] Cleanup query references `processedAt` — **already satisfied** by step 2's atomic-claim refactor (`ProcessedMessageRepository.deleteOlderThan` filters on `pm.processedAt`); no query change in this PR.
- [x] Existing scheduled-cleanup tests updated (both `IdempotencyServiceTest` and `IdempotencyIntegrationTest`).
- [x] CHANGELOG note added (Unreleased; will roll up into #88's 1.0.0 entry).

## Test plan

- [x] `mvn -pl looksee-persistence -am test` — 85/85 pass (including the two updated `IdempotencyIntegrationTest` cases and the renamed `IdempotencyServiceTest` case).
- [x] Grep guard: no remaining `RETENTION_DAYS = 3`, `after 3 days`, or `deleteOlderThan(3)` references in `looksee-persistence/src`.
- [ ] Reviewer to confirm the operational note in CHANGELOG ("if a service is down longer than 8 days, message replays may reprocess") is the right phrasing; #88 may rephrase during the 1.0.0 consolidation.

Refs #86, part of #28.

https://claude.ai/code/session_016eDUowDHfRtfE4NYEHrWfh

---
_Generated by [Claude Code](https://claude.ai/code/session_016eDUowDHfRtfE4NYEHrWfh)_