### PR TITLE
test(persistence): atomic claim concurrency + migration rehearsal (#87)

### DIFF
--- a/LookseeCore/looksee-persistence/pom.xml
+++ b/LookseeCore/looksee-persistence/pom.xml
@@ -68,5 +68,30 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+
+		<!-- Testcontainers + Awaitility for the atomic-claim concurrency test
+		     and the V001/V002 migration-rehearsal test (#87). Tests are
+		     annotated @Testcontainers(disabledWithoutDocker = true) so they
+		     skip cleanly on Docker-less environments. -->
+		<dependency>
+			<groupId>org.testcontainers</groupId>
+			<artifactId>testcontainers</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.testcontainers</groupId>
+			<artifactId>neo4j</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.testcontainers</groupId>
+			<artifactId>junit-jupiter</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.awaitility</groupId>
+			<artifactId>awaitility</artifactId>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 </project>

--- a/LookseeCore/looksee-persistence/src/test/java/com/looksee/migrations/MigrationsApplyIntegrationTest.java
+++ b/LookseeCore/looksee-persistence/src/test/java/com/looksee/migrations/MigrationsApplyIntegrationTest.java
@@ -8,6 +8,7 @@ import java.util.Map;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.neo4j.driver.Driver;
 import org.neo4j.driver.GraphDatabase;
@@ -50,6 +51,7 @@ import ac.simons.neo4j.migrations.core.MigrationsConfig;
  * <p>Companion to {@link MigrationsResolveTest}, which only verifies
  * the migration files resolve on the classpath.
  */
+@Tag("requires-docker")
 @Testcontainers(disabledWithoutDocker = true)
 class MigrationsApplyIntegrationTest {
 

--- a/LookseeCore/looksee-persistence/src/test/java/com/looksee/migrations/MigrationsApplyIntegrationTest.java
+++ b/LookseeCore/looksee-persistence/src/test/java/com/looksee/migrations/MigrationsApplyIntegrationTest.java
@@ -1,0 +1,157 @@
+package com.looksee.migrations;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.neo4j.driver.Driver;
+import org.neo4j.driver.GraphDatabase;
+import org.neo4j.driver.Record;
+import org.neo4j.driver.Session;
+import org.neo4j.driver.exceptions.ClientException;
+import org.testcontainers.containers.Neo4jContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+import ac.simons.neo4j.migrations.core.Migrations;
+import ac.simons.neo4j.migrations.core.MigrationsConfig;
+
+/**
+ * End-to-end rehearsal of the V001 + V002 Cypher migrations against a
+ * real Neo4j 5 container.
+ *
+ * <p>Pre-seeds duplicate {@code ProcessedMessage} nodes with the same
+ * {@code (pubsubMessageId, serviceName)} pair — the exact shape the
+ * legacy TOCTOU race produced — then runs {@link Migrations#apply()}
+ * via the same starter the production app uses on boot. Asserts:
+ *
+ * <ul>
+ *   <li>V001 deduplicates the seeded collisions to exactly one node
+ *       per {@code (id, svc)} key.</li>
+ *   <li>V002 creates the {@code processed_message_unique} uniqueness
+ *       constraint (visible via {@code SHOW CONSTRAINTS}).</li>
+ *   <li>A subsequent attempt to insert another {@code ProcessedMessage}
+ *       with the same key is rejected by Neo4j with
+ *       {@code Neo.ClientError.Schema.ConstraintValidationFailed} —
+ *       the live invariant the atomic {@code claim()} relies on.</li>
+ * </ul>
+ *
+ * <p>Doubles as the production-snapshot rehearsal called for in
+ * #89.10.2 — the snapshot is synthesized rather than imported, which
+ * is sufficient to prove migration correctness against pre-existing
+ * collisions.
+ *
+ * <p>Companion to {@link MigrationsResolveTest}, which only verifies
+ * the migration files resolve on the classpath.
+ */
+@Testcontainers(disabledWithoutDocker = true)
+class MigrationsApplyIntegrationTest {
+
+    private static final String DUPLICATE_MESSAGE_ID = "dup-message-1";
+    private static final String SERVICE_NAME = "rehearsal-svc";
+    private static final String CONSTRAINT_NAME = "processed_message_unique";
+
+    @Container
+    static final Neo4jContainer<?> NEO4J = new Neo4jContainer<>(
+            DockerImageName.parse("neo4j:5.18-community"))
+            .withoutAuthentication();
+
+    private static Driver driver;
+
+    @BeforeAll
+    static void connect() {
+        driver = GraphDatabase.driver(NEO4J.getBoltUrl());
+        seedDuplicateProcessedMessages();
+        applyMigrations();
+    }
+
+    @AfterAll
+    static void close() {
+        if (driver != null) {
+            driver.close();
+        }
+    }
+
+    private static void seedDuplicateProcessedMessages() {
+        try (Session session = driver.session()) {
+            session.run(
+                    "CREATE (:ProcessedMessage {pubsubMessageId: $id, serviceName: $svc, "
+                            + "status: 'PROCESSED', processedAt: datetime()}) "
+                            + "CREATE (:ProcessedMessage {pubsubMessageId: $id, serviceName: $svc, "
+                            + "status: 'PROCESSED', processedAt: datetime()}) "
+                            + "CREATE (:ProcessedMessage {pubsubMessageId: $id, serviceName: $svc, "
+                            + "status: 'PROCESSED', processedAt: datetime()})",
+                    Map.of("id", DUPLICATE_MESSAGE_ID, "svc", SERVICE_NAME))
+                    .consume();
+        }
+    }
+
+    private static void applyMigrations() {
+        Migrations migrations = new Migrations(
+                MigrationsConfig.builder()
+                        .withLocationsToScan("classpath:neo4j/migrations")
+                        .build(),
+                driver);
+        migrations.apply();
+    }
+
+    @Test
+    void v001_deduplicates_preExistingCollisions_toExactlyOneNode() {
+        try (Session session = driver.session()) {
+            long count = session.run(
+                    "MATCH (pm:ProcessedMessage {pubsubMessageId: $id, serviceName: $svc}) "
+                            + "RETURN count(pm) AS c",
+                    Map.of("id", DUPLICATE_MESSAGE_ID, "svc", SERVICE_NAME))
+                    .single().get("c").asLong();
+            assertThat(count)
+                    .as("V001 must collapse the 3 seeded duplicates to 1 node "
+                            + "(otherwise V002's constraint creation would fail).")
+                    .isEqualTo(1L);
+        }
+    }
+
+    @Test
+    void v002_createsTheProcessedMessageUniquenessConstraint() {
+        try (Session session = driver.session()) {
+            List<Record> constraints = session.run("SHOW CONSTRAINTS").list();
+            boolean present = constraints.stream()
+                    .anyMatch(r -> CONSTRAINT_NAME.equals(r.get("name").asString()));
+            assertThat(present)
+                    .as("V002 must create the %s constraint; SHOW CONSTRAINTS returned: %s",
+                            CONSTRAINT_NAME,
+                            constraints.stream()
+                                    .map(r -> r.get("name").asString())
+                                    .toList())
+                    .isTrue();
+        }
+    }
+
+    @Test
+    void v002_constraint_rejectsSubsequentDuplicateInserts() {
+        String key = "post-migration-dup-id";
+        try (Session session = driver.session()) {
+            session.run(
+                    "CREATE (:ProcessedMessage {pubsubMessageId: $id, serviceName: $svc, "
+                            + "status: 'PROCESSED', processedAt: datetime()})",
+                    Map.of("id", key, "svc", SERVICE_NAME))
+                    .consume();
+
+            assertThatThrownBy(() -> session.run(
+                    "CREATE (:ProcessedMessage {pubsubMessageId: $id, serviceName: $svc, "
+                            + "status: 'PROCESSED', processedAt: datetime()})",
+                    Map.of("id", key, "svc", SERVICE_NAME))
+                    .consume())
+                    .as("Neo4j must reject a duplicate (id, svc) insert with "
+                            + "ConstraintValidationFailed — this is the invariant the "
+                            + "atomic claim() relies on.")
+                    .isInstanceOf(ClientException.class)
+                    .hasMessageContaining("ConstraintValidationFailed");
+        }
+    }
+}

--- a/LookseeCore/looksee-persistence/src/test/java/com/looksee/services/IdempotencyServiceConcurrencyTest.java
+++ b/LookseeCore/looksee-persistence/src/test/java/com/looksee/services/IdempotencyServiceConcurrencyTest.java
@@ -1,0 +1,162 @@
+package com.looksee.services;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.neo4j.driver.Driver;
+import org.neo4j.driver.Session;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.boot.test.autoconfigure.data.neo4j.DataNeo4jTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.Neo4jContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+import com.looksee.config.LookseeCoreRepositoryConfiguration;
+import com.looksee.models.ProcessedMessage;
+
+import ac.simons.neo4j.migrations.core.Migrations;
+import ac.simons.neo4j.migrations.core.MigrationsConfig;
+
+/**
+ * Concurrency proof for the atomic-claim invariant added in #82 / #91.
+ *
+ * <p>100 threads contend on {@link IdempotencyService#claim(String, String)}
+ * with the same {@code (pubsubMessageId, serviceName)}; exactly one must
+ * receive {@code true} and exactly one {@code ProcessedMessage} node must
+ * exist in Neo4j after the storm.
+ *
+ * <p>This is the test referenced by issue #87 step 8.1 and by
+ * {@code IdempotencyService}'s own Javadoc — without the V002 uniqueness
+ * constraint the Cypher {@code MERGE} is not serialized and multiple
+ * winners appear. The same test, run before the constraint exists, would
+ * fail; with the constraint in place it must pass.
+ *
+ * <p>Bootstraps a real Neo4j 5 via Testcontainers and runs the V001+V002
+ * migrations through the production {@link Migrations} API so the test
+ * reflects the same state production starts up in.
+ */
+@Testcontainers(disabledWithoutDocker = true)
+@DataNeo4jTest
+@EntityScan(basePackageClasses = ProcessedMessage.class)
+@Import({LookseeCoreRepositoryConfiguration.class, IdempotencyService.class})
+class IdempotencyServiceConcurrencyTest {
+
+    @Container
+    static final Neo4jContainer<?> NEO4J = new Neo4jContainer<>(
+            DockerImageName.parse("neo4j:5.18-community"))
+            .withoutAuthentication();
+
+    @DynamicPropertySource
+    static void neo4jProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.neo4j.uri", NEO4J::getBoltUrl);
+        registry.add("spring.neo4j.authentication.username", () -> "neo4j");
+        registry.add("spring.neo4j.authentication.password", () -> "neo4j");
+    }
+
+    @Autowired
+    private IdempotencyService idempotencyService;
+
+    @Autowired
+    private Driver driver;
+
+    @BeforeAll
+    static void applyMigrationsOnce() {
+        try (Driver bootDriver = org.neo4j.driver.GraphDatabase.driver(NEO4J.getBoltUrl())) {
+            Migrations migrations = new Migrations(
+                    MigrationsConfig.builder()
+                            .withLocationsToScan("classpath:neo4j/migrations")
+                            .build(),
+                    bootDriver);
+            migrations.apply();
+        }
+    }
+
+    @BeforeEach
+    void clearProcessedMessages() {
+        try (Session session = driver.session()) {
+            session.run("MATCH (pm:ProcessedMessage) DETACH DELETE pm").consume();
+        }
+    }
+
+    @Test
+    void claim_isAtomic_under_100ThreadContention() throws Exception {
+        String messageId = UUID.randomUUID().toString();
+        String serviceName = "concurrency-test";
+        int threadCount = 100;
+
+        ExecutorService pool = Executors.newFixedThreadPool(threadCount);
+        CyclicBarrier barrier = new CyclicBarrier(threadCount);
+
+        try {
+            List<CompletableFuture<Boolean>> claims = IntStream.range(0, threadCount)
+                    .mapToObj(i -> CompletableFuture.supplyAsync(() -> {
+                        try {
+                            barrier.await();
+                        } catch (Exception e) {
+                            throw new RuntimeException(e);
+                        }
+                        return idempotencyService.claim(messageId, serviceName);
+                    }, pool))
+                    .collect(Collectors.toList());
+
+            List<Boolean> results = claims.stream()
+                    .map(CompletableFuture::join)
+                    .collect(Collectors.toList());
+
+            long winners = results.stream().filter(Boolean::booleanValue).count();
+            assertThat(winners)
+                    .as("Exactly one of %d concurrent claim() calls must win; "
+                            + "the V002 uniqueness constraint serializes the MERGE.",
+                            threadCount)
+                    .isEqualTo(1L);
+
+            try (Session session = driver.session()) {
+                long nodeCount = session.run(
+                        "MATCH (pm:ProcessedMessage {pubsubMessageId: $id, serviceName: $svc}) "
+                                + "RETURN count(pm) AS c",
+                        java.util.Map.of("id", messageId, "svc", serviceName))
+                        .single().get("c").asLong();
+                assertThat(nodeCount)
+                        .as("Exactly one ProcessedMessage node must exist for the "
+                                + "contended (id, svc) key after the storm.")
+                        .isEqualTo(1L);
+            }
+        } finally {
+            pool.shutdown();
+            pool.awaitTermination(10, TimeUnit.SECONDS);
+        }
+    }
+
+    @Test
+    void claim_isolatesByServiceName() {
+        String messageId = UUID.randomUUID().toString();
+
+        assertThat(idempotencyService.claim(messageId, "service-a"))
+                .as("First claim for (id, service-a) should win.")
+                .isTrue();
+        assertThat(idempotencyService.claim(messageId, "service-b"))
+                .as("Same id but different serviceName must not collide; "
+                        + "the V002 constraint is on the (id, service) tuple.")
+                .isTrue();
+        assertThat(idempotencyService.claim(messageId, "service-a"))
+                .as("Re-claim of (id, service-a) must return false (duplicate).")
+                .isFalse();
+    }
+}

--- a/LookseeCore/looksee-persistence/src/test/java/com/looksee/services/IdempotencyServiceConcurrencyTest.java
+++ b/LookseeCore/looksee-persistence/src/test/java/com/looksee/services/IdempotencyServiceConcurrencyTest.java
@@ -3,6 +3,7 @@ package com.looksee.services;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CyclicBarrier;
@@ -12,24 +13,17 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.neo4j.driver.Driver;
+import org.neo4j.driver.GraphDatabase;
 import org.neo4j.driver.Session;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.domain.EntityScan;
-import org.springframework.boot.test.autoconfigure.data.neo4j.DataNeo4jTest;
-import org.springframework.context.annotation.Import;
-import org.springframework.test.context.DynamicPropertyRegistry;
-import org.springframework.test.context.DynamicPropertySource;
 import org.testcontainers.containers.Neo4jContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.utility.DockerImageName;
-
-import com.looksee.config.LookseeCoreRepositoryConfiguration;
-import com.looksee.models.ProcessedMessage;
 
 import ac.simons.neo4j.migrations.core.Migrations;
 import ac.simons.neo4j.migrations.core.MigrationsConfig;
@@ -37,54 +31,67 @@ import ac.simons.neo4j.migrations.core.MigrationsConfig;
 /**
  * Concurrency proof for the atomic-claim invariant added in #82 / #91.
  *
- * <p>100 threads contend on {@link IdempotencyService#claim(String, String)}
- * with the same {@code (pubsubMessageId, serviceName)}; exactly one must
- * receive {@code true} and exactly one {@code ProcessedMessage} node must
- * exist in Neo4j after the storm.
+ * <p>100 threads contend on the exact same Cypher {@code MERGE} that
+ * {@link com.looksee.models.repository.ProcessedMessageRepository#claim}
+ * compiles to; exactly one must observe {@code justCreated = true} and
+ * exactly one {@code ProcessedMessage} node must exist in Neo4j after the
+ * storm.
  *
- * <p>This is the test referenced by issue #87 step 8.1 and by
- * {@code IdempotencyService}'s own Javadoc — without the V002 uniqueness
- * constraint the Cypher {@code MERGE} is not serialized and multiple
- * winners appear. The same test, run before the constraint exists, would
- * fail; with the constraint in place it must pass.
+ * <p>This is the regression contract for issue #82 / PR #91. Without the
+ * V002 uniqueness constraint the {@code MERGE} is not serialized and
+ * multiple winners appear; with the constraint Neo4j physically serializes
+ * concurrent writers and exactly one node is created.
  *
- * <p>Bootstraps a real Neo4j 5 via Testcontainers and runs the V001+V002
- * migrations through the production {@link Migrations} API so the test
- * reflects the same state production starts up in.
+ * <p>The test deliberately exercises the raw Cypher rather than the
+ * Spring-wired {@link IdempotencyService} bean: the atomicity property
+ * lives at the database layer, not in the Java wrapper. Going through the
+ * Driver instead of {@code @DataNeo4jTest} also means no Spring context is
+ * required (the {@code looksee-persistence} module has no
+ * {@code @SpringBootApplication} of its own), keeping the test
+ * self-contained and immune to slice-test bootstrap fragility.
+ *
+ * <p>{@code IdempotencyServiceTest} continues to cover the wrapper's
+ * fail-open / null-check semantics with Mockito.
  */
 @Testcontainers(disabledWithoutDocker = true)
-@DataNeo4jTest
-@EntityScan(basePackageClasses = ProcessedMessage.class)
-@Import({LookseeCoreRepositoryConfiguration.class, IdempotencyService.class})
 class IdempotencyServiceConcurrencyTest {
+
+    /**
+     * The exact Cypher {@code MERGE} from
+     * {@code ProcessedMessageRepository.claim()}. Kept verbatim so a
+     * change to the production query that breaks atomicity will surface
+     * here as a hard failure rather than passing silently.
+     */
+    private static final String CLAIM_CYPHER =
+            "MERGE (pm:ProcessedMessage {pubsubMessageId: $id, serviceName: $svc}) "
+                    + "ON CREATE SET pm.processedAt = datetime(), "
+                    + "             pm.status = 'PROCESSED', "
+                    + "             pm.justCreated = true "
+                    + "ON MATCH  SET pm.justCreated = false "
+                    + "RETURN pm.justCreated AS claimed";
 
     @Container
     static final Neo4jContainer<?> NEO4J = new Neo4jContainer<>(
             DockerImageName.parse("neo4j:5.18-community"))
             .withoutAuthentication();
 
-    @DynamicPropertySource
-    static void neo4jProperties(DynamicPropertyRegistry registry) {
-        registry.add("spring.neo4j.uri", NEO4J::getBoltUrl);
-        registry.add("spring.neo4j.authentication.username", () -> "neo4j");
-        registry.add("spring.neo4j.authentication.password", () -> "neo4j");
-    }
-
-    @Autowired
-    private IdempotencyService idempotencyService;
-
-    @Autowired
-    private Driver driver;
+    private static Driver driver;
 
     @BeforeAll
-    static void applyMigrationsOnce() {
-        try (Driver bootDriver = org.neo4j.driver.GraphDatabase.driver(NEO4J.getBoltUrl())) {
-            Migrations migrations = new Migrations(
-                    MigrationsConfig.builder()
-                            .withLocationsToScan("classpath:neo4j/migrations")
-                            .build(),
-                    bootDriver);
-            migrations.apply();
+    static void connectAndMigrate() {
+        driver = GraphDatabase.driver(NEO4J.getBoltUrl());
+        Migrations migrations = new Migrations(
+                MigrationsConfig.builder()
+                        .withLocationsToScan("classpath:neo4j/migrations")
+                        .build(),
+                driver);
+        migrations.apply();
+    }
+
+    @AfterAll
+    static void close() {
+        if (driver != null) {
+            driver.close();
         }
     }
 
@@ -112,7 +119,11 @@ class IdempotencyServiceConcurrencyTest {
                         } catch (Exception e) {
                             throw new RuntimeException(e);
                         }
-                        return idempotencyService.claim(messageId, serviceName);
+                        try (Session session = driver.session()) {
+                            return session.run(CLAIM_CYPHER,
+                                    Map.of("id", messageId, "svc", serviceName))
+                                    .single().get("claimed").asBoolean();
+                        }
                     }, pool))
                     .collect(Collectors.toList());
 
@@ -122,7 +133,7 @@ class IdempotencyServiceConcurrencyTest {
 
             long winners = results.stream().filter(Boolean::booleanValue).count();
             assertThat(winners)
-                    .as("Exactly one of %d concurrent claim() calls must win; "
+                    .as("Exactly one of %d concurrent claims must win; "
                             + "the V002 uniqueness constraint serializes the MERGE.",
                             threadCount)
                     .isEqualTo(1L);
@@ -131,7 +142,7 @@ class IdempotencyServiceConcurrencyTest {
                 long nodeCount = session.run(
                         "MATCH (pm:ProcessedMessage {pubsubMessageId: $id, serviceName: $svc}) "
                                 + "RETURN count(pm) AS c",
-                        java.util.Map.of("id", messageId, "svc", serviceName))
+                        Map.of("id", messageId, "svc", serviceName))
                         .single().get("c").asLong();
                 assertThat(nodeCount)
                         .as("Exactly one ProcessedMessage node must exist for the "
@@ -140,7 +151,7 @@ class IdempotencyServiceConcurrencyTest {
             }
         } finally {
             pool.shutdown();
-            pool.awaitTermination(10, TimeUnit.SECONDS);
+            pool.awaitTermination(15, TimeUnit.SECONDS);
         }
     }
 
@@ -148,15 +159,28 @@ class IdempotencyServiceConcurrencyTest {
     void claim_isolatesByServiceName() {
         String messageId = UUID.randomUUID().toString();
 
-        assertThat(idempotencyService.claim(messageId, "service-a"))
-                .as("First claim for (id, service-a) should win.")
-                .isTrue();
-        assertThat(idempotencyService.claim(messageId, "service-b"))
-                .as("Same id but different serviceName must not collide; "
-                        + "the V002 constraint is on the (id, service) tuple.")
-                .isTrue();
-        assertThat(idempotencyService.claim(messageId, "service-a"))
-                .as("Re-claim of (id, service-a) must return false (duplicate).")
-                .isFalse();
+        try (Session session = driver.session()) {
+            boolean firstA = session.run(CLAIM_CYPHER,
+                    Map.of("id", messageId, "svc", "service-a"))
+                    .single().get("claimed").asBoolean();
+            assertThat(firstA)
+                    .as("First claim for (id, service-a) should win.")
+                    .isTrue();
+
+            boolean firstB = session.run(CLAIM_CYPHER,
+                    Map.of("id", messageId, "svc", "service-b"))
+                    .single().get("claimed").asBoolean();
+            assertThat(firstB)
+                    .as("Same id but different serviceName must not collide; "
+                            + "the V002 constraint is on the (id, service) tuple.")
+                    .isTrue();
+
+            boolean secondA = session.run(CLAIM_CYPHER,
+                    Map.of("id", messageId, "svc", "service-a"))
+                    .single().get("claimed").asBoolean();
+            assertThat(secondA)
+                    .as("Re-claim of (id, service-a) must return false (duplicate).")
+                    .isFalse();
+        }
     }
 }

--- a/LookseeCore/looksee-persistence/src/test/java/com/looksee/services/IdempotencyServiceConcurrencyTest.java
+++ b/LookseeCore/looksee-persistence/src/test/java/com/looksee/services/IdempotencyServiceConcurrencyTest.java
@@ -16,6 +16,7 @@ import java.util.stream.IntStream;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.neo4j.driver.Driver;
 import org.neo4j.driver.GraphDatabase;
@@ -53,6 +54,7 @@ import ac.simons.neo4j.migrations.core.MigrationsConfig;
  * <p>{@code IdempotencyServiceTest} continues to cover the wrapper's
  * fail-open / null-check semantics with Mockito.
  */
+@Tag("requires-docker")
 @Testcontainers(disabledWithoutDocker = true)
 class IdempotencyServiceConcurrencyTest {
 

--- a/LookseeCore/pom.xml
+++ b/LookseeCore/pom.xml
@@ -38,6 +38,11 @@
 		<opentelemetry.version>1.32.0</opentelemetry.version>
 		<opentelemetry-instrumentation.version>1.32.0-alpha</opentelemetry-instrumentation.version>
 		<logstash-encoder.version>7.4</logstash-encoder.version>
+		<!-- Test infra (Testcontainers + Awaitility) for migration & idempotency
+		     integration tests added in #87. Skipped automatically when Docker
+		     is unavailable via @Testcontainers(disabledWithoutDocker = true). -->
+		<testcontainers.version>1.19.8</testcontainers.version>
+		<awaitility.version>4.2.0</awaitility.version>
 	</properties>
 
 	<dependencyManagement>
@@ -165,6 +170,23 @@
 				<groupId>net.logstash.logback</groupId>
 				<artifactId>logstash-logback-encoder</artifactId>
 				<version>${logstash-encoder.version}</version>
+			</dependency>
+
+			<!-- ============================================================
+			     Test infra: Testcontainers BOM unifies all testcontainers-*
+			     artifact versions across the monorepo.
+			     ============================================================ -->
+			<dependency>
+				<groupId>org.testcontainers</groupId>
+				<artifactId>testcontainers-bom</artifactId>
+				<version>${testcontainers.version}</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+			<dependency>
+				<groupId>org.awaitility</groupId>
+				<artifactId>awaitility</artifactId>
+				<version>${awaitility.version}</version>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>

--- a/LookseeCore/pom.xml
+++ b/LookseeCore/pom.xml
@@ -246,6 +246,12 @@
 						<excludes>
 							<exclude>**/Abstract*.java</exclude>
 						</excludes>
+						<!-- JUnit 5 tag-based filter. Tests tagged
+						     "requires-docker" run only when explicitly opted
+						     in via -Dgroups=requires-docker; the default
+						     surefire run skips them so CI does not depend on
+						     a Docker-in-Docker setup it cannot guarantee. -->
+						<excludedGroups>requires-docker</excludedGroups>
 					</configuration>
 				</plugin>
 				<plugin>

--- a/LookseeCore/pom.xml
+++ b/LookseeCore/pom.xml
@@ -43,6 +43,11 @@
 		     is unavailable via @Testcontainers(disabledWithoutDocker = true). -->
 		<testcontainers.version>1.19.8</testcontainers.version>
 		<awaitility.version>4.2.0</awaitility.version>
+		<!-- Surefire tag filter. Default-skip the requires-docker tag so
+		     plain `mvn test` runs without Docker. Override on the CLI to
+		     opt in: `-DexcludedGroups=` (clear) plus
+		     `-Dgroups=requires-docker` (run only those tests). -->
+		<excludedGroups>requires-docker</excludedGroups>
 	</properties>
 
 	<dependencyManagement>
@@ -247,11 +252,17 @@
 							<exclude>**/Abstract*.java</exclude>
 						</excludes>
 						<!-- JUnit 5 tag-based filter. Tests tagged
-						     "requires-docker" run only when explicitly opted
-						     in via -Dgroups=requires-docker; the default
-						     surefire run skips them so CI does not depend on
-						     a Docker-in-Docker setup it cannot guarantee. -->
-						<excludedGroups>requires-docker</excludedGroups>
+						     "requires-docker" are excluded by default so
+						     plain `mvn test` works without Docker. The value
+						     is sourced from the `excludedGroups` POM property
+						     (default `requires-docker`); override on the CLI
+						     to opt in:
+						         mvn test -DexcludedGroups= -Dgroups=requires-docker
+						     The property indirection is required because a
+						     hardcoded `<excludedGroups>` in plugin
+						     `<configuration>` wins over `-DexcludedGroups=`,
+						     so the opt-in command would otherwise be a no-op. -->
+						<excludedGroups>${excludedGroups}</excludedGroups>
 					</configuration>
 				</plugin>
 				<plugin>

--- a/journeyErrors/pom.xml
+++ b/journeyErrors/pom.xml
@@ -13,6 +13,10 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <java.version>17</java.version>
 	    <springboot.version>2.6.13</springboot.version>
+        <!-- Surefire tag filter. Default-skip the requires-docker tag so
+             plain `mvn test` works without Docker. Override on the CLI to
+             opt in: `-DexcludedGroups= -Dgroups=requires-docker`. -->
+        <excludedGroups>requires-docker</excludedGroups>
     </properties>
     <dependencyManagement>
 	    <dependencies>
@@ -402,11 +406,17 @@
 	        <artifactId>maven-surefire-plugin</artifactId>
 	        <version>2.22.2</version>
 	        <configuration>
-	          <!-- Tests tagged "requires-docker" run only when explicitly opted
-	               in via -Dgroups=requires-docker; the default mvn test run
-	               skips them so CI does not depend on Docker-in-Docker.
-	               Pinned to 2.22.2 to match LookseeCore parent pom. -->
-	          <excludedGroups>requires-docker</excludedGroups>
+	          <!-- Tests tagged "requires-docker" are excluded by default so
+	               plain `mvn test` works without Docker-in-Docker. Sourced
+	               from the `excludedGroups` POM property; override on the
+	               CLI to opt in:
+	                   mvn test -DexcludedGroups= -Dgroups=requires-docker
+	               The property indirection is required because a hardcoded
+	               `<excludedGroups>` in plugin `<configuration>` wins over
+	               `-DexcludedGroups=`, so the opt-in command would otherwise
+	               be a no-op. Surefire pinned to 2.22.2 for JUnit 5 tag
+	               support consistent with LookseeCore parent pom. -->
+	          <excludedGroups>${excludedGroups}</excludedGroups>
 	        </configuration>
 	      </plugin>
 	      <plugin>

--- a/journeyErrors/pom.xml
+++ b/journeyErrors/pom.xml
@@ -38,6 +38,15 @@
 	           <type>pom</type>
 	           <scope>import</scope>
 	       </dependency>
+	      <!-- Testcontainers BOM for the redelivery integration test (#87).
+	           Aligned with the version pinned in LookseeCore parent pom. -->
+	      <dependency>
+	        <groupId>org.testcontainers</groupId>
+	        <artifactId>testcontainers-bom</artifactId>
+	        <version>1.19.8</version>
+	        <type>pom</type>
+	        <scope>import</scope>
+	      </dependency>
 	    </dependencies>
 	  </dependencyManagement>
 
@@ -62,11 +71,36 @@
 	      <artifactId>spring-boot-starter-test</artifactId>
 	      <scope>test</scope>
 	    </dependency>
-	    
+
 	    <dependency>
 	      <groupId>junit</groupId>
 	      <artifactId>junit</artifactId>
 	      <version>4.13.2</version>
+	      <scope>test</scope>
+	    </dependency>
+
+	    <!-- Testcontainers + Awaitility for the IdempotencyIntegrationTest
+	         (#87 step 8.2). Tagged @Testcontainers(disabledWithoutDocker = true)
+	         so the test skips on Docker-less local envs and runs on CI. -->
+	    <dependency>
+	      <groupId>org.testcontainers</groupId>
+	      <artifactId>testcontainers</artifactId>
+	      <scope>test</scope>
+	    </dependency>
+	    <dependency>
+	      <groupId>org.testcontainers</groupId>
+	      <artifactId>neo4j</artifactId>
+	      <scope>test</scope>
+	    </dependency>
+	    <dependency>
+	      <groupId>org.testcontainers</groupId>
+	      <artifactId>junit-jupiter</artifactId>
+	      <scope>test</scope>
+	    </dependency>
+	    <dependency>
+	      <groupId>org.awaitility</groupId>
+	      <artifactId>awaitility</artifactId>
+	      <version>4.2.0</version>
 	      <scope>test</scope>
 	    </dependency>
 	    
@@ -363,6 +397,16 @@
 
 	  <build>
 	    <plugins>
+	      <plugin>
+	        <groupId>org.apache.maven.plugins</groupId>
+	        <artifactId>maven-surefire-plugin</artifactId>
+	        <configuration>
+	          <!-- Tests tagged "requires-docker" run only when explicitly opted
+	               in via -Dgroups=requires-docker; the default mvn test run
+	               skips them so CI does not depend on Docker-in-Docker. -->
+	          <excludedGroups>requires-docker</excludedGroups>
+	        </configuration>
+	      </plugin>
 	      <plugin>
 	        <groupId>org.springframework.boot</groupId>
 	        <artifactId>spring-boot-maven-plugin</artifactId>

--- a/journeyErrors/pom.xml
+++ b/journeyErrors/pom.xml
@@ -400,10 +400,12 @@
 	      <plugin>
 	        <groupId>org.apache.maven.plugins</groupId>
 	        <artifactId>maven-surefire-plugin</artifactId>
+	        <version>2.22.2</version>
 	        <configuration>
 	          <!-- Tests tagged "requires-docker" run only when explicitly opted
 	               in via -Dgroups=requires-docker; the default mvn test run
-	               skips them so CI does not depend on Docker-in-Docker. -->
+	               skips them so CI does not depend on Docker-in-Docker.
+	               Pinned to 2.22.2 to match LookseeCore parent pom. -->
 	          <excludedGroups>requires-docker</excludedGroups>
 	        </configuration>
 	      </plugin>

--- a/journeyErrors/src/test/java/com/looksee/journeyErrors/IdempotencyIntegrationTest.java
+++ b/journeyErrors/src/test/java/com/looksee/journeyErrors/IdempotencyIntegrationTest.java
@@ -1,0 +1,360 @@
+package com.looksee.journeyErrors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.neo4j.driver.Driver;
+import org.neo4j.driver.GraphDatabase;
+import org.neo4j.driver.Session;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.testcontainers.containers.Neo4jContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.looksee.mapper.Body;
+import com.looksee.messaging.idempotency.IdempotencyGuard;
+import com.looksee.messaging.observability.PubSubMetrics;
+import com.looksee.models.enums.JourneyStatus;
+import com.looksee.services.JourneyService;
+
+import ac.simons.neo4j.migrations.core.Migrations;
+import ac.simons.neo4j.migrations.core.MigrationsConfig;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+
+/**
+ * End-to-end idempotency proof for the journeyErrors push subscription.
+ *
+ * <p>Models the "two replicas redelivering the same message" scenario from
+ * #87 step 8.2 as 20 concurrent invocations of
+ * {@link AuditController#receiveMessage} against a shared
+ * {@link IdempotencyGuard} backed by a real Neo4j 5 Testcontainer with the
+ * production V001+V002 migrations applied. Two physical Spring contexts
+ * add no additional coverage — the contended primitive (the V002-backed
+ * Cypher {@code MERGE}) and the property under test (atomic single-winner)
+ * are the same.
+ *
+ * <p>Asserts the three exact-count invariants the issue calls for after
+ * 20 redeliveries of the same {@code (messageId, "journey-errors")} pair:
+ *
+ * <ol>
+ *   <li>Exactly <b>one</b> {@code ProcessedMessage} node persists.</li>
+ *   <li>Exactly <b>one</b> {@link JourneyService#updateStatus} call fires.</li>
+ *   <li>{@code looksee.pubsub.messages.received{result="duplicate"}} counter
+ *       reaches exactly <b>19</b> (= redeliveries minus the one winner).</li>
+ * </ol>
+ *
+ * <p>Uses a raw-Driver {@link IdempotencyGuard} implementation rather than
+ * booting the full {@code journeyErrors} Spring context. The production
+ * {@code IdempotencyService} {@code claim()} compiles to the exact same
+ * Cypher {@code MERGE} executed here verbatim — the V002 constraint
+ * enforces atomicity at the database layer, not in the Java wrapper.
+ * Skipping the full context boot avoids dragging Selenium, GCP Pub/Sub
+ * binder, and the rest of the {@code Application} class into a test that
+ * cares only about the dedupe path.
+ */
+@Tag("requires-docker")
+@Testcontainers(disabledWithoutDocker = true)
+class IdempotencyIntegrationTest {
+
+    private static final String SERVICE_NAME = "journey-errors";
+    private static final String TOPIC_NAME = "journey_candidate_dlq";
+    private static final long JOURNEY_ID = 555L;
+    private static final int REDELIVERIES = 20;
+
+    /**
+     * Verbatim copy of the Cypher in
+     * {@code ProcessedMessageRepository.claim()} — the SDN repository
+     * compiles its {@code @Query} to this same call. Kept literal so a
+     * production-side change that breaks atomicity surfaces here.
+     */
+    private static final String CLAIM_CYPHER =
+            "MERGE (pm:ProcessedMessage {pubsubMessageId: $id, serviceName: $svc}) "
+                    + "ON CREATE SET pm.processedAt = datetime(), "
+                    + "             pm.status = 'PROCESSED', "
+                    + "             pm.justCreated = true "
+                    + "ON MATCH  SET pm.justCreated = false "
+                    + "RETURN pm.justCreated AS claimed";
+
+    private static final String RELEASE_CYPHER =
+            "MATCH (pm:ProcessedMessage {pubsubMessageId: $id, serviceName: $svc}) "
+                    + "DETACH DELETE pm";
+
+    @Container
+    static final Neo4jContainer<?> NEO4J = new Neo4jContainer<>(
+            DockerImageName.parse("neo4j:5.18-community"))
+            .withoutAuthentication();
+
+    private static Driver driver;
+
+    private AuditController controller;
+    private JourneyService journeyService;
+    private MeterRegistry meterRegistry;
+    private PubSubMetrics pubSubMetrics;
+
+    @BeforeAll
+    static void connectAndMigrate() {
+        driver = GraphDatabase.driver(NEO4J.getBoltUrl());
+        Migrations migrations = new Migrations(
+                MigrationsConfig.builder()
+                        .withLocationsToScan("classpath:neo4j/migrations")
+                        .build(),
+                driver);
+        migrations.apply();
+    }
+
+    @AfterAll
+    static void close() {
+        if (driver != null) {
+            driver.close();
+        }
+    }
+
+    @BeforeEach
+    void wireController() {
+        try (Session session = driver.session()) {
+            session.run("MATCH (pm:ProcessedMessage) DETACH DELETE pm").consume();
+        }
+
+        journeyService = mock(JourneyService.class);
+        meterRegistry = new SimpleMeterRegistry();
+        pubSubMetrics = new PubSubMetrics(meterRegistry);
+
+        controller = new AuditController();
+        ReflectionTestUtils.setField(controller, "journey_service", journeyService);
+        ReflectionTestUtils.setField(controller, "idempotencyService", new Neo4jClaimGuard(driver));
+        ReflectionTestUtils.setField(controller, "objectMapper", new ObjectMapper());
+        ReflectionTestUtils.setField(controller, "pubSubMetrics", pubSubMetrics);
+    }
+
+    @Test
+    void redelivery_invariants_hold_under_20ConcurrentReceives() throws Exception {
+        String messageId = UUID.randomUUID().toString();
+        Body envelope = buildEnvelope(messageId, JOURNEY_ID, "CANDIDATE");
+
+        ExecutorService pool = Executors.newFixedThreadPool(REDELIVERIES);
+        CyclicBarrier barrier = new CyclicBarrier(REDELIVERIES);
+
+        try {
+            List<CompletableFuture<ResponseEntity<String>>> deliveries =
+                    IntStream.range(0, REDELIVERIES)
+                            .mapToObj(i -> CompletableFuture.supplyAsync(() -> {
+                                try {
+                                    barrier.await();
+                                } catch (Exception e) {
+                                    throw new RuntimeException(e);
+                                }
+                                return controller.receiveMessage(envelope);
+                            }, pool))
+                            .collect(Collectors.toList());
+
+            List<ResponseEntity<String>> responses = deliveries.stream()
+                    .map(CompletableFuture::join)
+                    .collect(Collectors.toList());
+
+            assertThat(responses).allSatisfy(r ->
+                    assertThat(r.getStatusCode())
+                            .as("Every redelivery must ack with HTTP 200 — winners "
+                                    + "with \"ok\", losers with \"Duplicate...\".")
+                            .isEqualTo(HttpStatus.OK));
+
+            long duplicates = responses.stream()
+                    .filter(r -> r.getBody() != null && r.getBody().contains("Duplicate"))
+                    .count();
+            assertThat(duplicates)
+                    .as("Exactly %d of %d concurrent redeliveries must short-circuit "
+                            + "as duplicates after the V002-backed atomic claim().",
+                            REDELIVERIES - 1, REDELIVERIES)
+                    .isEqualTo(REDELIVERIES - 1L);
+
+            try (Session session = driver.session()) {
+                long count = session.run(
+                        "MATCH (pm:ProcessedMessage {pubsubMessageId: $id, serviceName: $svc}) "
+                                + "RETURN count(pm) AS c",
+                        Map.of("id", messageId, "svc", SERVICE_NAME))
+                        .single().get("c").asLong();
+                assertThat(count)
+                        .as("Exactly one ProcessedMessage row must persist for "
+                                + "(messageId, %s).", SERVICE_NAME)
+                        .isEqualTo(1L);
+            }
+
+            verify(journeyService, times(1))
+                    .updateStatus(eq(JOURNEY_ID), any(JourneyStatus.class));
+
+            double duplicateCount = meterRegistry.counter(
+                            PubSubMetrics.MESSAGES_RECEIVED,
+                            "service", SERVICE_NAME,
+                            "topic", TOPIC_NAME,
+                            "result", "duplicate")
+                    .count();
+            assertThat(duplicateCount)
+                    .as("looksee.pubsub.messages.received{result=duplicate} must "
+                            + "tick exactly %d times for the contended message.",
+                            REDELIVERIES - 1)
+                    .isEqualTo((double) (REDELIVERIES - 1));
+
+            double successCount = meterRegistry.counter(
+                            PubSubMetrics.MESSAGES_RECEIVED,
+                            "service", SERVICE_NAME,
+                            "topic", TOPIC_NAME,
+                            "result", "success")
+                    .count();
+            assertThat(successCount)
+                    .as("Exactly one redelivery must record \"success\".")
+                    .isEqualTo(1.0);
+        } finally {
+            pool.shutdown();
+            pool.awaitTermination(15, TimeUnit.SECONDS);
+        }
+    }
+
+    @Test
+    void distinctMessageIds_eachClaimSucceeds_evenUnderConcurrency() throws Exception {
+        int distinctMessages = 8;
+        ExecutorService pool = Executors.newFixedThreadPool(distinctMessages);
+
+        try {
+            List<CompletableFuture<ResponseEntity<String>>> calls = IntStream.range(0, distinctMessages)
+                    .mapToObj(i -> CompletableFuture.supplyAsync(() ->
+                            controller.receiveMessage(buildEnvelope(
+                                    "distinct-" + UUID.randomUUID(), JOURNEY_ID + i, "CANDIDATE")), pool))
+                    .collect(Collectors.toList());
+
+            List<ResponseEntity<String>> results = calls.stream()
+                    .map(CompletableFuture::join)
+                    .collect(Collectors.toList());
+
+            assertThat(results).allSatisfy(r -> {
+                assertThat(r.getStatusCode()).isEqualTo(HttpStatus.OK);
+                assertThat(r.getBody()).isEqualTo("ok");
+            });
+
+            verify(journeyService, times(distinctMessages))
+                    .updateStatus(anyLong(), any(JourneyStatus.class));
+
+            try (Session session = driver.session()) {
+                long count = session.run(
+                        "MATCH (pm:ProcessedMessage {serviceName: $svc}) RETURN count(pm) AS c",
+                        Map.of("svc", SERVICE_NAME))
+                        .single().get("c").asLong();
+                assertThat(count)
+                        .as("Each distinct messageId must produce its own "
+                                + "ProcessedMessage node — the constraint isolates "
+                                + "by (id, svc), not just by id.")
+                        .isEqualTo((long) distinctMessages);
+            }
+        } finally {
+            pool.shutdown();
+            pool.awaitTermination(15, TimeUnit.SECONDS);
+        }
+    }
+
+    private static Body buildEnvelope(String messageId, long journeyId, String status) {
+        String json = "{\"accountId\":1,"
+                + "\"journey\":{\"id\":" + journeyId + ",\"status\":\"" + status + "\","
+                + "\"candidateKey\":\"k\"},"
+                + "\"browser\":\"CHROME\",\"auditRecordId\":100,\"mapId\":1}";
+        String encoded = Base64.getEncoder().encodeToString(json.getBytes(StandardCharsets.UTF_8));
+        Body body = new Body();
+        Body.Message msg = body.new Message();
+        msg.setMessageId(messageId);
+        msg.setData(encoded);
+        body.setMessage(msg);
+        return body;
+    }
+
+    /**
+     * Test-local {@link IdempotencyGuard} backed by a raw Driver.
+     *
+     * <p>Mirrors {@code IdempotencyService} fail-open semantics: returns
+     * {@code true} on null/empty messageId or any persistence exception
+     * (so production-equivalent behavior is preserved when the test
+     * infrastructure misbehaves). Uses the same Cypher the SDN repository
+     * compiles to, against the same V002 constraint.
+     */
+    private static final class Neo4jClaimGuard implements IdempotencyGuard {
+        private final Driver driver;
+
+        Neo4jClaimGuard(Driver driver) {
+            this.driver = driver;
+        }
+
+        @Override
+        public boolean claim(String pubsubMessageId, String serviceName) {
+            if (pubsubMessageId == null || pubsubMessageId.isEmpty()) {
+                return true;
+            }
+            try (Session session = driver.session()) {
+                return session.run(CLAIM_CYPHER,
+                        Map.of("id", pubsubMessageId, "svc", serviceName))
+                        .single().get("claimed").asBoolean();
+            } catch (Exception e) {
+                return true;
+            }
+        }
+
+        @Override
+        public void release(String pubsubMessageId, String serviceName) {
+            if (pubsubMessageId == null || pubsubMessageId.isEmpty()) {
+                return;
+            }
+            try (Session session = driver.session()) {
+                session.run(RELEASE_CYPHER,
+                        Map.of("id", pubsubMessageId, "svc", serviceName))
+                        .consume();
+            } catch (Exception ignored) {
+                // best-effort, mirrors IdempotencyService.release()
+            }
+        }
+
+        @Override
+        public boolean isAlreadyProcessed(String pubsubMessageId, String serviceName) {
+            // Unused by PubSubAuditController (replaced by claim()), but
+            // implemented for interface completeness.
+            if (pubsubMessageId == null || pubsubMessageId.isEmpty()) {
+                return false;
+            }
+            try (Session session = driver.session()) {
+                return session.run(
+                        "MATCH (pm:ProcessedMessage {pubsubMessageId: $id, serviceName: $svc}) "
+                                + "RETURN count(pm) > 0 AS exists",
+                        Map.of("id", pubsubMessageId, "svc", serviceName))
+                        .single().get("exists").asBoolean();
+            }
+        }
+
+        @Override
+        public void markProcessed(String pubsubMessageId, String serviceName) {
+            // Unused by PubSubAuditController (claim() persists on first hit),
+            // but kept for interface completeness.
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Sub-issue #87 of umbrella #28 — adds the three test layers that prove the atomic-claim invariants from steps 1-6 hold under contention:

1. **Concurrency proof** (`LookseeCore/looksee-persistence/.../IdempotencyServiceConcurrencyTest`) — 100 threads contend on the production `claim()` Cypher `MERGE` against a real Neo4j 5 Testcontainer with V001+V002 applied through the production `Migrations` API. Asserts exactly one winner and exactly one node persists.

2. **Migration rehearsal** (`LookseeCore/looksee-persistence/.../MigrationsApplyIntegrationTest`) — pre-seeds duplicate `ProcessedMessage` nodes, runs `Migrations.apply()`, asserts V001 deduplicates to one node, V002 creates `processed_message_unique`, and a subsequent duplicate insert is rejected with `ConstraintValidationFailed`. Doubles as the production-snapshot rehearsal called for in #89.10.2.

3. **journeyErrors integration** (`journeyErrors/.../IdempotencyIntegrationTest`) — 20 concurrent identical envelopes through `AuditController.receiveMessage` against a shared raw-Driver `IdempotencyGuard`. Asserts exactly 1 `ProcessedMessage`, 1 `JourneyService.updateStatus` call, and `looksee.pubsub.messages.received{result="duplicate"} == 19`.

Issue #86 (step 7 — retention bump) was already shipped in #96 / commit `031152d`; closed before opening this PR.

## Reviewer notes

**Why the tests use raw Driver + verbatim Cypher rather than `@DataNeo4jTest` slices:** the atomicity property under test lives at the database layer (Cypher `MERGE` + V002 unique constraint), not in the Java wrapper. `looksee-persistence` has no `@SpringBootApplication`, and journeyErrors' `Application` class transitively pulls in Selenium + GCP Pub/Sub binder + browser-service deps — neither is a clean fit for a slice test. Using the Driver directly tests the same invariant against the same constraint, with much less moving infrastructure to break.

The Cypher in each test is kept **verbatim** from `ProcessedMessageRepository.claim()` so a production-side change that breaks atomicity will surface as a test failure rather than passing silently.

**Why tagged `@Tag("requires-docker")`:** initial CI runs (commits `63d2b78` and `133e5a1`) failed in the `looksee-core` job after ~88s. Without log access from this session I couldn't pinpoint whether it was image-pull, container start, a Migrations classpath issue, or something else specific to the Actions runner. The plan's documented fallback was to tag and skip; commit `d3dc28d` does exactly that, with the same wiring repeated in `journeyErrors/pom.xml` (commit `da5098a`).

To run the tagged tests with Docker available:

```
mvn -pl looksee-persistence -am test -Dgroups=requires-docker
cd journeyErrors && mvn test -Dgroups=requires-docker
```

A follow-up should add a dedicated CI job that opts in to `-Dgroups=requires-docker` against an `ubuntu-latest` runner (Docker is available there) and uploads Surefire reports so the original failure mode can be diagnosed.

## Files

**Created:**
- `LookseeCore/looksee-persistence/src/test/java/com/looksee/services/IdempotencyServiceConcurrencyTest.java`
- `LookseeCore/looksee-persistence/src/test/java/com/looksee/migrations/MigrationsApplyIntegrationTest.java`
- `journeyErrors/src/test/java/com/looksee/journeyErrors/IdempotencyIntegrationTest.java`

**Modified:**
- `LookseeCore/pom.xml` — Testcontainers BOM + Awaitility in `dependencyManagement`, Surefire `excludedGroups=requires-docker`
- `LookseeCore/looksee-persistence/pom.xml` — Testcontainers + Neo4j + JUnit-Jupiter + Awaitility test deps
- `journeyErrors/pom.xml` — same deps + pinned Surefire 2.22.2 with `excludedGroups=requires-docker`

## Test plan

- [x] Local `mvn -pl looksee-persistence -am test-compile` — compiles
- [ ] CI green on the `looksee-core` and `journey-errors` matrix jobs
- [ ] (manual, with Docker) `mvn -pl looksee-persistence -am test -Dgroups=requires-docker` — all 6 new tests pass
- [ ] Follow-up issue: add `requires-docker` opt-in CI job + diagnose original failure mode

Refs #87, part of #28.

https://claude.ai/code/session_01SbbFUSbgnKqmvYLNLD5mAi