### PR TITLE
chore(pom): unify LookseeCore version property to core.version (#2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,16 @@ jobs:
             exit 1
           fi
 
-          # 2. Every service pom.xml that pins LookseeCore must match the root file.
+          # 2. The legacy `<looksee-core.version>` property is forbidden;
+          #    all services must pin LookseeCore via `<core.version>`.
+          forbidden=$(grep -rn '<looksee-core\.version>' --include='pom.xml' . || true)
+          if [ -n "$forbidden" ]; then
+            echo "Forbidden property <looksee-core.version> found; use <core.version> instead:" >&2
+            echo "$forbidden" >&2
+            exit 1
+          fi
+
+          # 3. Every service pom.xml that pins LookseeCore must match the root file.
           mismatches=$(grep -rEn '<core\.version>([^<]+)</' --include='pom.xml' . \
                        | grep -v ">${expected}<" || true)
           if [ -n "$mismatches" ]; then
@@ -48,7 +57,7 @@ jobs:
             exit 1
           fi
 
-          # 3. scripts/download-core.sh must exist and be executable.
+          # 4. scripts/download-core.sh must exist and be executable.
           test -x scripts/download-core.sh || (echo "scripts/download-core.sh missing or not executable" >&2; exit 1)
 
           echo "OK: LookseeCore version $expected is unified across the monorepo."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
           fi
 
           # 2. Every service pom.xml that pins LookseeCore must match the root file.
-          mismatches=$(grep -rEn '<(looksee-core|core)\.version>([^<]+)</' --include='pom.xml' . \
+          mismatches=$(grep -rEn '<core\.version>([^<]+)</' --include='pom.xml' . \
                        | grep -v ">${expected}<" || true)
           if [ -n "$mismatches" ]; then
             echo "pom.xml files pin a LookseeCore version != $expected:" >&2

--- a/CrawlerAPI/pom.xml
+++ b/CrawlerAPI/pom.xml
@@ -18,7 +18,7 @@
         <java.version>21</java.version>
 	    <springboot.version>3.5.0</springboot.version>
         <jackson.version>2.12.2</jackson.version>
-		<looksee-core.version>1.1.0</looksee-core.version>
+		<core.version>1.1.0</core.version>
 	</properties>
 
     <build>
@@ -401,7 +401,7 @@
 		<dependency>
             <groupId>com.looksee</groupId>
             <artifactId>A11yCore</artifactId>
-            <version>${looksee-core.version}</version>
+            <version>${core.version}</version>
         </dependency>
 
 		<!-- https://mvnrepository.com/artifact/org.springdoc/springdoc-openapi-starter-webmvc-ui -->

--- a/PageBuilder/pom.xml
+++ b/PageBuilder/pom.xml
@@ -13,7 +13,7 @@
         <java.version>17</java.version>
 		<springboot.version>2.6.13</springboot.version>
 		<lombok.version>1.18.34</lombok.version>
-		<looksee-core.version>1.1.0</looksee-core.version>
+		<core.version>1.1.0</core.version>
     </properties>
     
     <dependencyManagement>
@@ -110,7 +110,7 @@
         <dependency>
             <groupId>com.looksee</groupId>
             <artifactId>A11yCore</artifactId>
-            <version>${looksee-core.version}</version>
+            <version>${core.version}</version>
         </dependency>
 	</dependencies>
 

--- a/element-enrichment/pom.xml
+++ b/element-enrichment/pom.xml
@@ -13,6 +13,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <java.version>17</java.version>
 	    <springboot.version>2.6.13</springboot.version>
+	    <core.version>1.1.0</core.version>
     </properties>
     
     <dependencyManagement>
@@ -46,7 +47,7 @@
 	    <dependency>
 	        <groupId>com.looksee</groupId>
 	        <artifactId>A11yCore</artifactId>
-	        <version>1.1.0</version>
+	        <version>${core.version}</version>
 	    </dependency>
 
 	    <dependency>

--- a/journey-map-cleanup/pom.xml
+++ b/journey-map-cleanup/pom.xml
@@ -13,6 +13,7 @@
 	  <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 	  <java.version>17</java.version>
 	  <springboot.version>2.6.13</springboot.version>
+	  <core.version>1.1.0</core.version>
   </properties>
   <dependencyManagement>
 	  <dependencies>
@@ -45,7 +46,7 @@
 	  <dependency>
 	    <groupId>com.looksee</groupId>
 	    <artifactId>A11yCore</artifactId>
-	    <version>1.1.0</version>
+	    <version>${core.version}</version>
 	  </dependency>
 
 	  <dependency>

--- a/journeyErrors/pom.xml
+++ b/journeyErrors/pom.xml
@@ -13,6 +13,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <java.version>17</java.version>
 	    <springboot.version>2.6.13</springboot.version>
+	    <core.version>1.1.0</core.version>
         <!-- Surefire tag filter. Default-skip the requires-docker tag so
              plain `mvn test` works without Docker. Override on the CLI to
              opt in: `-DexcludedGroups= -Dgroups=requires-docker`. -->
@@ -58,7 +59,7 @@
 	    <dependency>
 	        <groupId>com.looksee</groupId>
 	        <artifactId>A11yCore</artifactId>
-	        <version>1.1.0</version>
+	        <version>${core.version}</version>
 	    </dependency>
 	    <dependency>
 	        <groupId>com.looksee</groupId>

--- a/look-see-front-end-broadcaster/pom.xml
+++ b/look-see-front-end-broadcaster/pom.xml
@@ -13,6 +13,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <java.version>17</java.version>
 	    <springboot.version>2.6.13</springboot.version>
+	    <core.version>1.1.0</core.version>
     </properties>
     <dependencyManagement>
 	    <dependencies>
@@ -45,7 +46,7 @@
 	    <dependency>
 	        <groupId>com.looksee</groupId>
 	        <artifactId>A11yCore</artifactId>
-	        <version>1.1.0</version>
+	        <version>${core.version}</version>
 	    </dependency>
 
 	    <dependency>


### PR DESCRIPTION
## Summary

Closes the residual inconsistency from #2. The original system-scoped local-JAR dependency described in that issue no longer exists in `CrawlerAPI/pom.xml` — it was already a standard compile-scoped Maven dependency. The remaining drift was in the property name used to pin the LookseeCore version.

- Rename `<looksee-core.version>` → `<core.version>` in `CrawlerAPI/pom.xml` and `PageBuilder/pom.xml`.
- Externalize the hardcoded `1.1.0` A11yCore version into `<core.version>` in four services that previously bypassed the version-consistency check:
  - `look-see-front-end-broadcaster/pom.xml`
  - `element-enrichment/pom.xml`
  - `journey-map-cleanup/pom.xml`
  - `journeyErrors/pom.xml`
- Tighten the `version-consistency` regex in `.github/workflows/ci.yml` from `<(looksee-core|core)\.version>` to `<core\.version>` so re-introducing the old property name fails CI.

After this change, all 13 service pom files use the same `<core.version>` property and every one is enforced by the existing version-consistency job at `.github/workflows/ci.yml:19-54`.

## Out of scope

- `A11yCore` (pom) vs `core` (Dockerfile `install:install-file`) artifactId mismatch.
- Outdated `look-see-front-end-broadcaster/Dockerfile` (still uses `adoptopenjdk/openjdk14`).
- `A11yMessaging` is also hardcoded `1.1.0` in `journeyErrors/pom.xml`; left alone — separate artifact.

Each could be a follow-up issue.

## Test plan

- [x] Local: `grep -rn 'looksee-core\.version' --include='pom.xml' .` → no matches.
- [x] Local: all 13 `<core.version>` pins equal `1.1.0` (matches `LOOKSEE_CORE_VERSION`).
- [x] Local: CI version-consistency check reproduced — no mismatches.
- [x] Local: `mvn dependency:resolve` against all 6 touched services resolves `com.looksee:A11yCore:jar:1.1.0:compile` with BUILD SUCCESS.
- [ ] CI: `version-consistency`, `looksee-core`, `java17-services` (matrix entries `page-builder`, `frontend-broadcaster`, `element-enrichment`, `journey-map-cleanup`, `journey-errors`), and `crawler-api` all green.

Refs #2

https://claude.ai/code/session_01Wp5cRxTJShKLpFiiakPX46

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wp5cRxTJShKLpFiiakPX46)_